### PR TITLE
fix(imageverify): repopulate intoto payload on attestation cache hit (#17117)

### DIFF
--- a/pkg/cel/libs/imageverify/impl.go
+++ b/pkg/cel/libs/imageverify/impl.go
@@ -2,6 +2,7 @@ package imageverify
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -46,6 +47,20 @@ type ivfuncs struct {
 	authOpts        []remote.Option
 	nameOpts        []name.Option
 	verifications   *ImageVerificationResults
+
+	// pendingIntotoRestores holds intoto payloads read back from the cache on
+	// a verifyAttestationSignatures() hit, keyed by "<image>\x00<attestation>".
+	// Applying them to ImageData (which needs an imgCtx.Get()) is deferred
+	// until extractPayload() actually asks for that image+attestation, so a
+	// policy that only calls verifyAttestationSignatures() never pays for it.
+	//
+	// The cache *write* on a miss stays eager (see
+	// verify_image_attestations_string_string_stringarray): img is already
+	// in memory at that point, so caching the payload costs no extra I/O,
+	// and deferring it to extractPayload() would mean a verify-only policy
+	// never completes the write -- so it would never get a real cache hit
+	// again, defeating caching entirely for that common case.
+	pendingIntotoRestores map[string]map[string][]byte
 }
 
 func ImageVerifyCELFuncs(
@@ -78,19 +93,20 @@ func ImageVerifyCELFuncs(
 	}
 
 	return &ivfuncs{
-		Adapter:         adapter,
-		logger:          logger,
-		imgCtx:          imgCtx,
-		policy:          ivpol,
-		creds:           spec.Credentials,
-		imgRules:        imgRules,
-		attestationList: attestationMap(ivpol),
-		cosignVerifier:  cosign.NewVerifier(lister, logger),
-		notaryVerifier:  notary.NewVerifier(logger),
-		ivCache:         ivCache,
-		nameOpts:        nameOpts,
-		authOpts:        authOpts[:],
-		verifications:   verifications,
+		Adapter:               adapter,
+		logger:                logger,
+		imgCtx:                imgCtx,
+		policy:                ivpol,
+		creds:                 spec.Credentials,
+		imgRules:              imgRules,
+		attestationList:       attestationMap(ivpol),
+		cosignVerifier:        cosign.NewVerifier(lister, logger),
+		notaryVerifier:        notary.NewVerifier(logger),
+		ivCache:               ivCache,
+		nameOpts:              nameOpts,
+		authOpts:              authOpts[:],
+		verifications:         verifications,
+		pendingIntotoRestores: map[string]map[string][]byte{},
 	}, nil
 }
 
@@ -113,6 +129,12 @@ func attestorCacheRule(fn string, qualifier string, attestors []v1beta1.Attestor
 
 func writeCacheKeyPart(b *strings.Builder, part string) {
 	fmt.Fprintf(b, "%d:%s|", len(part), part)
+}
+
+// pendingKey builds the request-scoped lookup key used by the
+// pendingIntotoRestores map.
+func pendingKey(image, attestation string) string {
+	return image + "\x00" + attestation
 }
 
 func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attestors ref.Val) ref.Val {
@@ -209,21 +231,37 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 			return f.NativeToValue(count)
 		}
 		f.logger.V(4).Info("verifyAttestationSignatures called", "image", image, "attestation", attestation, "attestorCount", len(attestors))
-		cacheRule := attestorCacheRule(attestationCacheRule, attestation, attestors)
-		if f.ivCache != nil {
-			if found, err := f.ivCache.Get(ctx, f.policy, cacheRule, image, true); err != nil {
-				f.logger.Error(err, "error occurred during image verify cache get", "image", image)
-			} else if found {
-				f.logger.V(4).Info("image attestation verification cache hit", "image", image, "policy", f.policy.GetName())
-				f.verifications.Record(image, true)
-				return f.NativeToValue(len(attestors))
-			}
-		}
-		// Hoist invariant lookups out of the loop: both the attestation
-		// definition and the image data are the same for every attestor.
 		attest, ok := f.attestationList[attestation]
 		if !ok {
 			return types.NewErr("attestation not found in policy: %s", attestation)
+		}
+		cacheRule := attestorCacheRule(attestationCacheRule, attestation, attestors)
+		if f.ivCache != nil {
+			if found, payloads, err := f.ivCache.GetWithPayload(ctx, f.policy, cacheRule, image, true); err != nil {
+				f.logger.Error(err, "error occurred during image verify cache get", "image", image)
+			} else if found {
+				if attest.IsInToto() && len(payloads) == 0 {
+					// A degraded entry (cached "found" but no payload to
+					// restore) can't be trusted as a hit -- we can't safely
+					// defer this decision since we don't know yet whether
+					// extractPayload() will be called later in this same
+					// evaluation. Fall back to full re-verification below
+					// rather than denying an admission that was already
+					// verified once.
+					f.logger.V(4).Info("cache hit has no payload to restore, falling back to re-verification", "image", image, "attestation", attestation)
+				} else {
+					if len(payloads) > 0 {
+						// Defer applying the payload to ImageData (which
+						// needs an imgCtx.Get()) until extractPayload()
+						// actually asks for it -- a verify-only policy
+						// never pays for it.
+						f.pendingIntotoRestores[pendingKey(image, attestation)] = payloads
+					}
+					f.logger.V(4).Info("image attestation verification cache hit", "image", image, "policy", f.policy.GetName())
+					f.verifications.Record(image, true)
+					return f.NativeToValue(len(attestors))
+				}
+			}
 		}
 		img, err := f.imgCtx.Get(ctx, image, f.authOpts, f.nameOpts)
 		if err != nil {
@@ -261,7 +299,23 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 		}
 		f.logger.V(6).Info("verifyAttestationSignatures returning", "image", image, "attestation", attestation, "verifiedCount", count)
 		if f.ivCache != nil && len(attestors) > 0 && count == len(attestors) {
-			if _, err := f.ivCache.Set(ctx, f.policy, cacheRule, image, true); err != nil {
+			// The write stays eager: img is already in memory (fetched
+			// above for verification), so extracting the payload here costs
+			// no extra I/O -- unlike the read-side restore, which does.
+			// Deferring this write to extractPayload() would mean a
+			// verify-only policy (which never calls it) never completes
+			// the write, so it would never get a real cache hit again.
+			payloads := intotoPayloadsFromImage(img, attest)
+			if attest.IsInToto() && len(payloads) == 0 {
+				// Verification succeeded but we couldn't capture the payload to
+				// cache alongside it. Skip the cache write entirely rather than
+				// recording a presence-only hit: a future admission would see
+				// "found" but have nothing to restore, silently reproducing the
+				// "cannot be fetch before verifying" error. Leaving this
+				// uncached means the next request re-verifies from scratch
+				// instead of degrading.
+				f.logger.Error(nil, "skipping cache write: failed to capture intoto payload after successful verification", "image", image, "attestation", attestation)
+			} else if _, err := f.ivCache.SetWithPayload(ctx, f.policy, cacheRule, image, true, payloads); err != nil {
 				f.logger.Error(err, "error occurred during image verify cache set", "image", image)
 			}
 		}
@@ -270,6 +324,28 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 		}
 		return f.NativeToValue(count)
 	}
+}
+
+// intotoPayloadsFromImage reads verified intoto payloads from ImageData after a
+// successful Cosign attestation verify. ImageData does not expose a getter for
+// the raw map, so we round-trip through GetPayload + json.Marshal.
+//
+// Safe degrade: if GetPayload (or Marshal) fails, we return nil and the
+// caller skips caching this result entirely rather than recording a
+// presence-only entry.
+func intotoPayloadsFromImage(img *imagedataloader.ImageData, attest v1beta1.Attestation) map[string][]byte {
+	if img == nil || !attest.IsInToto() || attest.InToto == nil {
+		return nil
+	}
+	payload, err := img.GetPayload(attest)
+	if err != nil {
+		return nil
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil
+	}
+	return map[string][]byte{attest.InToto.Type: b}
 }
 
 func (f *ivfuncs) payload_string_string(image ref.Val, attestation ref.Val) ref.Val {
@@ -287,10 +363,23 @@ func (f *ivfuncs) payload_string_string(image ref.Val, attestation ref.Val) ref.
 		if err != nil {
 			return types.NewErr("failed to get imagedata: %v", err)
 		}
+		key := pendingKey(image, attestation)
+
+		// Complete a deferred restore from a same-request cache hit: only
+		// now, since extractPayload() was actually called, apply the cached
+		// payload to this fresh ImageData.
+		if payloads, ok := f.pendingIntotoRestores[key]; ok {
+			for predicateType, data := range payloads {
+				img.AddVerifiedIntotoPayloads(predicateType, data)
+			}
+			delete(f.pendingIntotoRestores, key)
+		}
+
 		payload, err := img.GetPayload(attest)
 		if err != nil {
 			return types.NewErr("failed to get payload: %v", err)
 		}
+
 		return f.NativeToValue(payload)
 	}
 }

--- a/pkg/cel/libs/imageverify/impl_test.go
+++ b/pkg/cel/libs/imageverify/impl_test.go
@@ -2,6 +2,7 @@ package imageverify
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -244,4 +245,452 @@ func Test_impl_verify_image_signature_cache_miss_does_not_cache_failure(t *testi
 	found, err := ivCache.Get(context.TODO(), pol, cacheRule, image, true)
 	assert.NoError(t, err)
 	assert.False(t, found, "a partial or failed verification must never be cached")
+}
+
+// Demonstrates that a verifyAttestationSignatures cache hit restores Cosign
+// verifiedIntotoPayloads onto a fresh ImageData so extractPayload still works.
+func Test_impl_verify_attestation_cache_hit_restores_payload(t *testing.T) {
+	attestors := []v1beta1.Attestor{
+		{
+			Name: "github-keyless-attestation",
+			Cosign: &v1beta1.Cosign{
+				Keyless: &v1beta1.Keyless{
+					Identities: []v1beta1.Identity{
+						{
+							Issuer:  "https://token.actions.githubusercontent.com",
+							Subject: "https://github.com/kyverno/test-images/.github/workflows/cosign.yml@refs/heads/main",
+						},
+					},
+				},
+				CTLog: &v1beta1.CTLog{
+					URL:               "https://rekor.sigstore.dev",
+					InsecureIgnoreSCT: true,
+				},
+			},
+		},
+	}
+	attestations := []v1beta1.Attestation{
+		{
+			Name: "slsa",
+			InToto: &v1beta1.InToto{
+				Type: "https://slsa.dev/provenance/v1",
+			},
+		},
+	}
+	pol := &v1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "attestation-cache-policy",
+			UID:             "test-uid-attestation-cache",
+			ResourceVersion: "1",
+		},
+		Spec: v1beta1.ImageValidatingPolicySpec{
+			Attestors:    attestors,
+			Attestations: attestations,
+		},
+	}
+	// Cosign/InToto image — Referrer/Notary GetPayload falls back to the registry and
+	// would not reproduce the "intoto attestation payload cannot be fetch" error.
+	image := "ghcr.io/kyverno/test-images/cosign:github-attestation"
+	attestationName := "slsa"
+
+	imgCtx, err := imagedataloader.NewImageContext(nil, nil, nil)
+	assert.NoError(t, err)
+
+	ivCache, err := imageverifycache.New(
+		imageverifycache.WithCacheEnableFlag(true),
+		imageverifycache.WithMaxSize(0),
+		imageverifycache.WithTTLDuration(0),
+	)
+	assert.NoError(t, err)
+
+	f := &ivfuncs{
+		Adapter:               types.DefaultTypeAdapter,
+		imgCtx:                imgCtx,
+		policy:                pol,
+		attestationList:       attestationMap(pol),
+		cosignVerifier:        cosign.NewVerifier(nil, logr.Discard()),
+		notaryVerifier:        notary.NewVerifier(logr.Discard()),
+		ivCache:               ivCache,
+		verifications:         NewImageVerificationResults(),
+		pendingIntotoRestores: map[string]map[string][]byte{},
+	}
+
+	// 1. Cache miss: real Cosign verification populates verifiedIntotoPayloads and Sets the ivCache.
+	out := f.verify_image_attestations_string_string_stringarray(
+		f.NativeToValue(image),
+		f.NativeToValue(attestationName),
+		f.NativeToValue(attestors),
+	)
+	assert.False(t, types.IsError(out), "cache-miss verification should not error: %v", out)
+	assert.Equal(t, int64(len(attestors)), out.Value())
+
+	// 2. extractPayload succeeds on the same ImageData that verification just populated.
+	payload := f.payload_string_string(f.NativeToValue(image), f.NativeToValue(attestationName))
+	assert.False(t, types.IsError(payload), "extractPayload should succeed after a cache miss: %v", payload)
+	missPayload := payload.Value()
+	assert.NotNil(t, missPayload)
+
+	// 3. New admission request: fresh imgCtx, same process-lifetime ivCache (already Set by step 1).
+	imgCtx2, err := imagedataloader.NewImageContext(nil, nil, nil)
+	assert.NoError(t, err)
+	f.imgCtx = imgCtx2
+	f.verifications = NewImageVerificationResults()
+
+	// 4. Cache hit: restores verifiedIntotoPayloads onto the fresh ImageData from ivCache.
+	out2 := f.verify_image_attestations_string_string_stringarray(
+		f.NativeToValue(image),
+		f.NativeToValue(attestationName),
+		f.NativeToValue(attestors),
+	)
+	assert.False(t, types.IsError(out2), "cache-hit verification should not error: %v", out2)
+	assert.Equal(t, int64(len(attestors)), out2.Value())
+
+	// 5. extractPayload after cache hit must match the miss-path payload exactly
+	// (proves GetPayload→json.Marshal→AddVerifiedIntotoPayloads→GetPayload is lossless).
+	payload2 := f.payload_string_string(f.NativeToValue(image), f.NativeToValue(attestationName))
+	assert.False(t, types.IsError(payload2), "extractPayload should succeed after attestation cache hit: %v", payload2)
+	hitPayload := payload2.Value()
+	assert.NotNil(t, hitPayload)
+	assert.Equal(t, missPayload, hitPayload, "cache-restored payload must deeply equal the fresh-verification payload")
+}
+
+// Attestation verify-only (no extractPayload): miss then hit must both succeed with the
+// SetWithPayload/GetWithPayload plumbing — payload caching must not break verify-only use.
+func Test_impl_verify_attestation_cache_hit_without_extract_payload(t *testing.T) {
+	attestors := []v1beta1.Attestor{
+		{
+			Name: "github-keyless-attestation",
+			Cosign: &v1beta1.Cosign{
+				Keyless: &v1beta1.Keyless{
+					Identities: []v1beta1.Identity{
+						{
+							Issuer:  "https://token.actions.githubusercontent.com",
+							Subject: "https://github.com/kyverno/test-images/.github/workflows/cosign.yml@refs/heads/main",
+						},
+					},
+				},
+				CTLog: &v1beta1.CTLog{
+					URL:               "https://rekor.sigstore.dev",
+					InsecureIgnoreSCT: true,
+				},
+			},
+		},
+	}
+	pol := &v1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "attestation-verify-only-policy",
+			UID:             "test-uid-attestation-verify-only",
+			ResourceVersion: "1",
+		},
+		Spec: v1beta1.ImageValidatingPolicySpec{
+			Attestors: attestors,
+			Attestations: []v1beta1.Attestation{
+				{
+					Name: "slsa",
+					InToto: &v1beta1.InToto{
+						Type: "https://slsa.dev/provenance/v1",
+					},
+				},
+			},
+		},
+	}
+	image := "ghcr.io/kyverno/test-images/cosign:github-attestation"
+	attestationName := "slsa"
+
+	imgCtx, err := imagedataloader.NewImageContext(nil, nil, nil)
+	assert.NoError(t, err)
+
+	ivCache, err := imageverifycache.New(
+		imageverifycache.WithCacheEnableFlag(true),
+		imageverifycache.WithMaxSize(0),
+		imageverifycache.WithTTLDuration(0),
+	)
+	assert.NoError(t, err)
+
+	f := &ivfuncs{
+		Adapter:               types.DefaultTypeAdapter,
+		imgCtx:                imgCtx,
+		policy:                pol,
+		attestationList:       attestationMap(pol),
+		cosignVerifier:        cosign.NewVerifier(nil, logr.Discard()),
+		notaryVerifier:        notary.NewVerifier(logr.Discard()),
+		ivCache:               ivCache,
+		verifications:         NewImageVerificationResults(),
+		pendingIntotoRestores: map[string]map[string][]byte{},
+	}
+
+	out := f.verify_image_attestations_string_string_stringarray(
+		f.NativeToValue(image),
+		f.NativeToValue(attestationName),
+		f.NativeToValue(attestors),
+	)
+	assert.False(t, types.IsError(out), "cache-miss verification should not error: %v", out)
+	assert.Equal(t, int64(len(attestors)), out.Value())
+
+	imgCtx2, err := imagedataloader.NewImageContext(nil, nil, nil)
+	assert.NoError(t, err)
+	f.imgCtx = imgCtx2
+	f.verifications = NewImageVerificationResults()
+
+	out2 := f.verify_image_attestations_string_string_stringarray(
+		f.NativeToValue(image),
+		f.NativeToValue(attestationName),
+		f.NativeToValue(attestors),
+	)
+	assert.False(t, types.IsError(out2), "cache-hit verification should not error: %v", out2)
+	assert.Equal(t, int64(len(attestors)), out2.Value())
+}
+
+// Two intoto attestation types on the same image: each cache entry is keyed by attestation
+// name and stores a predicateType→payload map. After a fresh imgCtx, both cache hits must
+// restore the correct payload with no cross-attestation leak/overwrite.
+//
+// This verifies cache-KEY isolation (generateKey/cacheRule differs per attestation name +
+// attestor set), not within-map key collision: intotoPayloadsFromImage only ever returns a
+// single-key map {attest.InToto.Type: bytes}, and production SetWithPayload callers never
+// write a multi-key payload map today.
+func Test_impl_verify_attestation_cache_hit_two_intoto_types_isolated(t *testing.T) {
+	attestorsSlsa := []v1beta1.Attestor{
+		{
+			Name: "github-keyless-slsa",
+			Cosign: &v1beta1.Cosign{
+				Keyless: &v1beta1.Keyless{
+					Identities: []v1beta1.Identity{
+						{
+							Issuer:  "https://token.actions.githubusercontent.com",
+							Subject: "https://github.com/kyverno/test-images/.github/workflows/cosign.yml@refs/heads/main",
+						},
+					},
+				},
+				CTLog: &v1beta1.CTLog{
+					URL:               "https://rekor.sigstore.dev",
+					InsecureIgnoreSCT: true,
+				},
+			},
+		},
+	}
+	// Distinct attestor name so attestorCacheRule differs from the SLSA combo.
+	attestorsCustom := []v1beta1.Attestor{
+		{
+			Name: "github-keyless-custom",
+			Cosign: &v1beta1.Cosign{
+				Keyless: &v1beta1.Keyless{
+					Identities: []v1beta1.Identity{
+						{
+							Issuer:  "https://token.actions.githubusercontent.com",
+							Subject: "https://github.com/kyverno/test-images/.github/workflows/cosign.yml@refs/heads/main",
+						},
+					},
+				},
+				CTLog: &v1beta1.CTLog{
+					URL:               "https://rekor.sigstore.dev",
+					InsecureIgnoreSCT: true,
+				},
+			},
+		},
+	}
+	const (
+		slsaType   = "https://slsa.dev/provenance/v1"
+		customType = "https://example.com/attestation/custom/v1"
+		slsaName   = "slsa"
+		customName = "custom"
+	)
+	pol := &v1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "attestation-two-types-policy",
+			UID:             "test-uid-attestation-two-types",
+			ResourceVersion: "1",
+		},
+		Spec: v1beta1.ImageValidatingPolicySpec{
+			Attestors: append(append([]v1beta1.Attestor{}, attestorsSlsa...), attestorsCustom...),
+			Attestations: []v1beta1.Attestation{
+				{Name: slsaName, InToto: &v1beta1.InToto{Type: slsaType}},
+				{Name: customName, InToto: &v1beta1.InToto{Type: customType}},
+			},
+		},
+	}
+	image := "ghcr.io/kyverno/test-images/cosign:github-attestation"
+
+	imgCtx, err := imagedataloader.NewImageContext(nil, nil, nil)
+	assert.NoError(t, err)
+
+	ivCache, err := imageverifycache.New(
+		imageverifycache.WithCacheEnableFlag(true),
+		imageverifycache.WithMaxSize(0),
+		imageverifycache.WithTTLDuration(0),
+	)
+	assert.NoError(t, err)
+
+	f := &ivfuncs{
+		Adapter:               types.DefaultTypeAdapter,
+		imgCtx:                imgCtx,
+		policy:                pol,
+		attestationList:       attestationMap(pol),
+		cosignVerifier:        cosign.NewVerifier(nil, logr.Discard()),
+		notaryVerifier:        notary.NewVerifier(logr.Discard()),
+		ivCache:               ivCache,
+		verifications:         NewImageVerificationResults(),
+		pendingIntotoRestores: map[string]map[string][]byte{},
+	}
+
+	// Miss path for SLSA: real Cosign verify + SetWithPayload.
+	outSlsa := f.verify_image_attestations_string_string_stringarray(
+		f.NativeToValue(image),
+		f.NativeToValue(slsaName),
+		f.NativeToValue(attestorsSlsa),
+	)
+	assert.False(t, types.IsError(outSlsa), "slsa cache-miss verification should not error: %v", outSlsa)
+	assert.Equal(t, int64(len(attestorsSlsa)), outSlsa.Value())
+
+	slsaMiss := f.payload_string_string(f.NativeToValue(image), f.NativeToValue(slsaName))
+	assert.False(t, types.IsError(slsaMiss), "slsa extractPayload after miss: %v", slsaMiss)
+	slsaMissPayload := slsaMiss.Value()
+	assert.NotNil(t, slsaMissPayload)
+
+	// The public test image only carries SLSA provenance. Seed the second attestation's
+	// cache entry (same key shape verify would write) so we can exercise two hit restores
+	// without requiring a second signed predicate type on the image.
+	customPayloadObj := map[string]any{
+		"marker":        "custom-attestation-payload",
+		"predicateType": customType,
+	}
+	customPayloadBytes, err := json.Marshal(customPayloadObj)
+	assert.NoError(t, err)
+	customRule := attestorCacheRule(attestationCacheRule, customName, attestorsCustom)
+	stored, err := ivCache.SetWithPayload(context.TODO(), pol, customRule, image, true, map[string][]byte{
+		customType: customPayloadBytes,
+	})
+	assert.NoError(t, err)
+	assert.True(t, stored)
+
+	// Fresh request: same ivCache, empty ImageData.
+	imgCtx2, err := imagedataloader.NewImageContext(nil, nil, nil)
+	assert.NoError(t, err)
+	f.imgCtx = imgCtx2
+	f.verifications = NewImageVerificationResults()
+
+	outSlsaHit := f.verify_image_attestations_string_string_stringarray(
+		f.NativeToValue(image),
+		f.NativeToValue(slsaName),
+		f.NativeToValue(attestorsSlsa),
+	)
+	assert.False(t, types.IsError(outSlsaHit), "slsa cache-hit verification should not error: %v", outSlsaHit)
+	assert.Equal(t, int64(len(attestorsSlsa)), outSlsaHit.Value())
+
+	outCustomHit := f.verify_image_attestations_string_string_stringarray(
+		f.NativeToValue(image),
+		f.NativeToValue(customName),
+		f.NativeToValue(attestorsCustom),
+	)
+	assert.False(t, types.IsError(outCustomHit), "custom cache-hit verification should not error: %v", outCustomHit)
+	assert.Equal(t, int64(len(attestorsCustom)), outCustomHit.Value())
+
+	slsaHit := f.payload_string_string(f.NativeToValue(image), f.NativeToValue(slsaName))
+	assert.False(t, types.IsError(slsaHit), "slsa extractPayload after hit: %v", slsaHit)
+	slsaHitPayload := slsaHit.Value()
+	assert.Equal(t, slsaMissPayload, slsaHitPayload, "slsa restored payload must match miss-path payload")
+
+	customHit := f.payload_string_string(f.NativeToValue(image), f.NativeToValue(customName))
+	assert.False(t, types.IsError(customHit), "custom extractPayload after hit: %v", customHit)
+	customHitPayload := customHit.Value()
+	assert.Equal(t, customPayloadObj, customHitPayload, "custom restored payload must match seeded payload")
+
+	assert.NotEqual(t, slsaHitPayload, customHitPayload, "distinct attestation types must not share or overwrite payloads")
+}
+
+// Demonstrates that a degraded cache entry -- the cache reports "found" but
+// carries no payload to restore, e.g. from a TTL-window entry predating the
+// write-side fix that now skips caching on failed payload capture -- falls
+// back to full re-verification instead of hard-failing the CEL expression.
+// This is the fix requested in PR review for "cache-hit restore can deny
+// valid admissions": missing/degraded payloads must be treated as a cache
+// miss, not an error.
+func Test_impl_verify_attestation_cache_hit_missing_payload_falls_back_to_reverify(t *testing.T) {
+	attestors := []v1beta1.Attestor{
+		{
+			Name: "github-keyless-attestation",
+			Cosign: &v1beta1.Cosign{
+				Keyless: &v1beta1.Keyless{
+					Identities: []v1beta1.Identity{
+						{
+							Issuer:  "https://token.actions.githubusercontent.com",
+							Subject: "https://github.com/kyverno/test-images/.github/workflows/cosign.yml@refs/heads/main",
+						},
+					},
+				},
+				CTLog: &v1beta1.CTLog{
+					URL:               "https://rekor.sigstore.dev",
+					InsecureIgnoreSCT: true,
+				},
+			},
+		},
+	}
+	attestations := []v1beta1.Attestation{
+		{
+			Name: "slsa",
+			InToto: &v1beta1.InToto{
+				Type: "https://slsa.dev/provenance/v1",
+			},
+		},
+	}
+	pol := &v1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "attestation-degraded-cache-policy",
+			UID:             "test-uid-attestation-degraded-cache",
+			ResourceVersion: "1",
+		},
+		Spec: v1beta1.ImageValidatingPolicySpec{
+			Attestors:    attestors,
+			Attestations: attestations,
+		},
+	}
+	image := "ghcr.io/kyverno/test-images/cosign:github-attestation"
+	attestationName := "slsa"
+
+	imgCtx, err := imagedataloader.NewImageContext(nil, nil, nil)
+	assert.NoError(t, err)
+
+	ivCache, err := imageverifycache.New(
+		imageverifycache.WithCacheEnableFlag(true),
+		imageverifycache.WithMaxSize(0),
+		imageverifycache.WithTTLDuration(0),
+	)
+	assert.NoError(t, err)
+
+	f := &ivfuncs{
+		Adapter:               types.DefaultTypeAdapter,
+		imgCtx:                imgCtx,
+		policy:                pol,
+		attestationList:       attestationMap(pol),
+		cosignVerifier:        cosign.NewVerifier(nil, logr.Discard()),
+		notaryVerifier:        notary.NewVerifier(logr.Discard()),
+		ivCache:               ivCache,
+		verifications:         NewImageVerificationResults(),
+		pendingIntotoRestores: map[string]map[string][]byte{},
+	}
+
+	// Seed a degraded (presence-only) cache entry directly, simulating what a
+	// failed payload capture used to leave behind before the write-side fix.
+	// This exercises the READ-side fallback independent of the write-side skip.
+	cacheRule := attestorCacheRule(attestationCacheRule, attestationName, attestors)
+	stored, err := ivCache.SetWithPayload(context.TODO(), pol, cacheRule, image, true, nil)
+	assert.NoError(t, err)
+	assert.True(t, stored, "degraded presence-only entry must still be cacheable, matching pre-fix Set() behavior")
+
+	// Cache reports found=true but there is nothing to restore. The fix must
+	// NOT error the CEL expression here -- it must fall back to a real verify
+	// and succeed, exactly as if this had been a genuine cache miss.
+	out := f.verify_image_attestations_string_string_stringarray(
+		f.NativeToValue(image),
+		f.NativeToValue(attestationName),
+		f.NativeToValue(attestors),
+	)
+	assert.False(t, types.IsError(out), "degraded cache hit must fall back to re-verification, not error: %v", out)
+	assert.Equal(t, int64(len(attestors)), out.Value())
+
+	// extractPayload must succeed too: the fallback real-verify populates the
+	// payload on this request's ImageData, same as a genuine cache miss would.
+	payload := f.payload_string_string(f.NativeToValue(image), f.NativeToValue(attestationName))
+	assert.False(t, types.IsError(payload), "extractPayload should succeed after fallback re-verification: %v", payload)
+	assert.NotNil(t, payload.Value())
 }

--- a/pkg/image/verification/cache/client.go
+++ b/pkg/image/verification/cache/client.go
@@ -92,6 +92,15 @@ func generateKey(policy metav1.Object, ruleName string, imageRef string) string 
 }
 
 func (c *cache) Set(ctx context.Context, policy metav1.Object, ruleName string, imageRef string, useCache bool) (bool, error) {
+	return c.SetWithPayload(ctx, policy, ruleName, imageRef, useCache, nil)
+}
+
+func (c *cache) Get(ctx context.Context, policy metav1.Object, ruleName string, imageRef string, useCache bool) (bool, error) {
+	found, _, err := c.GetWithPayload(ctx, policy, ruleName, imageRef, useCache)
+	return found, err
+}
+
+func (c *cache) SetWithPayload(ctx context.Context, policy metav1.Object, ruleName string, imageRef string, useCache bool, payloads map[string][]byte) (bool, error) {
 	if !c.isCacheEnabled {
 		// If cache is globally disabled just return
 		return false, nil
@@ -101,7 +110,7 @@ func (c *cache) Set(ctx context.Context, policy metav1.Object, ruleName string, 
 	}
 	key := generateKey(policy, ruleName, imageRef)
 
-	stored := c.cache.SetWithTTL(key, nil, 1, c.ttl)
+	stored := c.cache.SetWithTTL(key, clonePayloads(payloads), payloadCost(payloads), c.ttl)
 	c.cache.Wait()
 	if stored {
 		return true, nil
@@ -109,18 +118,48 @@ func (c *cache) Set(ctx context.Context, policy metav1.Object, ruleName string, 
 	return false, nil
 }
 
-func (c *cache) Get(ctx context.Context, policy metav1.Object, ruleName string, imageRef string, useCache bool) (bool, error) {
+func (c *cache) GetWithPayload(ctx context.Context, policy metav1.Object, ruleName string, imageRef string, useCache bool) (bool, map[string][]byte, error) {
 	if !c.isCacheEnabled {
 		// If cache is globally disabled just return
-		return false, nil
+		return false, nil, nil
 	} else if !useCache {
 		// Else If enabled globally then return if locally disabled
-		return false, nil
+		return false, nil, nil
 	}
 	key := generateKey(policy, ruleName, imageRef)
-	_, found := c.cache.Get(key)
-	if found {
-		return true, nil
+	val, found := c.cache.Get(key)
+	if !found {
+		return false, nil, nil
 	}
-	return false, nil
+	payloads, _ := val.(map[string][]byte)
+	return true, clonePayloads(payloads), nil
+}
+
+// payloadCost estimates the memory footprint of a cache entry so ristretto's
+// MaxCost (--imageVerifyCacheMaxSize) bounds actual memory rather than just
+// entry count: a presence-only entry (nil payloads) still costs 1, while an
+// entry carrying attestation payload bytes costs roughly its real size.
+func payloadCost(payloads map[string][]byte) int64 {
+	cost := int64(1)
+	for _, v := range payloads {
+		cost += int64(len(v))
+	}
+	return cost
+}
+
+func clonePayloads(in map[string][]byte) map[string][]byte {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string][]byte, len(in))
+	for k, v := range in {
+		if v == nil {
+			out[k] = nil
+			continue
+		}
+		cp := make([]byte, len(v))
+		copy(cp, v)
+		out[k] = cp
+	}
+	return out
 }

--- a/pkg/image/verification/cache/client_test.go
+++ b/pkg/image/verification/cache/client_test.go
@@ -1,0 +1,64 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Test_payloadCost verifies cache entry cost is charged by real payload byte
+// size instead of a flat 1 per entry, so --imageVerifyCacheMaxSize (ristretto's
+// MaxCost) bounds actual memory rather than just entry count.
+func Test_payloadCost(t *testing.T) {
+	assert.Equal(t, int64(1), payloadCost(nil), "presence-only entry (nil payload) must keep the old flat cost of 1")
+	assert.Equal(t, int64(1), payloadCost(map[string][]byte{}), "empty payload map must keep the old flat cost of 1")
+	assert.Equal(t, int64(1+5), payloadCost(map[string][]byte{"a": []byte("hello")}), "cost must include the payload's byte length")
+	assert.Equal(t, int64(1+5+3), payloadCost(map[string][]byte{"a": []byte("hello"), "b": []byte("foo")}), "cost must sum every payload's byte length")
+	assert.Equal(t, int64(1), payloadCost(map[string][]byte{"a": nil}), "a nil-valued entry contributes zero bytes, not a panic")
+}
+
+// Test_SetWithPayload_presence_only_entry_costs_flat_one confirms the legacy
+// Set()/plain-signature-cache path (which always stores a nil payload) keeps
+// exactly the pre-fix cost of 1, so existing callers like the legacy
+// ClusterPolicy image-verification engine are unaffected by this change.
+func Test_SetWithPayload_presence_only_entry_costs_flat_one(t *testing.T) {
+	c, err := New(WithCacheEnableFlag(true), WithMaxSize(0), WithTTLDuration(0))
+	assert.NoError(t, err)
+
+	pol := &metav1.ObjectMeta{Name: "cost-test-policy", UID: "cost-test-uid", ResourceVersion: "1"}
+
+	stored, err := c.Set(context.TODO(), pol, "signature-rule", "image-a", true)
+	assert.NoError(t, err)
+	assert.True(t, stored)
+
+	found, err := c.Get(context.TODO(), pol, "signature-rule", "image-a", true)
+	assert.NoError(t, err)
+	assert.True(t, found)
+}
+
+// Test_SetWithPayload_round_trips_real_payload_size confirms a payload-carrying
+// entry (the attestation-cache path) round-trips correctly through the cache
+// once cost accounting reflects its real size, not just that storage still
+// works with the old flat cost.
+func Test_SetWithPayload_round_trips_real_payload_size(t *testing.T) {
+	// MaxSize must comfortably exceed the test payload's cost (1 + byte
+	// length, see payloadCost): the default MaxSize of 1000 is sized for the
+	// old flat per-entry cost of 1 and would reject a single real
+	// multi-KB attestation payload outright.
+	c, err := New(WithCacheEnableFlag(true), WithMaxSize(1_000_000), WithTTLDuration(0))
+	assert.NoError(t, err)
+
+	pol := &metav1.ObjectMeta{Name: "cost-test-policy", UID: "cost-test-uid", ResourceVersion: "1"}
+	largePayload := map[string][]byte{"https://slsa.dev/provenance/v1": make([]byte, 4096)}
+
+	stored, err := c.SetWithPayload(context.TODO(), pol, "attestation-rule", "image-b", true, largePayload)
+	assert.NoError(t, err)
+	assert.True(t, stored)
+
+	found, got, err := c.GetWithPayload(context.TODO(), pol, "attestation-rule", "image-b", true)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, largePayload, got)
+}

--- a/pkg/image/verification/cache/interface.go
+++ b/pkg/image/verification/cache/interface.go
@@ -15,4 +15,14 @@ type Client interface {
 	// Get Searches for the image verified using the rule in the policy in the cache
 	// Returns true when the cache entry is found
 	Get(ctx context.Context, policy metav1.Object, ruleName string, imagerRef string, useCache bool) (bool, error)
+
+	// SetWithPayload is like Set, but also stores verified intoto attestation payloads
+	// keyed by predicate type (matching imagedataloader.ImageData.verifiedIntotoPayloads).
+	// Callers that only need a presence marker can keep using Set.
+	SetWithPayload(ctx context.Context, policy metav1.Object, ruleName string, imageRef string, useCache bool, payloads map[string][]byte) (bool, error)
+
+	// GetWithPayload is like Get, but also returns any cached intoto payloads.
+	// found is true when the verification cache entry exists; payloads may be nil/empty
+	// when the entry was written with Set (presence-only).
+	GetWithPayload(ctx context.Context, policy metav1.Object, ruleName string, imageRef string, useCache bool) (found bool, payloads map[string][]byte, err error)
 }

--- a/test/conformance/chainsaw/image-validating-policies/standard/cosign-attestation-extract-cache-hit/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/standard/cosign-attestation-extract-cache-hit/chainsaw-test.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+# Regression: verifyAttestationSignatures cache hit must still allow extractPayload
+# for Cosign/intoto attestations (process-lifetime image verify cache on the admission
+# controller). Reproduces the 3-attempt create/delete/recreate loop from the bug report.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cosign-attestation-extract-cache-hit
+spec:
+  concurrent: false
+  steps:
+  - name: create policy
+    use:
+      template: ../../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: wait-image-validating-policy-ready
+    use:
+      template: ../../../_step-templates/image-validating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: ivpol-cosign-attestation-extract-cache
+  - name: create pod (cache miss)
+    try:
+    - create:
+        file: pod.yaml
+        # Cold-start allowance: the first-ever Cosign/Sigstore verification in a freshly
+        # started admission controller can exceed the default 10s ApplyTimeout while it
+        # does real Fulcio/Rekor network calls (see context/imagedata/image-data for the
+        # same pattern with real registry I/O).
+        timeout: 90s
+    - assert:
+        file: pod.yaml
+  - name: delete pod after first admission
+    try:
+    - delete:
+        ref:
+          apiVersion: v1
+          kind: Pod
+          name: test-pod-cosign-attestation-cache
+          namespace: default
+  - name: recreate pod (cache hit)
+    try:
+    - create:
+        file: pod.yaml
+    - assert:
+        file: pod.yaml
+  - name: delete pod after second admission
+    try:
+    - delete:
+        ref:
+          apiVersion: v1
+          kind: Pod
+          name: test-pod-cosign-attestation-cache
+          namespace: default
+  - name: recreate pod again (cache hit, third attempt)
+    try:
+    - create:
+        file: pod.yaml
+    - assert:
+        file: pod.yaml

--- a/test/conformance/chainsaw/image-validating-policies/standard/cosign-attestation-extract-cache-hit/pod.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/standard/cosign-attestation-extract-cache-hit/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-cosign-attestation-cache
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: ghcr.io/kyverno/test-images/cosign:github-attestation

--- a/test/conformance/chainsaw/image-validating-policies/standard/cosign-attestation-extract-cache-hit/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/standard/cosign-attestation-extract-cache-hit/policy.yaml
@@ -1,0 +1,45 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ImageValidatingPolicy
+metadata:
+  name: ivpol-cosign-attestation-extract-cache
+spec:
+  webhookConfiguration:
+    timeoutSeconds: 30
+  failurePolicy: Fail
+  validationActions:
+    - Deny
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+  matchImageReferences:
+    - glob: ghcr.io/kyverno/test-images/cosign:*
+  validationConfigurations:
+    mutateDigest: false
+    verifyDigest: false
+    required: false
+  attestors:
+    - name: cosign
+      cosign:
+        keyless:
+          identities:
+            - issuer: https://token.actions.githubusercontent.com
+              subject: https://github.com/kyverno/test-images/.github/workflows/cosign.yml@refs/heads/main
+        ctlog:
+          url: https://rekor.sigstore.dev
+          insecureIgnoreSCT: true
+  attestations:
+    - name: slsa
+      intoto:
+        type: https://slsa.dev/provenance/v1
+  validations:
+    # Cache miss verifies Cosign intoto and stores the payload; cache hit must restore it
+    # so extractPayload still succeeds across admission requests.
+    - expression: >-
+        images.containers.map(image, verifyAttestationSignatures(image, attestations.slsa, [attestors.cosign])).all(e, e > 0)
+      message: failed to verify SLSA intoto attestation with Cosign keyless
+    - expression: >-
+        images.containers.map(image, has(extractPayload(image, attestations.slsa).predicate.buildDefinition)).all(e, e)
+      message: failed to extract SLSA intoto attestation payload after verification


### PR DESCRIPTION
Cherry-pick of #17117 to release-1.19.

Fixes imageverify attestation cache hit payload repopulation issue.