### PR TITLE
docs(agents): fix stale paths and API group in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,6 @@ cmd/                  # Entry points for all binaries
   background-controller/ # Background controller (generate/mutate existing)
   readiness-checker/  #   Readiness checker
   internal/           #   Shared internal cmd helpers
-  tools/              #   Internal tooling (webhook-cleanup, etc.)
 pkg/                  # Core library code
   engine/             #   Policy engine (rule evaluation, matching, context)
   webhooks/           #   Admission webhook handlers
@@ -41,8 +40,7 @@ pkg/                  # Core library code
   metrics/            #   Prometheus metrics
   validation/         #   Policy validation logic
   autogen/            #   Auto-generation of rules for Pod controllers
-  cosign/             #   Cosign image signature verification
-  notary/             #   Notary image signature verification
+  image/              #   Image signature verification (cosign, notary)
   utils/              #   Shared utilities
 ext/                  # Small standalone utility packages
 charts/               # Helm charts
@@ -60,6 +58,12 @@ docs/                 # Internal developer documentation
 scripts/              # Build and CI scripts
 hack/                 # Code generation helpers
 ```
+
+> **Note:** not every API type lives in `api/`. The `policies.kyverno.io` types
+> (`ValidatingPolicy`, `MutatingPolicy`, `GeneratingPolicy`, `ImageValidatingPolicy`,
+> `DeletingPolicy`, and their `Namespaced*` variants) are defined in the external
+> `github.com/kyverno/api` module. Searching this repository for them finds usages only,
+> never the type definitions. Their engines do live here, under `pkg/cel/policies/`.
 
 ## Build System
 
@@ -175,8 +179,8 @@ Controller code is primarily in `pkg/controllers/`. Webhook handlers are in `pkg
 
 ## API Design Rules
 
-- API types live in `api/` with versioned packages
-- API groups: `kyverno.io`, `policies.kyverno.io`, `policyreport.io`, `reports.kyverno.io`
+- API types live in `api/` with versioned packages, except the `policies.kyverno.io` types, which come from the external `github.com/kyverno/api` module
+- API groups: `kyverno.io`, `policies.kyverno.io`, `wgpolicyk8s.io`, `reports.kyverno.io`
 - New resource types must NOT be added to `kyverno.io/v1`; use `v2alpha1` and promote as they stabilize
 - New attributes can be added without a new version
 - Attributes cannot be deleted or modified in a version; deprecate and remove after 3 minor releases


### PR DESCRIPTION
The repository structure block referenced three directories that no longer exist, and the API design section named a group that was never correct. Agents and new contributors following this file are sent to paths that are not there.

Corrections, each verified against the tree:

  - cmd/tools/ was removed in 480c0b01a; drop the entry.
  - pkg/cosign/ and pkg/notary/ no longer exist. The code now lives under pkg/image/verifiers/{cpol,ivpol}/{cosign,notary}, so the tree now lists pkg/image/ instead of the two stale entries.
  - The policy report API group is wgpolicyk8s.io, not policyreport.io. See api/policyreport/v1alpha2/zz_generated.register.go, which sets GroupName = "wgpolicyk8s.io". The tree block already had this right; only the API Design Rules line was wrong.

Also added a note that the policies.kyverno.io types (ValidatingPolicy, MutatingPolicy, GeneratingPolicy, ImageValidatingPolicy, DeletingPolicy and their Namespaced variants) are defined in the external github.com/kyverno/api module rather than in api/. Both the tree block and the "API types live in api/" rule imply otherwise, so searching this repository for those types turns up usages but never a definition.

Documentation only; no code or behaviour changes.

## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [x] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [x] My PR contains new or altered behavior to Kyverno and
  - [x] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
