### PR TITLE
fix(reports): resolve GVR split-label reconstruction length mismatch

### DIFF
--- a/pkg/utils/report/metadata.go
+++ b/pkg/utils/report/metadata.go
@@ -225,13 +225,10 @@ func GetResourceGVR(report metav1.Object) schema.GroupVersionResource {
 	group := controllerutils.GetLabel(report, LabelResourceGroup)
 	version := controllerutils.GetLabel(report, LabelResourceVersion)
 	resource := controllerutils.GetLabel(report, AnnotationResourceName)
-	GVRstring := group + version + resource
 
 	// If all three parts exist, return the GVR
 	if group != "" && version != "" && resource != "" {
-		if len(GVRstring) > 63 {
-			return schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
-		}
+		return schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
 	}
 
 	// Fallback to the old combined label

--- a/pkg/utils/report/metadata_test.go
+++ b/pkg/utils/report/metadata_test.go
@@ -361,3 +361,51 @@ func TestCleanupKyvernoLabels_NilLabels(t *testing.T) {
 	CleanupKyvernoLabels(obj)
 	assert.Nil(t, obj.Labels)
 }
+
+func TestGetResourceGVR_SplitLabelMismatch_64Chars(t *testing.T) {
+	report := &reportsv1.EphemeralReport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-report",
+			Labels: make(map[string]string),
+		},
+	}
+
+	// Dotted length: 24 (resource) + 1 (dot) + 7 (version) + 1 (dot) + 31 (group) = 64.
+	// Combined length: 24 + 7 + 31 = 62 (which is <= 63).
+	gvr := schema.GroupVersionResource{
+		Group:    "infrastructure.cluster.x-k8s.io",
+		Version:  "v1beta1",
+		Resource: "openstackmachinecreators",
+	}
+
+	SetResourceGVR(report, gvr)
+	result := GetResourceGVR(report)
+
+	assert.Equal(t, gvr.Group, result.Group, "Group should match for 64-char GVR")
+	assert.Equal(t, gvr.Version, result.Version, "Version should match for 64-char GVR")
+	assert.Equal(t, gvr.Resource, result.Resource, "Resource should match for 64-char GVR")
+}
+
+func TestGetResourceGVR_SplitLabelMismatch_65Chars(t *testing.T) {
+	report := &reportsv1.EphemeralReport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-report",
+			Labels: make(map[string]string),
+		},
+	}
+
+	// Dotted length: 25 (resource) + 1 (dot) + 7 (version) + 1 (dot) + 31 (group) = 65.
+	// Combined length: 25 + 7 + 31 = 63 (which is <= 63).
+	gvr := schema.GroupVersionResource{
+		Group:    "infrastructure.cluster.x-k8s.io",
+		Version:  "v1beta1",
+		Resource: "openstackmachinetemplates",
+	}
+
+	SetResourceGVR(report, gvr)
+	result := GetResourceGVR(report)
+
+	assert.Equal(t, gvr.Group, result.Group, "Group should match for 65-char GVR")
+	assert.Equal(t, gvr.Version, result.Version, "Version should match for 65-char GVR")
+	assert.Equal(t, gvr.Resource, result.Resource, "Resource should match for 65-char GVR")
+}


### PR DESCRIPTION
## Description

This PR fixes an issue in `GetResourceGVR()` where split GVR metadata could not be reconstructed for certain boundary cases.

`SetResourceGVR()` splits a GVR into separate labels when the dotted representation exceeds Kubernetes' 63-character label limit.

However, `GetResourceGVR()` attempted to determine whether reconstruction was necessary by calculating the length of a concatenated string that excluded the `.` separators.

As a result, GVRs with dotted lengths of 64 and 65 characters were written using the split-label format but were not reconstructed correctly when read back.

This could cause the report aggregation controller to fail to locate the original resource, preventing report adoption and eventually leading to the deletion of ephemeral reports.

## Changes

- Remove the redundant `len(GVRstring) > 63` check.
- Reconstruct the GVR whenever all split-label components are present.
- Preserve the existing fallback behavior for reports that still use the legacy combined label format.

## Testing

Added regression tests covering the previously untested boundary cases:

- 64-character dotted GVR.
- 65-character dotted GVR.

Verified that:

- The new regression tests pass.
- Existing `GetResourceGVR()` tests continue to pass.
- `make imports-check` passes.
- `make fmt-check` passes.

## Follow up
    Issue #17191 