### PR TITLE
fix: thread context to toggle.FromContext to preserve feature flags

### DIFF
--- a/pkg/controllers/admissionpolicygenerator/controller.go
+++ b/pkg/controllers/admissionpolicygenerator/controller.go
@@ -221,7 +221,7 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 
 	polType := strings.Split(key, "/")[0]
 	if polType == "ClusterPolicy" {
-		generateValidatingAdmissionPolicy := toggle.FromContext(context.TODO()).GenerateValidatingAdmissionPolicy()
+		generateValidatingAdmissionPolicy := toggle.FromContext(ctx).GenerateValidatingAdmissionPolicy()
 		if !generateValidatingAdmissionPolicy {
 			return nil
 		}
@@ -243,7 +243,7 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 			return err
 		}
 	} else if polType == "ValidatingPolicy" {
-		generateValidatingAdmissionPolicy := toggle.FromContext(context.TODO()).GenerateValidatingAdmissionPolicy()
+		generateValidatingAdmissionPolicy := toggle.FromContext(ctx).GenerateValidatingAdmissionPolicy()
 		if !generateValidatingAdmissionPolicy {
 			return nil
 		}
@@ -269,7 +269,7 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 			logger.Error(err, "unable to get the policy from policy informer")
 			return err
 		}
-		generateMutatingAdmissionPolicy := toggle.FromContext(context.TODO()).GenerateMutatingAdmissionPolicy()
+		generateMutatingAdmissionPolicy := toggle.FromContext(ctx).GenerateMutatingAdmissionPolicy()
 		if !generateMutatingAdmissionPolicy {
 			if !mpol.Spec.GenerateMutatingAdmissionPolicyEnabled() {
 				return nil

--- a/pkg/webhooks/resource/mpol/handler.go
+++ b/pkg/webhooks/resource/mpol/handler.go
@@ -129,7 +129,7 @@ func (h *handler) mutate(ctx context.Context, logger logr.Logger, admissionReque
 		}()
 	}
 
-	resp, err := h.admissionResponse(request, response)
+	resp, err := h.admissionResponse(ctx, request, response)
 	if err != nil {
 		logger.Error(err, "mutation failures")
 		return admissionutils.Response(admissionRequest.UID, err)
@@ -211,7 +211,7 @@ func (h *handler) needsReports(request celengine.EngineRequest) bool {
 	return true
 }
 
-func (h *handler) admissionResponse(request celengine.EngineRequest, response mpolengine.EngineResponse) (handlers.AdmissionResponse, error) {
+func (h *handler) admissionResponse(ctx context.Context, request celengine.EngineRequest, response mpolengine.EngineResponse) (handlers.AdmissionResponse, error) {
 	if len(response.Policies) == 0 {
 		return admissionutils.ResponseSuccess(request.Request.UID), nil
 	}
@@ -220,7 +220,7 @@ func (h *handler) admissionResponse(request celengine.EngineRequest, response mp
 	var mutationErrors []string
 
 	for _, policy := range response.Policies {
-		failurePolicy := policy.Policy.GetFailurePolicy(toggle.FromContext(context.TODO()).ForceFailurePolicyIgnore())
+		failurePolicy := policy.Policy.GetFailurePolicy(toggle.FromContext(ctx).ForceFailurePolicyIgnore())
 		for _, rule := range policy.Rules {
 			switch rule.Status() {
 			case engineapi.RuleStatusError:

--- a/pkg/webhooks/resource/mutation/mutation.go
+++ b/pkg/webhooks/resource/mutation/mutation.go
@@ -157,8 +157,8 @@ func (v *mutationHandler) applyMutations(
 	v.eventGen.Add(events...)
 
 	if v.needsReports(request, v.admissionReports) && reportutils.IsPolicyReportable(policyContext.Policy()) {
-		go func() { //nolint:gosec // background context is intentional: the goroutine outlives the request
-			if err := v.createReports(context.TODO(), policyContext.NewResource(), request, engineResponses...); err != nil {
+		go func() {
+			if err := v.createReports(context.WithoutCancel(ctx), policyContext.NewResource(), request, engineResponses...); err != nil {
 				v.log.Error(err, "failed to create report")
 			}
 		}()

--- a/pkg/webhooks/resource/validation/validation.go
+++ b/pkg/webhooks/resource/validation/validation.go
@@ -154,8 +154,8 @@ func (v *validationHandler) HandleValidationEnforce(
 
 	// create the admission report if any of the policies involved doesn't have the report exclusion label
 	if NeedsReports(request, policyContext.NewResource(), v.admissionReports) && hasReportablePolicy(policies) {
-		go func() { //nolint:gosec // background context is intentional: the goroutine outlives the request
-			if err := v.createReports(context.TODO(), policyContext.NewResource(), request, engineResponses...); err != nil {
+		go func() {
+			if err := v.createReports(context.WithoutCancel(ctx), policyContext.NewResource(), request, engineResponses...); err != nil {
 				if reportutils.IsNamespaceTerminationError(err) {
 					// Log namespace termination errors at debug level as they are expected
 					v.log.V(2).Info("skipping report creation due to namespace termination", "error", err.Error())


### PR DESCRIPTION
## Explanation

Multiple code paths in the admission webhook pipeline and webhook controllers incorrectly called `toggle.FromContext(context.TODO())` instead of using the request-scoped `context.Context` that is already available in the call chain.

Because `context.TODO()` never carries a `toggle.Toggles` value, `FromContext` silently fell back to the global `defaults` (the process-wide flag values). This entirely bypassed the context-based override mechanism for feature toggles. Most critically, this affected `ForceFailurePolicyIgnore()` inside the mutating webhook, meaning that any per-request toggle overrides to the failure policy were completely ignored.

This PR threads the existing `context.Context` from the caller instead of spawning a disconnected `context.TODO()` in:
- `pkg/webhooks/resource/mpol/handler.go`
- `pkg/webhooks/resource/validation/validation.go`
- `pkg/webhooks/resource/mutation/mutation.go`
- `pkg/controllers/admissionpolicygenerator/controller.go` (3 sites)

*Note: For the compiler call sites mentioned in the issue, they are not patched here as they run in background controllers without a live request context, so the fallback is functionally identical.*

## Related issue

Fixes #17224

## Milestone of this PR

/milestone TBD

## What type of PR is this

/kind bug

## Proposed Changes

- Threaded `ctx context.Context` into `admissionResponse` in `pkg/webhooks/resource/mpol/handler.go`.
- Replaced `context.TODO()` with `context.WithoutCancel(ctx)` in webhook background report generation (`pkg/webhooks/resource/validation/validation.go` and `pkg/webhooks/resource/mutation/mutation.go`).
- Threaded `ctx` down in `pkg/controllers/admissionpolicygenerator/controller.go` when resolving VAP/MAP toggles.

### Proof Manifests

Not applicable.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This addresses the most critical context propagation drops in the admission paths. Compiler paths were omitted because they operate in the background and do not receive request-scoped toggles anyway.
