### PR TITLE
fix(policystatus): only require RBAC verbs a subresource supports

### DIFF
--- a/pkg/clients/dclient/discovery.go
+++ b/pkg/clients/dclient/discovery.go
@@ -279,23 +279,20 @@ func (c *serverResources) FindResource(groupVersion string, kind string) (apiRes
 
 func (c *serverResources) FindResources(group, version, kind, subresource string) (map[TopLevelApiDescription]metav1.APIResource, error) {
 	resources, err := c.findResources(group, version, kind, subresource)
-	// if no resource was found, we have to force cache invalidation
-	if err != nil || len(resources) == 0 {
-		if !c.cachedClient.Fresh() || len(resources) == 0 {
-			c.cachedClient.Invalidate()
-			if c.mapper != nil {
-				c.mapper.Reset()
-			}
-			resources, err := c.findResources(group, version, kind, subresource)
-			if err != nil {
-				return nil, err
-			} else if len(resources) == 0 {
-				return nil, ErrResourceNotFound
-			}
-			return resources, err
+	if (err != nil || len(resources) == 0) && !c.cachedClient.Fresh() {
+		c.cachedClient.Invalidate()
+		if c.mapper != nil {
+			c.mapper.Reset()
 		}
+		resources, err = c.findResources(group, version, kind, subresource)
 	}
-	return resources, err
+	if err != nil {
+		return nil, err
+	}
+	if len(resources) == 0 {
+		return nil, ErrResourceNotFound
+	}
+	return resources, nil
 }
 
 func (c *serverResources) findResources(group, version, kind, subresource string) (map[TopLevelApiDescription]metav1.APIResource, error) {

--- a/pkg/clients/dclient/discovery_test.go
+++ b/pkg/clients/dclient/discovery_test.go
@@ -4,8 +4,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery/cached/memory"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	kubetesting "k8s.io/client-go/testing"
 )
 
 var (
@@ -173,6 +177,26 @@ func Test_getServerResourceGroupVersion(t *testing.T) {
 	apiResource = &metav1.APIResource{Name: "deployments/scale", SingularName: "", Namespaced: true, Group: "autoscaling", Version: "v1", Kind: "Scale"}
 	apiResourceListGV = "apps/v1"
 	assert.Equal(t, getServerResourceGroupVersion(apiResourceListGV, apiResource.Group, apiResource.Version), "autoscaling/v1")
+}
+
+func TestFindResources_NotFoundDoesNotRefetchFreshCache(t *testing.T) {
+	fake := &fakediscovery.FakeDiscovery{Fake: &kubetesting.Fake{
+		Resources: []*metav1.APIResourceList{
+			{GroupVersion: "v1", APIResources: []metav1.APIResource{podAPIResource}},
+		},
+	}}
+	sr := &serverResources{cachedClient: memory.NewMemCacheClient(fake)}
+
+	_, err := sr.FindResources("", "v1", "Pod", "")
+	require.NoError(t, err)
+	callsAfterWarmup := len(fake.Actions())
+	require.NotZero(t, callsAfterWarmup)
+
+	for range 3 {
+		_, err := sr.FindResources("", "v1", "DoesNotExist", "")
+		assert.ErrorIs(t, err, ErrResourceNotFound)
+	}
+	assert.Equal(t, callsAfterWarmup, len(fake.Actions()), "not-found lookups against a fresh cache should not trigger extra discovery calls")
 }
 
 func Test_findResourceFromResourceName(t *testing.T) {

--- a/pkg/clients/dclient/fake.go
+++ b/pkg/clients/dclient/fake.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	openapiv2 "github.com/google/gnostic-models/openapiv2"
+	"github.com/kyverno/kyverno/ext/wildcard"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -166,21 +167,60 @@ func (c *fakeDiscoveryClient) GetGVRFromGVK(gvk schema.GroupVersionKind) (schema
 	return c.getGVR(resource)
 }
 
+var fakeConnectOnlySubresources = []string{"exec", "attach", "portforward"}
+
 func (c *fakeDiscoveryClient) FindResources(group, version, kind, subresource string) (map[TopLevelApiDescription]metav1.APIResource, error) {
-	r := strings.ToLower(kind) + "s"
+	subresources := []string{subresource}
+	if subresource != "" && strings.Contains(subresource, "*") {
+		subresources = fakeConnectOnlySubresources
+	}
+
+	results := map[TopLevelApiDescription]metav1.APIResource{}
 	for _, resource := range c.registeredResources {
-		if resource.Resource == r {
-			return map[TopLevelApiDescription]metav1.APIResource{
-				{
-					GroupVersion: schema.GroupVersion{Group: resource.Group, Version: resource.Version},
-					Kind:         kind,
-					Resource:     r,
-					SubResource:  subresource,
-				}: {},
-			}, nil
+		if kind != "*" && resource.Resource != strings.ToLower(kind)+"s" {
+			continue
+		}
+		desc := TopLevelApiDescription{
+			GroupVersion: schema.GroupVersion{Group: resource.Group, Version: resource.Version},
+			Kind:         inferKindFromResourceName(resource.Resource),
+			Resource:     resource.Resource,
+		}
+		if subresource == "" {
+			results[desc] = metav1.APIResource{Verbs: fakeVerbsFor("")}
+			continue
+		}
+		if kind == "*" && subresource == "*" {
+			// mirrors the real discovery client, which merges the plain
+			// top-level resource in alongside its subresources here.
+			results[desc] = metav1.APIResource{Verbs: fakeVerbsFor("")}
+		}
+		for _, sub := range subresources {
+			if !wildcard.Match(subresource, sub) {
+				continue
+			}
+			d := desc
+			d.SubResource = sub
+			results[d] = metav1.APIResource{Verbs: fakeVerbsFor(sub)}
 		}
 	}
-	return nil, fmt.Errorf("not found")
+	if len(results) == 0 {
+		return nil, fmt.Errorf("not found")
+	}
+	return results, nil
+}
+
+// fakeVerbsFor approximates real API server verbs: connect-only
+// subresources (exec/attach/portforward) get no get/list/watch, others
+// behave like a status subresource.
+func fakeVerbsFor(subresource string) []string {
+	switch subresource {
+	case "":
+		return []string{"get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"}
+	case "exec", "attach", "portforward":
+		return []string{"create"}
+	default:
+		return []string{"get", "patch", "update"}
+	}
 }
 
 func (c *fakeDiscoveryClient) OpenAPISchema() (*openapiv2.Document, error) {

--- a/pkg/controllers/policystatus/controller.go
+++ b/pkg/controllers/policystatus/controller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/ext/wildcard"
 	auth "github.com/kyverno/kyverno/pkg/auth/checker"
 	"github.com/kyverno/kyverno/pkg/client/clientset/versioned"
 	policiesv1beta1informers "github.com/kyverno/kyverno/pkg/client/informers/externalversions/policies.kyverno.io/v1beta1"
@@ -16,10 +17,13 @@ import (
 	"github.com/kyverno/kyverno/pkg/controllers/webhook"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
+	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"go.uber.org/multierr"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
@@ -440,16 +444,35 @@ func (c controller) reconcileBeta1Conditions(ctx context.Context, policy enginea
 	return status
 }
 
-func (c controller) resolveGVRs(rules []admissionregistrationv1.NamedRuleWithOperations) []metav1.GroupVersionResource {
-	gvrs := []metav1.GroupVersionResource{}
+// backgroundReadVerbs are the verbs background scanning needs on a matched resource.
+var backgroundReadVerbs = []string{"get", "list", "watch"}
+
+type gvrTarget struct {
+	schema.GroupVersionResource
+	Subresource string
+}
+
+func (t gvrTarget) String() string {
+	if t.Subresource == "" {
+		return t.GroupVersionResource.String()
+	}
+	return fmt.Sprintf("%s, Subresource=%s", t.GroupVersionResource.String(), t.Subresource)
+}
+
+func (c controller) resolveGVRs(rules []admissionregistrationv1.NamedRuleWithOperations) []gvrTarget {
+	gvrs := []gvrTarget{}
 	for _, rule := range rules {
 		for _, g := range rule.RuleWithOperations.APIGroups {
 			for _, v := range rule.RuleWithOperations.APIVersions {
 				for _, r := range rule.RuleWithOperations.Resources {
-					gvrs = append(gvrs, metav1.GroupVersionResource{
-						Group:    g,
-						Version:  v,
-						Resource: r,
+					resource, subresource := kubeutils.SplitSubresource(r)
+					gvrs = append(gvrs, gvrTarget{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    g,
+							Version:  v,
+							Resource: resource,
+						},
+						Subresource: subresource,
 					})
 				}
 			}
@@ -459,11 +482,11 @@ func (c controller) resolveGVRs(rules []admissionregistrationv1.NamedRuleWithOpe
 	return gvrs
 }
 
-func (c controller) permissionsCheck(ctx context.Context, gvrs []metav1.GroupVersionResource) []error {
+func (c controller) permissionsCheck(ctx context.Context, gvrs []gvrTarget) []error {
 	var errs []error
 	for _, gvr := range gvrs {
-		for _, verb := range []string{"get", "list", "watch"} {
-			result, err := c.authChecker.Check(ctx, gvr.Group, gvr.Version, gvr.Resource, "", "", "", verb)
+		for _, verb := range c.backgroundVerbsFor(gvr) {
+			result, err := c.authChecker.Check(ctx, gvr.Group, gvr.Version, gvr.Resource, gvr.Subresource, "", "", verb)
 			if baseerrors.Is(err, auth.ErrNoServiceAccount) {
 				continue
 			} else if err != nil {
@@ -475,4 +498,39 @@ func (c controller) permissionsCheck(ctx context.Context, gvrs []metav1.GroupVer
 	}
 
 	return errs
+}
+
+// backgroundVerbsFor intersects backgroundReadVerbs with what gvr supports.
+// gvr.Resource/Subresource may be wildcards (e.g. "pods/*", "*/exec"), and
+// verbs from every match are unioned first. Falls back to the full list on
+// error or no match.
+func (c controller) backgroundVerbsFor(gvr gvrTarget) []string {
+	resources, err := c.dclient.Discovery().FindResources(gvr.Group, gvr.Version, "*", gvr.Subresource)
+	if err != nil {
+		return backgroundReadVerbs
+	}
+
+	supported := sets.New[string]()
+	matched := false
+	for desc, apiResource := range resources {
+		if !wildcard.Match(gvr.Resource, desc.Resource) || !subresourceMatches(gvr.Subresource, desc.SubResource) {
+			continue
+		}
+		matched = true
+		supported.Insert(apiResource.Verbs...)
+	}
+	if !matched {
+		return backgroundReadVerbs
+	}
+
+	return sets.New(backgroundReadVerbs...).Intersection(supported).UnsortedList()
+}
+
+// subresourceMatches reports whether name satisfies pattern. A subresource
+// pattern never matches the plain top-level resource, even if pattern is "*".
+func subresourceMatches(pattern, name string) bool {
+	if pattern == "" {
+		return name == ""
+	}
+	return name != "" && wildcard.Match(pattern, name)
 }

--- a/pkg/controllers/policystatus/controller_test.go
+++ b/pkg/controllers/policystatus/controller_test.go
@@ -394,3 +394,91 @@ func TestReconcileBeta1Conditions_RBACGatedOnBackground(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcileConditions_GeneratingPolicy_ConnectOnlySubresource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		resources     []string
+		wantRBAC      metav1.ConditionStatus
+		wantMsgSubstr string
+	}{
+		{
+			name:          "connect-only subresource (pods/exec): readiness is not blocked by unsatisfiable permissions",
+			resources:     []string{"pods/exec"},
+			wantRBAC:      metav1.ConditionTrue,
+			wantMsgSubstr: "Policy is ready for reporting",
+		},
+		{
+			name:          "plain resource (pods): missing get/list/watch still blocks readiness",
+			resources:     []string{"pods"},
+			wantRBAC:      metav1.ConditionFalse,
+			wantMsgSubstr: "missing permissions",
+		},
+		{
+			name:          "wildcard subresource (pods/*)",
+			resources:     []string{"pods/*"},
+			wantRBAC:      metav1.ConditionTrue,
+			wantMsgSubstr: "Policy is ready for reporting",
+		},
+		{
+			name:          "wildcard resource (*/exec)",
+			resources:     []string{"*/exec"},
+			wantRBAC:      metav1.ConditionTrue,
+			wantMsgSubstr: "Policy is ready for reporting",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			rule := []admissionregistrationv1.NamedRuleWithOperations{
+				{
+					RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Connect},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   tt.resources,
+						},
+					},
+				},
+			}
+
+			dc := dclient.NewEmptyFakeClient()
+			dc.SetDiscovery(dclient.NewFakeDiscoveryClient([]schema.GroupVersionResource{{Version: "v1", Resource: "pods"}}))
+
+			// Deny every SubjectAccessReview: no RBAC is granted anywhere in this test.
+			kube := dc.GetKubeClient().(*kubefake.Clientset)
+			kube.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, &authorizationv1.SubjectAccessReview{
+					Status: authorizationv1.SubjectAccessReviewStatus{Allowed: false, Reason: "denied by test"},
+				}, nil
+			})
+
+			c := controller{
+				dclient:          dc,
+				client:           versionedfake.NewSimpleClientset(),
+				authChecker:      auth.NewSubjectChecker(dc.GetKubeClient().AuthorizationV1().SubjectAccessReviews(), "system:serviceaccount:kyverno:reports-controller", nil),
+				polStateRecorder: webhook.NewStateRecorder(nil),
+			}
+
+			gpol := &policiesv1beta1.GeneratingPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-gpol"},
+				Spec: policiesv1beta1.GeneratingPolicySpec{
+					MatchConstraints: &admissionregistrationv1.MatchResources{ResourceRules: rule},
+				},
+			}
+
+			status := c.reconcileConditions(ctx, engineapi.NewGeneratingPolicy(gpol))
+
+			cond := findCondition(status.Conditions, policiesv1beta1.PolicyConditionTypeRBACPermissionsGranted)
+			require.NotNil(t, cond, "RBACPermissionsGranted condition should always be set")
+			assert.Equal(t, tt.wantRBAC, cond.Status, "RBACPermissionsGranted status")
+			assert.Contains(t, cond.Message, tt.wantMsgSubstr, "RBACPermissionsGranted message")
+		})
+	}
+}

--- a/test/conformance/chainsaw/generating-policies/subresources/exec-readiness/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generating-policies/subresources/exec-readiness/chainsaw-test.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: exec-readiness
+spec:
+  concurrent: false
+  steps:
+  # No RBAC is granted for pods/exec anywhere in this test. It's a
+  # connect-only subresource, so readiness must not depend on get/list/watch.
+  - name: create policy
+    use:
+      template: ../../../_step-templates/create-policy.yaml
+      with:
+        bindings:
+        - name: file
+          value: policy.yaml
+  - name: generating policy becomes ready without any RBAC on pods/exec
+    use:
+      template: ../../../_step-templates/generating-policy-ready.yaml
+      with:
+        bindings:
+        - name: name
+          value: connect-only-subresource-readiness

--- a/test/conformance/chainsaw/generating-policies/subresources/exec-readiness/policy.yaml
+++ b/test/conformance/chainsaw/generating-policies/subresources/exec-readiness/policy.yaml
@@ -1,0 +1,32 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: GeneratingPolicy
+metadata:
+  name: connect-only-subresource-readiness
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CONNECT"]
+      resources:   ["pods/exec"]
+  variables:
+    - name: nsName
+      expression: "object.metadata.namespace"
+    - name: configmap
+      expression: >-
+        [
+          {
+            "kind": dyn("ConfigMap"),
+            "apiVersion": dyn("v1"),
+            "metadata": dyn({
+              "name": "connect-only-subresource-readiness",
+              "namespace": string(variables.nsName),
+            }),
+            "data": dyn({
+              "KAFKA_ADDRESS": "192.168.10.13:9092,192.168.10.14:9092,192.168.10.15:9092",
+              "ZK_ADDRESS": "192.168.10.10:2181,192.168.10.11:2181,192.168.10.12:2181"
+            })
+          }
+        ]
+  generate:
+    - expression: generator.apply(variables.nsName, variables.configmap)


### PR DESCRIPTION


## Explanation

This PR fixed the required RBAC grants on pods/exec, etc, which lead to policies never becoming ready.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> 
> /kind cleanup-->

/kind design

<!--
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

Checks with discovery what verbs a resource/subresource supports.
Defaults to the existing behaviour if the CRD is missing or another error occurs.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
