### PR TITLE
fix(webhook): avoid nil pointer dereference in sortedRules when rule Scope is nil

### DIFF
--- a/pkg/controllers/webhook/utils.go
+++ b/pkg/controllers/webhook/utils.go
@@ -246,7 +246,14 @@ func sortedRules(rules []admissionregistrationv1.RuleWithOperations) []admission
 		if x := less(a.Operations, b.Operations); x != 0 {
 			return x
 		}
-		if x := strings.Compare(string(*a.Scope), string(*b.Scope)); x != 0 {
+		var scopeA, scopeB string
+		if a.Scope != nil {
+			scopeA = string(*a.Scope)
+		}
+		if b.Scope != nil {
+			scopeB = string(*b.Scope)
+		}
+		if x := strings.Compare(scopeA, scopeB); x != 0 {
 			return x
 		}
 		return 0

--- a/pkg/controllers/webhook/utils_test.go
+++ b/pkg/controllers/webhook/utils_test.go
@@ -849,6 +849,30 @@ func TestSortedRules(t *testing.T) {
 			admissionregistrationv1.Update,
 		},
 	}
+	rule_apps_pods_nil_scope := admissionregistrationv1.RuleWithOperations{
+		Rule: admissionregistrationv1.Rule{
+			APIGroups:   []string{"apps"},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"pods"},
+			Scope:       nil,
+		},
+		Operations: []admissionregistrationv1.OperationType{
+			admissionregistrationv1.Create,
+			admissionregistrationv1.Update,
+		},
+	}
+	rule_batch_jobs_nil_scope := admissionregistrationv1.RuleWithOperations{
+		Rule: admissionregistrationv1.Rule{
+			APIGroups:   []string{"batch"},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"jobs"},
+			Scope:       nil,
+		},
+		Operations: []admissionregistrationv1.OperationType{
+			admissionregistrationv1.Create,
+			admissionregistrationv1.Delete,
+		},
+	}
 
 	testCases := []struct {
 		name          string
@@ -880,6 +904,16 @@ func TestSortedRules(t *testing.T) {
 			name:          "Sorted by scope",
 			input:         []admissionregistrationv1.RuleWithOperations{rule_apps_pods, rule_apps_pods_cluster},
 			expectedRules: []admissionregistrationv1.RuleWithOperations{rule_apps_pods_cluster, rule_apps_pods},
+		},
+		{
+			name:          "Sorted by scope with nil scope",
+			input:         []admissionregistrationv1.RuleWithOperations{rule_apps_pods, rule_apps_pods_nil_scope},
+			expectedRules: []admissionregistrationv1.RuleWithOperations{rule_apps_pods_nil_scope, rule_apps_pods},
+		},
+		{
+			name:          "Sorted with multiple nil scopes",
+			input:         []admissionregistrationv1.RuleWithOperations{rule_batch_jobs_nil_scope, rule_apps_pods_nil_scope},
+			expectedRules: []admissionregistrationv1.RuleWithOperations{rule_apps_pods_nil_scope, rule_batch_jobs_nil_scope},
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
### Description
In `admissionregistrationv1.Rule`, `Scope` is an optional pointer field (`*ScopeType`). When sorting webhook rules in `sortedRules()`, directly dereferencing `*a.Scope` and `*b.Scope` panics the webhook controller if any rule has a `nil` Scope.

### Solution
- Safely extract the scope string only when `Scope != nil` before calling `strings.Compare(scopeA, scopeB)`, matching the pattern already used in `generateRuleKey()`.
- Add unit test cases in `pkg/controllers/webhook/utils_test.go` covering rules with `nil` scope sorting.

### Related Issue
Fixes #17132
