### PR TITLE
feat: deprecate kyverno.io/v2beta1 policy API versions (Phase 1)

### DIFF
--- a/api/kyverno/v2beta1/cleanup_policy_types.go
+++ b/api/kyverno/v2beta1/cleanup_policy_types.go
@@ -35,7 +35,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=".spec.schedule"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2beta1 CleanupPolicy is deprecated; use kyverno.io/v2"
 
 // CleanupPolicy defines a rule for resource cleanup.
 type CleanupPolicy struct {
@@ -121,7 +121,7 @@ type CleanupPolicyList struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=".spec.schedule"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2beta1 ClusterCleanupPolicy is deprecated; use kyverno.io/v2"
 
 // ClusterCleanupPolicy defines rule for resource cleanup.
 type ClusterCleanupPolicy struct {

--- a/api/kyverno/v2beta1/clusterpolicy_types.go
+++ b/api/kyverno/v2beta1/clusterpolicy_types.go
@@ -26,6 +26,7 @@ import (
 // +kubebuilder:printcolumn:name="GENERATE",type=integer,JSONPath=`.status.rulecount.generate`,priority=1
 // +kubebuilder:printcolumn:name="VERIFY IMAGES",type=integer,JSONPath=`.status.rulecount.verifyimages`,priority=1
 // +kubebuilder:printcolumn:name="MESSAGE",type=string,JSONPath=`.status.conditions[?(@.type == "Ready")].message`
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2beta1 ClusterPolicy is deprecated; use kyverno.io/v1"
 
 // ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.
 type ClusterPolicy struct {

--- a/api/kyverno/v2beta1/policy_exception_types.go
+++ b/api/kyverno/v2beta1/policy_exception_types.go
@@ -26,7 +26,7 @@ import (
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=polex,categories=kyverno
-// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2beta1 PolicyException is deprecated; use kyverno.io/v2"
 
 // PolicyException declares resources to be excluded from specified policies.
 type PolicyException struct {

--- a/api/kyverno/v2beta1/policy_types.go
+++ b/api/kyverno/v2beta1/policy_types.go
@@ -25,6 +25,7 @@ import (
 // +kubebuilder:printcolumn:name="VERIFY IMAGES",type=integer,JSONPath=`.status.rulecount.verifyimages`,priority=1
 // +kubebuilder:printcolumn:name="MESSAGE",type=string,JSONPath=`.status.conditions[?(@.type == "Ready")].message`
 // +kubebuilder:resource:shortName=pol,categories=kyverno
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2beta1 Policy is deprecated; use kyverno.io/v1"
 
 // Policy declares validation, mutation, and generation behaviors for matching resources.
 // See: https://kyverno.io/docs/writing-policies/ for more information.

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_cleanuppolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_cleanuppolicies.yaml
@@ -1325,6 +1325,7 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 CleanupPolicy is deprecated; use kyverno.io/v2
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clustercleanuppolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clustercleanuppolicies.yaml
@@ -1325,6 +1325,8 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterCleanupPolicy is deprecated; use
+      kyverno.io/v2
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clusterpolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clusterpolicies.yaml
@@ -10363,6 +10363,8 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterPolicy is deprecated; use kyverno.io/v1
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policies.yaml
@@ -10365,6 +10365,8 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 Policy is deprecated; use kyverno.io/v1
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policyexceptions.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policyexceptions.yaml
@@ -665,6 +665,7 @@ spec:
     served: true
     storage: true
   - deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 PolicyException is deprecated; use kyverno.io/v2
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -43,6 +44,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/cli/loader"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/config"
+	deprecationspkg "github.com/kyverno/kyverno/pkg/deprecations"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/factories"
@@ -1137,12 +1139,15 @@ func (c *ApplyCommandConfig) loadPolicies() (
 			}
 			for _, policyYaml := range policyYamls {
 				loaderResults, err := policy.Load(fs, "", policyYaml)
-				if loaderResults != nil && loaderResults.NonFatalErrors != nil {
-					for _, err := range loaderResults.NonFatalErrors {
-						log.Log.Error(err.Error, "Non-fatal parsing error for single document")
+				if loaderResults != nil {
+					for _, ne := range loaderResults.NonFatalErrors {
+						log.Log.Error(ne.Error, "Non-fatal parsing error for single document")
 					}
 				}
 				if err != nil {
+					if errors.Is(err, deprecationspkg.ErrDeprecated) {
+						return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, err
+					}
 					continue
 				}
 				policies = append(policies, loaderResults.Policies...)
@@ -1163,12 +1168,15 @@ func (c *ApplyCommandConfig) loadPolicies() (
 			}
 		} else {
 			loaderResults, err := policy.Load(nil, "", path)
-			if loaderResults != nil && loaderResults.NonFatalErrors != nil {
-				for _, err := range loaderResults.NonFatalErrors {
-					log.Log.Error(err.Error, "Non-fatal parsing error for single document")
+			if loaderResults != nil {
+				for _, ne := range loaderResults.NonFatalErrors {
+					log.Log.Error(ne.Error, "Non-fatal parsing error for single document")
 				}
 			}
 			if err != nil {
+				if errors.Is(err, deprecationspkg.ErrDeprecated) {
+					return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, err
+				}
 				log.Log.V(3).Info("skipping invalid YAML file", "path", path, "error", err)
 			} else {
 				policies = append(policies, loaderResults.Policies...)

--- a/cmd/cli/kubectl-kyverno/commands/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/command.go
@@ -12,19 +12,28 @@ import (
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/oci"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/test"
 	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/commands/version"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/exception"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/policy"
 	"github.com/spf13/cobra"
 )
 
 func RootCommand(experimental bool) *cobra.Command {
+	var warningsAsErrors bool
 	cmd := &cobra.Command{
 		Use:          "kyverno",
 		Short:        command.FormatDescription(true, websiteUrl, false, description...),
 		Long:         command.FormatDescription(false, websiteUrl, false, description...),
 		SilenceUsage: true,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			policy.WarningsAsErrors = warningsAsErrors
+			exception.WarningsAsErrors = warningsAsErrors
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
 	}
+	cmd.PersistentFlags().BoolVar(&warningsAsErrors, "warnings-as-errors", false, "fail the command if deprecated API versions or fields are detected")
 	cmd.AddCommand(
 		apply.Command(),
 		completion.Command(),

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_cleanuppolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_cleanuppolicies.yaml
@@ -1319,6 +1319,7 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 CleanupPolicy is deprecated; use kyverno.io/v2
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clustercleanuppolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clustercleanuppolicies.yaml
@@ -1319,6 +1319,8 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterCleanupPolicy is deprecated; use
+      kyverno.io/v2
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
@@ -10357,6 +10357,8 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterPolicy is deprecated; use kyverno.io/v1
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policies.yaml
@@ -10359,6 +10359,8 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 Policy is deprecated; use kyverno.io/v1
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policyexceptions.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policyexceptions.yaml
@@ -659,6 +659,7 @@ spec:
     served: true
     storage: true
   - deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 PolicyException is deprecated; use kyverno.io/v2
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/exception/load.go
+++ b/cmd/cli/kubectl-kyverno/exception/load.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kyverno/kyverno/ext/resource/convert"
 	resourceloader "github.com/kyverno/kyverno/ext/resource/loader"
 	yamlutils "github.com/kyverno/kyverno/ext/yaml"
+	"github.com/kyverno/kyverno/pkg/deprecations"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/kubectl-validate/pkg/openapiclient"
@@ -27,6 +28,10 @@ var (
 	celExceptionV1       = schema.GroupVersion(policiesv1.GroupVersion).WithKind("PolicyException")
 )
 
+// WarningsAsErrors turns deprecation warnings emitted while loading exceptions
+// into errors. It is controlled by the --warnings-as-errors CLI flag.
+var WarningsAsErrors bool
+
 type LoaderResults struct {
 	Exceptions    []*kyvernov2.PolicyException
 	CELExceptions []*policiesv1beta1.PolicyException
@@ -39,7 +44,7 @@ func Load(paths ...string) (*LoaderResults, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to read yaml (%w)", err)
 		}
-		results, err := load(bytes)
+		results, err := load(path, bytes)
 		if err != nil {
 			return nil, fmt.Errorf("unable to load exceptions (%w)", err)
 		}
@@ -49,7 +54,7 @@ func Load(paths ...string) (*LoaderResults, error) {
 	return loaderResults, nil
 }
 
-func load(content []byte) (*LoaderResults, error) {
+func load(path string, content []byte) (*LoaderResults, error) {
 	results := &LoaderResults{}
 	documents, err := yamlutils.SplitDocuments(content)
 	if err != nil {
@@ -67,6 +72,14 @@ func load(content []byte) (*LoaderResults, error) {
 
 	for _, document := range documents {
 		gvk, untyped, err := factory.Load(document)
+		if gvk.Kind != "" && gvk.Group != "" {
+			if warning := deprecations.APIVersionWarning(gvk); warning != "" {
+				fmt.Fprintf(os.Stderr, "Warning: %s: %s\n", path, warning)
+				if WarningsAsErrors {
+					return nil, fmt.Errorf("%s: %w", path, deprecations.ErrDeprecated)
+				}
+			}
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/cli/kubectl-kyverno/exception/load_test.go
+++ b/cmd/cli/kubectl-kyverno/exception/load_test.go
@@ -51,7 +51,7 @@ func Test_load(t *testing.T) {
 			bytes, err := os.ReadFile(tt.policies)
 			require.NoError(t, err)
 			require.NoError(t, err)
-			if res, err := load(bytes); (err != nil) != tt.wantErr {
+			if res, err := load(tt.policies, bytes); (err != nil) != tt.wantErr {
 				t.Errorf("Load() error = %v, wantErr %v", err, tt.wantErr)
 			} else if res != nil {
 				if len(res.Exceptions) != tt.exceptionsLoaded {

--- a/cmd/cli/kubectl-kyverno/policy/deprecated_test.go
+++ b/cmd/cli/kubectl-kyverno/policy/deprecated_test.go
@@ -1,0 +1,61 @@
+package policy
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/kyverno/kyverno/pkg/deprecations"
+)
+
+func repoRoot(t *testing.T) string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine test file location")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found")
+		}
+		dir = parent
+	}
+}
+
+// TestDeprecatedAPIVersionWarning asserts that loading a v2beta1 fixture
+// succeeds normally but returns deprecations.ErrDeprecated when the
+// --warnings-as-errors flag is enabled. These fixtures intentionally use the
+// deprecated apiVersion and serve as warning-assertion tests.
+func TestDeprecatedAPIVersionWarning(t *testing.T) {
+	root := repoRoot(t)
+	fixtures := []string{
+		"clusterpolicy.yaml",
+		"policy.yaml",
+		"policyexception.yaml",
+		"cleanuppolicy.yaml",
+		"clustercleanuppolicy.yaml",
+	}
+	for _, name := range fixtures {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(root, "test", "cli", "deprecated-versions", name)
+			WarningsAsErrors = false
+			if _, err := Load(nil, "", path); err != nil {
+				t.Fatalf("unexpected error loading deprecated fixture %s: %v", name, err)
+			}
+			WarningsAsErrors = true
+			defer func() { WarningsAsErrors = false }()
+			if _, err := Load(nil, "", path); err == nil {
+				t.Fatalf("expected deprecation error for %s", name)
+			} else if !errors.Is(err, deprecations.ErrDeprecated) {
+				t.Fatalf("expected ErrDeprecated for %s, got %v", name, err)
+			}
+		})
+	}
+}

--- a/cmd/cli/kubectl-kyverno/policy/deprecated_test.go
+++ b/cmd/cli/kubectl-kyverno/policy/deprecated_test.go
@@ -1,10 +1,13 @@
 package policy
 
 import (
+	"bytes"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/kyverno/kyverno/pkg/deprecations"
@@ -57,5 +60,74 @@ func TestDeprecatedAPIVersionWarning(t *testing.T) {
 				t.Fatalf("expected ErrDeprecated for %s, got %v", name, err)
 			}
 		})
+	}
+}
+
+// captureStderr runs f while capturing everything written to os.Stderr.
+func captureStderr(f func()) string {
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		return ""
+	}
+	os.Stderr = w
+	f()
+	w.Close()
+	os.Stderr = orig
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+// TestDeprecatedFieldWarning asserts that deprecated spec fields (e.g.
+// spec.validationFailureAction, spec.webhookTimeoutSeconds) are surfaced by the
+// CLI loader, not only by the admission webhook. This is the offline part of
+// the migration path (plan Step 2) that previously was only enforced in-cluster.
+func TestDeprecatedFieldWarning(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.yaml")
+	content := `apiVersion: kyverno.io/v2beta1
+kind: ClusterPolicy
+metadata:
+  name: require-labels
+spec:
+  validationFailureAction: Enforce
+  webhookTimeoutSeconds: 15
+  rules:
+  - name: check-team
+    match:
+      any:
+      - resources:
+          kinds: [Pod]
+    validate:
+      message: "label 'team' is required"
+      pattern:
+        metadata:
+          labels:
+            team: "?*"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	WarningsAsErrors = false
+	out := captureStderr(func() {
+		if _, err := Load(nil, "", path); err != nil {
+			t.Fatalf("unexpected error loading policy with deprecated fields: %v", err)
+		}
+	})
+	if !strings.Contains(out, "spec.validationFailureAction is deprecated") {
+		t.Fatalf("expected field deprecation warning for validationFailureAction, got:\n%s", out)
+	}
+	if !strings.Contains(out, "spec.webhookTimeoutSeconds is deprecated") {
+		t.Fatalf("expected field deprecation warning for webhookTimeoutSeconds, got:\n%s", out)
+	}
+
+	WarningsAsErrors = true
+	defer func() { WarningsAsErrors = false }()
+	if _, err := Load(nil, "", path); err == nil {
+		t.Fatal("expected deprecation error with --warnings-as-errors")
+	} else if !errors.Is(err, deprecations.ErrDeprecated) {
+		t.Fatalf("expected ErrDeprecated, got %v", err)
 	}
 }

--- a/cmd/cli/kubectl-kyverno/policy/load.go
+++ b/cmd/cli/kubectl-kyverno/policy/load.go
@@ -210,6 +210,9 @@ func kubectlValidateLoader(path string, content []byte) (*LoaderResults, error) 
 					return nil, fmt.Errorf("%s: %w", path, deprecations.ErrDeprecated)
 				}
 			}
+			if err := warnPolicyFieldDeprecations(path, gvk, &untyped); err != nil {
+				return nil, err
+			}
 		}
 		if err != nil {
 			// Check if this is a List object and handle it explicitly
@@ -234,6 +237,43 @@ func kubectlValidateLoader(path string, content []byte) (*LoaderResults, error) 
 		}
 	}
 	return results, nil
+}
+
+// warnPolicyFieldDeprecations emits warnings for deprecated fields in the spec
+// of a legacy kyverno.io ClusterPolicy/Policy (e.g. spec.validationFailureAction,
+// spec.webhookTimeoutSeconds, spec.failurePolicy). It mirrors the field-level
+// deprecation checks performed by the admission webhook so that kubectl-kyverno
+// surfaces them offline as well, not just in-cluster. PolicyException, cleanup
+// policies and the CEL-based types use different specs and have no deprecated
+// fields covered by deprecations.CheckPolicy.
+func warnPolicyFieldDeprecations(path string, gvk schema.GroupVersionKind, untyped *unstructured.Unstructured) error {
+	if gvk.Group != kyvernov1.GroupVersion.Group {
+		return nil
+	}
+	var spec *kyvernov1.Spec
+	switch gvk.Kind {
+	case "ClusterPolicy":
+		typed, err := convert.To[kyvernov1.ClusterPolicy](*untyped)
+		if err != nil {
+			return nil
+		}
+		spec = &typed.Spec
+	case "Policy":
+		typed, err := convert.To[kyvernov1.Policy](*untyped)
+		if err != nil {
+			return nil
+		}
+		spec = &typed.Spec
+	default:
+		return nil
+	}
+	for _, w := range deprecations.CheckPolicy(spec) {
+		fmt.Fprintf(os.Stderr, "Warning: %s: %s\n", path, w.Message)
+		if WarningsAsErrors {
+			return fmt.Errorf("%s: %w", path, deprecations.ErrDeprecated)
+		}
+	}
+	return nil
 }
 
 // handleListItems processes a v1.List object by extracting and processing its items

--- a/cmd/cli/kubectl-kyverno/policy/load.go
+++ b/cmd/cli/kubectl-kyverno/policy/load.go
@@ -24,6 +24,7 @@ import (
 	resourceloader "github.com/kyverno/kyverno/ext/resource/loader"
 	extyaml "github.com/kyverno/kyverno/ext/yaml"
 	"github.com/kyverno/kyverno/pkg/admissionpolicy"
+	"github.com/kyverno/kyverno/pkg/deprecations"
 	"github.com/kyverno/kyverno/pkg/utils/git"
 	"github.com/pkg/errors"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -185,6 +186,10 @@ var loaderDelegate = sync.OnceValues(func() (resourceloader.Loader, error) {
 	return factory, err
 })
 
+// WarningsAsErrors turns deprecation warnings emitted while loading policies
+// into errors. It is controlled by the --warnings-as-errors CLI flag.
+var WarningsAsErrors bool
+
 func kubectlValidateLoader(path string, content []byte) (*LoaderResults, error) {
 	documents, err := extyaml.SplitDocuments(content)
 	if err != nil {
@@ -197,6 +202,14 @@ func kubectlValidateLoader(path string, content []byte) (*LoaderResults, error) 
 	}
 	for _, document := range documents {
 		gvk, untyped, err := factory.Load(document)
+		if gvk.Kind != "" && gvk.Group != "" {
+			if warning := deprecations.APIVersionWarning(gvk); warning != "" {
+				fmt.Fprintf(os.Stderr, "Warning: %s: %s\n", path, warning)
+				if WarningsAsErrors {
+					return nil, fmt.Errorf("%s: %w", path, deprecations.ErrDeprecated)
+				}
+			}
+		}
 		if err != nil {
 			// Check if this is a List object and handle it explicitly
 			if gvk.Kind == "List" && gvk.Version == "v1" {

--- a/config/crds/kyverno/kyverno.io_cleanuppolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_cleanuppolicies.yaml
@@ -1319,6 +1319,7 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 CleanupPolicy is deprecated; use kyverno.io/v2
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_clustercleanuppolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_clustercleanuppolicies.yaml
@@ -1319,6 +1319,8 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterCleanupPolicy is deprecated; use
+      kyverno.io/v2
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
@@ -10357,6 +10357,8 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterPolicy is deprecated; use kyverno.io/v1
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_policies.yaml
+++ b/config/crds/kyverno/kyverno.io_policies.yaml
@@ -10359,6 +10359,8 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 Policy is deprecated; use kyverno.io/v1
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_policyexceptions.yaml
+++ b/config/crds/kyverno/kyverno.io_policyexceptions.yaml
@@ -659,6 +659,7 @@ spec:
     served: true
     storage: true
   - deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 PolicyException is deprecated; use kyverno.io/v2
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -1526,6 +1526,7 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 CleanupPolicy is deprecated; use kyverno.io/v2
     name: v2beta1
     schema:
       openAPIV3Schema:
@@ -4138,6 +4139,8 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterCleanupPolicy is deprecated; use
+      kyverno.io/v2
     name: v2beta1
     schema:
       openAPIV3Schema:
@@ -15788,6 +15791,8 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterPolicy is deprecated; use kyverno.io/v1
     name: v2beta1
     schema:
       openAPIV3Schema:
@@ -36931,6 +36936,8 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 Policy is deprecated; use kyverno.io/v1
     name: v2beta1
     schema:
       openAPIV3Schema:
@@ -47593,6 +47600,7 @@ spec:
     served: true
     storage: true
   - deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 PolicyException is deprecated; use kyverno.io/v2
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/docs/user/cli/commands/kyverno.md
+++ b/docs/user/cli/commands/kyverno.md
@@ -39,6 +39,7 @@ kyverno [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_apply.md
+++ b/docs/user/cli/commands/kyverno_apply.md
@@ -102,6 +102,7 @@ kyverno apply [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_completion.md
+++ b/docs/user/cli/commands/kyverno_completion.md
@@ -71,6 +71,7 @@ kyverno completion [bash|zsh|fish|powershell]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_create.md
+++ b/docs/user/cli/commands/kyverno_create.md
@@ -53,6 +53,7 @@ kyverno create [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_create_cluster-role.md
+++ b/docs/user/cli/commands/kyverno_create_cluster-role.md
@@ -42,6 +42,7 @@ kyverno create cluster-role [name]  [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_create_exception.md
+++ b/docs/user/cli/commands/kyverno_create_exception.md
@@ -50,6 +50,7 @@ kyverno create exception [name] [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_create_metrics-config.md
+++ b/docs/user/cli/commands/kyverno_create_metrics-config.md
@@ -49,6 +49,7 @@ kyverno create metrics-config [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_create_test.md
+++ b/docs/user/cli/commands/kyverno_create_test.md
@@ -52,6 +52,7 @@ kyverno create test [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_create_user-info.md
+++ b/docs/user/cli/commands/kyverno_create_user-info.md
@@ -49,6 +49,7 @@ kyverno create user-info [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_create_values.md
+++ b/docs/user/cli/commands/kyverno_create_values.md
@@ -49,6 +49,7 @@ kyverno create values [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_docs.md
+++ b/docs/user/cli/commands/kyverno_docs.md
@@ -56,6 +56,7 @@ kyverno docs [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_fix.md
+++ b/docs/user/cli/commands/kyverno_fix.md
@@ -49,6 +49,7 @@ kyverno fix [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_fix_policy.md
+++ b/docs/user/cli/commands/kyverno_fix_policy.md
@@ -50,6 +50,7 @@ kyverno fix policy [dir]... [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_fix_test.md
+++ b/docs/user/cli/commands/kyverno_fix_test.md
@@ -56,6 +56,7 @@ kyverno fix test [dir]... [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_jp.md
+++ b/docs/user/cli/commands/kyverno_jp.md
@@ -50,6 +50,7 @@ kyverno jp [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_jp_function.md
+++ b/docs/user/cli/commands/kyverno_jp_function.md
@@ -47,6 +47,7 @@ kyverno jp function [function_name]... [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_jp_parse.md
+++ b/docs/user/cli/commands/kyverno_jp_parse.md
@@ -57,6 +57,7 @@ kyverno jp parse [-f file|expression]... [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_jp_query.md
+++ b/docs/user/cli/commands/kyverno_jp_query.md
@@ -60,6 +60,7 @@ kyverno jp query [-i input] [-q query|query]... [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_migrate.md
+++ b/docs/user/cli/commands/kyverno_migrate.md
@@ -46,6 +46,7 @@ kyverno migrate [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_oci.md
+++ b/docs/user/cli/commands/kyverno_oci.md
@@ -49,6 +49,7 @@ kyverno oci [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_oci_pull.md
+++ b/docs/user/cli/commands/kyverno_oci_pull.md
@@ -47,6 +47,7 @@ kyverno oci pull [dir] [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_oci_push.md
+++ b/docs/user/cli/commands/kyverno_oci_push.md
@@ -50,6 +50,7 @@ kyverno oci push [dir or file] [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_test.md
+++ b/docs/user/cli/commands/kyverno_test.md
@@ -65,6 +65,7 @@ kyverno test [local folder or git repository]... [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/docs/user/cli/commands/kyverno_version.md
+++ b/docs/user/cli/commands/kyverno_version.md
@@ -44,6 +44,7 @@ kyverno version [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
+      --warnings-as-errors                  fail the command if deprecated API versions or fields are detected
 ```
 
 ### SEE ALSO

--- a/pkg/deprecations/deprecations.go
+++ b/pkg/deprecations/deprecations.go
@@ -3,11 +3,106 @@
 // policies.kyverno.io policy types and scheduled for removal.
 package deprecations
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ErrDeprecated is returned by the CLI loaders when --warnings-as-errors is set
+// and a deprecated API version or field is detected. Commands treat it as a
+// fatal error (non-zero exit) rather than skipping the file.
+var ErrDeprecated = errors.New("deprecated API version or field detected")
 
 // MigrationGuideURL points to the guide describing how to migrate legacy
 // kyverno.io policies to the policies.kyverno.io policy types.
 const MigrationGuideURL = "https://kyverno.io/docs/guides/migration-to-cel/"
+
+// deprecatedAPIVersions maps a deprecated kyverno.io <apiVersion> <Kind> to the
+// apiVersion that should be used instead. The kube-apiserver already emits
+// Warning: headers for these via the CRD deprecatedversion marker; this table
+// is used by the CLI and metrics where the apiserver warning is not available.
+var deprecatedAPIVersions = map[string]string{
+	"kyverno.io/v2beta1 ClusterPolicy":        "kyverno.io/v1",
+	"kyverno.io/v2beta1 Policy":               "kyverno.io/v1",
+	"kyverno.io/v2beta1 PolicyException":      "kyverno.io/v2",
+	"kyverno.io/v2beta1 CleanupPolicy":        "kyverno.io/v2",
+	"kyverno.io/v2beta1 ClusterCleanupPolicy": "kyverno.io/v2",
+	"kyverno.io/v2alpha1 GlobalContextEntry":  "kyverno.io/v2",
+}
+
+// APIVersionWarning returns a deprecation warning for using a deprecated
+// apiVersion (e.g. kyverno.io/v2beta1 ClusterPolicy), or an empty string if the
+// GVK is not a deprecated apiVersion.
+func APIVersionWarning(gvk schema.GroupVersionKind) string {
+	key := gvk.GroupVersion().String() + " " + gvk.Kind
+	replacement, ok := deprecatedAPIVersions[key]
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%s is deprecated and will be removed after 1.19; migrate to %s", key, replacement)
+}
+
+// PolicyDeprecation describes a deprecated field detected in a policy spec.
+type PolicyDeprecation struct {
+	// Field is the JSON path of the deprecated field (used as a metric label).
+	Field string
+	// Message is the human-readable deprecation notice.
+	Message string
+}
+
+// CheckPolicy returns deprecation warnings for the use of deprecated fields in a
+// policy spec (version-agnostic; the spec is always interpreted as kyvernov1).
+func CheckPolicy(spec *kyvernov1.Spec) []PolicyDeprecation {
+	if spec == nil {
+		return nil
+	}
+	var warnings []PolicyDeprecation
+	add := func(field, message string) {
+		warnings = append(warnings, PolicyDeprecation{Field: field, Message: message})
+	}
+	if spec.ValidationFailureAction != "" {
+		add("spec.validationFailureAction", "spec.validationFailureAction is deprecated; use validationFailureAction under the validate rule")
+	}
+	if spec.FailurePolicy != nil {
+		add("spec.failurePolicy", "spec.failurePolicy is deprecated; use webhookConfiguration.failurePolicy")
+	}
+	if spec.WebhookTimeoutSeconds != nil {
+		add("spec.webhookTimeoutSeconds", "spec.webhookTimeoutSeconds is deprecated; use webhookConfiguration.timeoutSeconds")
+	}
+	if spec.GenerateExistingOnPolicyUpdate != nil {
+		add("spec.generateExistingOnPolicyUpdate", "spec.generateExistingOnPolicyUpdate is deprecated; use generateExisting under the generate rule")
+	}
+	if spec.MutateExistingOnPolicyUpdate {
+		add("spec.mutateExistingOnPolicyUpdate", "spec.mutateExistingOnPolicyUpdate is deprecated; use mutateExistingOnPolicyUpdate under the mutate rule")
+	}
+	for i := range spec.Rules {
+		rule := &spec.Rules[i]
+		for j := range rule.VerifyImages {
+			iv := &rule.VerifyImages[j]
+			if iv.Image != "" {
+				add(fmt.Sprintf("rules[%d].verifyImages.image", i), fmt.Sprintf("rules[%d].verifyImages.image is deprecated; use imageReferences", i))
+			}
+			if iv.Key != "" {
+				add(fmt.Sprintf("rules[%d].verifyImages.key", i), fmt.Sprintf("rules[%d].verifyImages.key is deprecated; use staticKey", i))
+			}
+			if iv.Roots != "" {
+				add(fmt.Sprintf("rules[%d].verifyImages.roots", i), fmt.Sprintf("rules[%d].verifyImages.roots is deprecated; use keyless", i))
+			}
+			for k := range iv.Attestations {
+				if iv.Attestations[k].PredicateType != "" {
+					add(fmt.Sprintf("rules[%d].verifyImages.attestations[%d].predicateType", i, k), fmt.Sprintf("rules[%d].verifyImages.attestations[%d].predicateType is deprecated; use type", i, k))
+				}
+			}
+		}
+		if rule.Validation != nil && rule.Validation.DeprecatedAssert != nil {
+			add(fmt.Sprintf("rules[%d].validate.assert", i), fmt.Sprintf("rules[%d].validate.assert is deprecated and has no effect since 1.19", i))
+		}
+	}
+	return warnings
+}
 
 // replacements maps a legacy kyverno.io kind to its policies.kyverno.io replacement(s).
 var replacements = map[string]string{

--- a/pkg/deprecations/deprecations_test.go
+++ b/pkg/deprecations/deprecations_test.go
@@ -3,7 +3,136 @@ package deprecations
 import (
 	"strings"
 	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+func TestAPIVersionWarning(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		gvk       schema.GroupVersionKind
+		expectMsg bool
+	}{
+		{schema.GroupVersionKind{Group: "kyverno.io", Version: "v2beta1", Kind: "ClusterPolicy"}, true},
+		{schema.GroupVersionKind{Group: "kyverno.io", Version: "v2beta1", Kind: "Policy"}, true},
+		{schema.GroupVersionKind{Group: "kyverno.io", Version: "v2beta1", Kind: "PolicyException"}, true},
+		{schema.GroupVersionKind{Group: "kyverno.io", Version: "v2beta1", Kind: "CleanupPolicy"}, true},
+		{schema.GroupVersionKind{Group: "kyverno.io", Version: "v2beta1", Kind: "ClusterCleanupPolicy"}, true},
+		{schema.GroupVersionKind{Group: "kyverno.io", Version: "v2alpha1", Kind: "GlobalContextEntry"}, true},
+		{schema.GroupVersionKind{Group: "kyverno.io", Version: "v1", Kind: "ClusterPolicy"}, false},
+		{schema.GroupVersionKind{Group: "kyverno.io", Version: "v2", Kind: "PolicyException"}, false},
+	}
+	for _, tt := range tests {
+		warning := APIVersionWarning(tt.gvk)
+		if tt.expectMsg && warning == "" {
+			t.Errorf("APIVersionWarning(%q) = %q, expected a deprecation warning", tt.gvk, warning)
+		}
+		if !tt.expectMsg && warning != "" {
+			t.Errorf("APIVersionWarning(%q) = %q, expected empty string", tt.gvk, warning)
+		}
+		if warning != "" && !strings.Contains(warning, "will be removed after 1.19") {
+			t.Errorf("APIVersionWarning(%q) = %q, expected removal notice", tt.gvk, warning)
+		}
+	}
+}
+
+func TestCheckPolicy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		spec     *kyvernov1.Spec
+		expected []string
+	}{
+		{
+			name:     "nil spec",
+			spec:     nil,
+			expected: nil,
+		},
+		{
+			name: "spec-level deprecated fields",
+			spec: &kyvernov1.Spec{
+				ValidationFailureAction:        "Enforce",
+				FailurePolicy:                  failurePolicyTypePtr("Fail"),
+				WebhookTimeoutSeconds:          int32Ptr(10),
+				GenerateExistingOnPolicyUpdate: boolPtr(true),
+				MutateExistingOnPolicyUpdate:   true,
+			},
+			expected: []string{
+				"spec.validationFailureAction is deprecated",
+				"spec.failurePolicy is deprecated",
+				"spec.webhookTimeoutSeconds is deprecated",
+				"spec.generateExistingOnPolicyUpdate is deprecated",
+				"spec.mutateExistingOnPolicyUpdate is deprecated",
+			},
+		},
+		{
+			name: "rule-level deprecated verify image fields",
+			spec: &kyvernov1.Spec{
+				Rules: []kyvernov1.Rule{
+					{
+						VerifyImages: []kyvernov1.ImageVerification{
+							{Image: "nginx", Key: "key", Roots: "roots", Attestations: []kyvernov1.Attestation{{PredicateType: "custom"}}},
+						},
+						Validation: &kyvernov1.Validation{DeprecatedAssert: &kyvernov1.Any{}},
+					},
+				},
+			},
+			expected: []string{
+				"rules[0].verifyImages.image is deprecated",
+				"rules[0].verifyImages.key is deprecated",
+				"rules[0].verifyImages.roots is deprecated",
+				"rules[0].verifyImages.attestations[0].predicateType is deprecated",
+				"rules[0].validate.assert is deprecated",
+			},
+		},
+		{
+			name: "no deprecated fields",
+			spec: &kyvernov1.Spec{
+				WebhookConfiguration: &kyvernov1.WebhookConfiguration{TimeoutSeconds: int32Ptr(10)},
+				Rules: []kyvernov1.Rule{
+					{Validation: &kyvernov1.Validation{FailureAction: validationFailureActionPtr("Enforce")}},
+				},
+			},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			warnings := CheckPolicy(tt.spec)
+			for _, want := range tt.expected {
+				found := false
+				for _, got := range warnings {
+					if got.Field == "" {
+						t.Errorf("CheckPolicy() returned warning with empty Field: %+v", got)
+					}
+					if strings.Contains(got.Message, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("CheckPolicy() missing warning %q, got %v", want, warnings)
+				}
+			}
+			if len(warnings) != len(tt.expected) {
+				t.Errorf("CheckPolicy() got %d warnings %v, expected %d", len(warnings), warnings, len(tt.expected))
+			}
+		})
+	}
+}
+
+func int32Ptr(i int32) *int32 { return &i }
+func boolPtr(b bool) *bool    { return &b }
+func failurePolicyTypePtr(s string) *kyvernov1.FailurePolicyType {
+	v := kyvernov1.FailurePolicyType(s)
+	return &v
+}
+func validationFailureActionPtr(s string) *kyvernov1.ValidationFailureAction {
+	v := kyvernov1.ValidationFailureAction(s)
+	return &v
+}
 
 func TestWarning(t *testing.T) {
 	t.Parallel()

--- a/pkg/metrics/deprecations.go
+++ b/pkg/metrics/deprecations.go
@@ -1,0 +1,54 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+func GetDeprecationMetrics() DeprecationMetrics {
+	if metricsConfig == nil {
+		return nil
+	}
+
+	return metricsConfig.DeprecationMetrics()
+}
+
+type deprecationsMetrics struct {
+	requestsMetric metric.Int64Counter
+
+	logger logr.Logger
+}
+
+type DeprecationMetrics interface {
+	RecordDeprecatedAPIRequest(ctx context.Context, group, version, kind, field string)
+}
+
+func (m *deprecationsMetrics) init(meter metric.Meter) {
+	var err error
+
+	m.requestsMetric, err = meter.Int64Counter(
+		"kyverno_deprecated_api_requests_total",
+		metric.WithDescription("can be used to track the number of requests that use a deprecated Kyverno API version or field"),
+	)
+	if err != nil {
+		m.logger.Error(err, "Failed to create instrument, kyverno_deprecated_api_requests_total")
+	}
+}
+
+func (m *deprecationsMetrics) RecordDeprecatedAPIRequest(ctx context.Context, group, version, kind, field string) {
+	if m.requestsMetric == nil {
+		return
+	}
+
+	attributes := []attribute.KeyValue{
+		attribute.String("group", group),
+		attribute.String("version", version),
+		attribute.String("kind", kind),
+		attribute.String("field", field),
+	}
+
+	m.requestsMetric.Add(ctx, 1, metric.WithAttributes(attributes...))
+}

--- a/pkg/metrics/deprecations_test.go
+++ b/pkg/metrics/deprecations_test.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestDeprecationMetrics_Record(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m := &deprecationsMetrics{}
+	m.init(provider.Meter("test"))
+
+	ctx := context.Background()
+	m.RecordDeprecatedAPIRequest(ctx, "kyverno.io", "v2beta1", "ClusterPolicy", "")
+	m.RecordDeprecatedAPIRequest(ctx, "kyverno.io", "v2beta1", "ClusterPolicy", "spec.validationFailureAction")
+
+	var rm metricdata.ResourceMetrics
+	assert.NoError(t, reader.Collect(ctx, &rm))
+
+	var sum *metricdata.Sum[int64]
+	for _, sm := range rm.ScopeMetrics {
+		for i := range sm.Metrics {
+			if sm.Metrics[i].Name == "kyverno_deprecated_api_requests_total" {
+				s := sm.Metrics[i].Data.(metricdata.Sum[int64])
+				sum = &s
+			}
+		}
+	}
+	assert.NotNil(t, sum, "metric kyverno_deprecated_api_requests_total not found")
+	assert.Len(t, sum.DataPoints, 2)
+
+	var total int64
+	for _, dp := range sum.DataPoints {
+		total += dp.Value
+		attrs := make(map[string]string)
+		for _, kv := range dp.Attributes.ToSlice() {
+			attrs[string(kv.Key)] = kv.Value.AsString()
+		}
+		assert.Equal(t, "kyverno.io", attrs["group"])
+		assert.Equal(t, "v2beta1", attrs["version"])
+		assert.Equal(t, "ClusterPolicy", attrs["kind"])
+	}
+	assert.Equal(t, int64(2), total)
+}
+
+func TestDeprecationMetrics_RecordNilInstrument(t *testing.T) {
+	m := &deprecationsMetrics{} // requestsMetric is nil
+	assert.NotPanics(t, func() {
+		m.RecordDeprecatedAPIRequest(context.Background(), "g", "v", "k", "f")
+	})
+}
+
+func TestGetDeprecationMetrics_NilManager(t *testing.T) {
+	old := GetManager()
+	t.Cleanup(func() { SetManager(old) })
+	SetManager(nil)
+	assert.Nil(t, GetDeprecationMetrics())
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -54,6 +54,7 @@ type MetricsConfig struct {
 	ivpolMetrics         *imageValidatingMetrics
 	mpolMetrics          *mutatingMetrics
 	gpolMetrics          *generatingMetrics
+	deprecationMetrics   *deprecationsMetrics
 
 	// config
 	config kconfig.MetricsConfiguration
@@ -79,6 +80,7 @@ type MetricsConfigManager interface {
 	IVPOLMetrics() ImageValidatingMetrics
 	MPOLMetrics() MutatingMetrics
 	GPOLMetrics() GeneratingMetrics
+	DeprecationMetrics() DeprecationMetrics
 }
 
 func (m *MetricsConfig) Config() kconfig.MetricsConfiguration {
@@ -145,6 +147,10 @@ func (m *MetricsConfig) GPOLMetrics() GeneratingMetrics {
 	return m.gpolMetrics
 }
 
+func (m *MetricsConfig) DeprecationMetrics() DeprecationMetrics {
+	return m.deprecationMetrics
+}
+
 func (m *MetricsConfig) initializeMetrics(meterProvider metric.MeterProvider) error {
 	var err error
 	meter := meterProvider.Meter(MeterName)
@@ -185,6 +191,7 @@ func (m *MetricsConfig) initializeMetrics(meterProvider metric.MeterProvider) er
 	m.ivpolMetrics.init(meter)
 	m.mpolMetrics.init(meter)
 	m.gpolMetrics.init(meter)
+	m.deprecationMetrics.init(meter)
 
 	initKyvernoInfoMetric(m)
 	return nil
@@ -348,6 +355,7 @@ func NewMetricsConfigManager(logger logr.Logger, metricsConfiguration kconfig.Me
 		ivpolMetrics:         &imageValidatingMetrics{logger: logger.WithName("image-validating-policy")},
 		mpolMetrics:          &mutatingMetrics{logger: logger.WithName("mutating-policy")},
 		gpolMetrics:          &generatingMetrics{logger: logger.WithName("generating-policy")},
+		deprecationMetrics:   &deprecationsMetrics{logger: logger.WithName("deprecations")},
 	}
 
 	return config

--- a/pkg/webhooks/policy/handlers.go
+++ b/pkg/webhooks/policy/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/deprecations"
 	eval "github.com/kyverno/kyverno/pkg/image/verification/evaluator"
+	"github.com/kyverno/kyverno/pkg/metrics"
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	policyvalidate "github.com/kyverno/kyverno/pkg/validation/policy"
 	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
@@ -96,6 +97,24 @@ func (h *policyHandlers) Validate(ctx context.Context, logger logr.Logger, reque
 		if warning := deprecations.Warning(request.Kind.Kind); warning != "" {
 			logger.V(2).Info(warning, "kind", request.Kind.Kind, "namespace", request.Namespace, "name", request.Name)
 			warnings = append(warnings, warning)
+		}
+		policyWarnings := deprecations.CheckPolicy(policy.AsKyvernoPolicy().GetSpec())
+		if len(policyWarnings) > 0 {
+			for _, w := range policyWarnings {
+				logger.V(2).Info(w.Message, "kind", request.Kind.Kind, "namespace", request.Namespace, "name", request.Name)
+			}
+			for _, w := range policyWarnings {
+				warnings = append(warnings, w.Message)
+			}
+		}
+		if metric := metrics.GetDeprecationMetrics(); metric != nil {
+			gvk := request.GroupVersionKind
+			if deprecations.APIVersionWarning(gvk) != "" {
+				metric.RecordDeprecatedAPIRequest(ctx, gvk.Group, gvk.Version, gvk.Kind, "")
+			}
+			for _, w := range policyWarnings {
+				metric.RecordDeprecatedAPIRequest(ctx, gvk.Group, gvk.Version, gvk.Kind, w.Field)
+			}
 		}
 		return admissionutils.Response(request.UID, err, warnings...)
 	}

--- a/pkg/webhooks/policy/handlers_test.go
+++ b/pkg/webhooks/policy/handlers_test.go
@@ -1,0 +1,85 @@
+package policy
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	kconfig "github.com/kyverno/kyverno/pkg/config"
+	"github.com/kyverno/kyverno/pkg/metrics"
+	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	ktesting "k8s.io/client-go/testing"
+)
+
+// cachedDiscovery wraps a dclient discovery implementation so that
+// CachedDiscoveryInterface() returns a working cache. The default dclient fake
+// returns nil here, which the policy validator dereferences and panics on.
+type cachedDiscovery struct {
+	dclient.IDiscovery
+	k8s discovery.DiscoveryInterface
+}
+
+func (c cachedDiscovery) CachedDiscoveryInterface() discovery.CachedDiscoveryInterface {
+	return memory.NewMemCacheClient(c.k8s)
+}
+
+func TestPolicyHandlerDeprecationWarnings(t *testing.T) {
+	old := metrics.GetManager()
+	t.Cleanup(func() { metrics.SetManager(old) })
+	metrics.SetManager(metrics.NewMetricsConfigManager(logr.Discard(), kconfig.NewDefaultMetricsConfiguration()))
+
+	client, err := dclient.NewFakeClient(scheme.Scheme, map[schema.GroupVersionResource]string{})
+	assert.NoError(t, err)
+	fd := dclient.NewFakeDiscoveryClient([]schema.GroupVersionResource{
+		{Group: "", Version: "v1", Resource: "pods"},
+	})
+	client.SetDiscovery(cachedDiscovery{
+		IDiscovery: fd,
+		k8s:        &fake.FakeDiscovery{Fake: &ktesting.Fake{}},
+	})
+
+	h := NewHandlers(client, nil, "", "")
+
+	raw := []byte(`{
+		"apiVersion": "kyverno.io/v2beta1",
+		"kind": "ClusterPolicy",
+		"metadata": {"name": "test-cp"},
+		"spec": {
+			"validationFailureAction": "Enforce",
+			"webhookConfiguration": {
+				"matchConditions": [{"name": "invalid", "expression": "this is not valid cel !!"}]
+			},
+			"rules": [{"name": "check", "match": {"any": [{"resources": {"kinds": ["Pod"]}}]}}]
+		}
+	}`)
+
+	req := handlers.AdmissionRequest{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID:       types.UID("test-uid"),
+			Operation: admissionv1.Create,
+			Kind:      metav1.GroupVersionKind{Group: "kyverno.io", Version: "v2beta1", Kind: "ClusterPolicy"},
+			Object:    runtime.RawExtension{Raw: raw},
+		},
+		GroupVersionKind: schema.GroupVersionKind{Group: "kyverno.io", Version: "v2beta1", Kind: "ClusterPolicy"},
+	}
+
+	resp := h.Validate(context.Background(), logr.Discard(), req, "", time.Time{})
+	joined := strings.Join(resp.Warnings, " ")
+	// The legacy-kind deprecation (CEL migration) warning is surfaced on every
+	// kyverno.io policy, and the deprecated-field warning comes from CheckPolicy.
+	assert.Contains(t, joined, "ClusterPolicy (kyverno.io) is deprecated")
+	assert.Contains(t, joined, "spec.validationFailureAction is deprecated")
+}

--- a/test/cli/deprecated-versions/cleanuppolicy.yaml
+++ b/test/cli/deprecated-versions/cleanuppolicy.yaml
@@ -1,0 +1,13 @@
+apiVersion: kyverno.io/v2beta1
+kind: CleanupPolicy
+metadata:
+  name: deprecated-cleanuppolicy
+  namespace: test
+spec:
+  schedule: "*/1 * * * *"
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        name: cleanup-pod-1

--- a/test/cli/deprecated-versions/clustercleanuppolicy.yaml
+++ b/test/cli/deprecated-versions/clustercleanuppolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: kyverno.io/v2beta1
+kind: ClusterCleanupPolicy
+metadata:
+  name: deprecated-clustercleanuppolicy
+spec:
+  schedule: "*/1 * * * *"
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        name: cleanup-pod-1

--- a/test/cli/deprecated-versions/clusterpolicy.yaml
+++ b/test/cli/deprecated-versions/clusterpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: kyverno.io/v2beta1
+kind: ClusterPolicy
+metadata:
+  name: deprecated-clusterpolicy
+spec:
+  validationFailureAction: Audit
+  rules:
+  - name: check-labels
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "label 'team' is required"
+      pattern:
+        metadata:
+          labels:
+            team: "?*"

--- a/test/cli/deprecated-versions/policy.yaml
+++ b/test/cli/deprecated-versions/policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: kyverno.io/v2beta1
+kind: Policy
+metadata:
+  name: deprecated-policy
+  namespace: test
+spec:
+  validationFailureAction: Audit
+  rules:
+  - name: check-labels
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "label 'team' is required"
+      pattern:
+        metadata:
+          labels:
+            team: "?*"

--- a/test/cli/deprecated-versions/policyexception.yaml
+++ b/test/cli/deprecated-versions/policyexception.yaml
@@ -1,0 +1,21 @@
+apiVersion: kyverno.io/v2beta1
+kind: PolicyException
+metadata:
+  name: delta-exception
+  namespace: delta
+spec:
+  exceptions:
+  - policyName: disallow-host-namespaces
+    ruleNames:
+    - host-namespaces
+    - autogen-host-namespaces
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        - Deployment
+        namespaces:
+        - delta
+        names:
+        - important-tool*

--- a/test/cli/test-cleanup-policy/cleanup-pod-by-name/policy.yaml
+++ b/test/cli/test-cleanup-policy/cleanup-pod-by-name/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v2
 kind: CleanupPolicy
 metadata:
   name: cleanup-pod-by-name

--- a/test/cli/test-cleanup-policy/cluster-cleanup-namespace/policy.yaml
+++ b/test/cli/test-cleanup-policy/cluster-cleanup-namespace/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v2
 kind: ClusterCleanupPolicy
 metadata:
   name: cluster-cleanup-namespace

--- a/test/cli/test-exceptions/exceptions-1/policy.yaml
+++ b/test/cli/test-exceptions/exceptions-1/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-host-namespaces

--- a/test/conformance/chainsaw/exceptions/allows-rejects-creation/policy.yaml
+++ b/test/conformance/chainsaw/exceptions/allows-rejects-creation/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-labels

--- a/test/conformance/chainsaw/exceptions/only-for-specific-user/policy.yaml
+++ b/test/conformance/chainsaw/exceptions/only-for-specific-user/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-labels

--- a/test/conformance/chainsaw/exceptions/with-wildcard/policy.yaml
+++ b/test/conformance/chainsaw/exceptions/with-wildcard/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-labels

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/clone-source-name-exceeds-63-characters/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/clone-source-name-exceeds-63-characters/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: generate-secret

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-create-on-trigger-deletion/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-create-on-trigger-deletion/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-create-on-trigger-deletion

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-sync-create-source-after-policy/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-sync-create-source-after-policy/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-create-source-after-policy

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/generate-event-upon-edit/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/generate-event-upon-edit/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: generate-event-upon-edit

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-create/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-create/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-downstream/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-policy/chainsaw-test.yaml
@@ -34,6 +34,6 @@ spec:
         file: check.yaml
     - delete:
         ref:
-          apiVersion: kyverno.io/v2beta1
+          apiVersion: kyverno.io/v1
           kind: ClusterPolicy
           name: cpol-nosync-clone-delete-policy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-policy/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-policy/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone-delete-policy
@@ -20,6 +20,7 @@ spec:
         namespace: default
         name: regcred
 ---
+
 apiVersion: v1
 data:
   foo: YmFy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-rule/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-rule/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone
@@ -35,6 +35,7 @@ spec:
         namespace: default
         name: mytestcm
 ---
+
 apiVersion: v1
 data:
   foo: YmFy
@@ -44,6 +45,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
+
 apiVersion: v1
 data:
   color: yellow

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-rule/singlerule.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-rule/singlerule.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-source/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-source/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-nosync-delete-source
@@ -20,6 +20,7 @@ spec:
         namespace: default
         name: regcred
 ---
+
 apiVersion: v1
 data:
   foo: YmFy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-trigger/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-trigger/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-nosync-delete-trigger-policy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-modify-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-modify-downstream/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-nosync-modify-downstream
@@ -20,6 +20,7 @@ spec:
         namespace: default
         name: regcred
 ---
+
 apiVersion: v1
 data:
   foo: YmFy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-modify-source/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-modify-source/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone-modify-source
@@ -20,6 +20,7 @@ spec:
         namespace: default
         name: regcred
 ---
+
 apiVersion: v1
 data:
   foo: YmFy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-update-trigger-no-match/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-update-trigger-no-match/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-nosync-update-trigger-no-match-policy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-create/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-create/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-sync-clone

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-downstream/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-sync-clone

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-policy/chainsaw-test.yaml
@@ -42,7 +42,7 @@ spec:
     try:
     - delete:
         ref:
-          apiVersion: kyverno.io/v2beta1
+          apiVersion: kyverno.io/v1
           kind: ClusterPolicy
           name: cpol-clone-sync-delete-policy
   - name: step-05

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-policy/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-policy/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-delete-policy
@@ -20,6 +20,7 @@ spec:
         namespace: default
         name: regcred
 ---
+
 apiVersion: v1
 data:
   foo: YmFy
@@ -29,6 +30,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
+
 apiVersion: v1
 data:
   color: yellow

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-rule/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-rule/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-delete-rule
@@ -39,6 +39,7 @@ spec:
         namespace: default
         name: mytestcm
 ---
+
 apiVersion: v1
 data:
   foo: YmFy
@@ -48,6 +49,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
+
 apiVersion: v1
 data:
   color: yellow

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-rule/singlerule.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-rule/singlerule.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-delete-rule

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-source/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-source/policy.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: cpol-clone-sync-delete-source-ns
 ---
+
 apiVersion: v1
 data:
   foo: YmFy
@@ -12,7 +13,8 @@ metadata:
   namespace: cpol-clone-sync-delete-source-ns
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-delete-source

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-trigger/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-trigger/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-delete-trigger-policy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-modify-downstream-apply/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-modify-downstream-apply/policy.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-modify-downstream-apply

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-modify-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-modify-downstream/policy.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-modify-downstream

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-modify-source/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-modify-source/policy.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: cpol-clone-sync-modify-source-ns
 ---
+
 apiVersion: v1
 data:
   foo: YmFy
@@ -12,7 +13,8 @@ metadata:
   namespace: cpol-clone-sync-modify-source-ns
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-modify-source

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-update-trigger-no-match/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-update-trigger-no-match/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-update-trigger-no-match-policy

--- a/test/conformance/chainsaw/generate/policy/cornercases/pol-clone-sync-create-source-after-policy/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/cornercases/pol-clone-sync-create-source-after-policy/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-create-source-after-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-create/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-create/manifests.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-create-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-downstream/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-downstream/manifests.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-create-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-policy/chainsaw-test.yaml
@@ -36,7 +36,7 @@ spec:
     try:
     - delete:
         ref:
-          apiVersion: kyverno.io/v2beta1
+          apiVersion: kyverno.io/v1
           kind: Policy
           name: pol-clone-nosync-delete-policy
           namespace: default

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-policy/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-policy/manifests.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-delete-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-rule/chainsaw-step-03-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-rule/chainsaw-step-03-apply-1-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-delete-rule

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-rule/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-rule/manifests.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
+
 apiVersion: v1
 kind: LimitRange
 metadata:
@@ -24,7 +25,8 @@ spec:
     min:
       cpu: 100m
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-delete-rule

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-source/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-source/manifests.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-delete-source

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-trigger/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-trigger/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-delete-trigger-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-invalid/policy1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-invalid/policy1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-invalid

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-invalid/policy2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-invalid/policy2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-invalid

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-modify-downstream/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-modify-downstream/manifests.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: pol-clone-nosync-modify-downstream-ns
 ---
+
 apiVersion: v1
 data:
   foo: YmFy
@@ -12,7 +13,8 @@ metadata:
   namespace: pol-clone-nosync-modify-downstream-ns
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-modify-downstream

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-modify-source/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-modify-source/manifests.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-modify-source

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-update-trigger-no-match/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-update-trigger-no-match/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-update-trigger-no-match-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-downstream/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-sync-clone-delete-downstream

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-policy/chainsaw-test.yaml
@@ -40,7 +40,7 @@ spec:
     try:
     - delete:
         ref:
-          apiVersion: kyverno.io/v2beta1
+          apiVersion: kyverno.io/v1
           kind: Policy
           name: pol-clone-sync-delete-policy
           namespace: default

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-policy/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-policy/manifests.yaml
@@ -7,7 +7,8 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-delete-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-rule/chainsaw-step-03-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-rule/chainsaw-step-03-apply-1-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-delete-rule

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-rule/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-rule/manifests.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
+
 apiVersion: v1
 kind: LimitRange
 metadata:
@@ -24,7 +25,8 @@ spec:
     min:
       cpu: 100m
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-delete-rule

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-source/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-source/policy.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: pol-clone-sync-delete-source
 ---
+
 apiVersion: v1
 data:
   foo: YmFy
@@ -12,7 +13,8 @@ metadata:
   namespace: pol-clone-sync-delete-source
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-delete-source

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-trigger/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-trigger/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-delete-trigger-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-invalid/policy1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-invalid/policy1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-invalid

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-invalid/policy2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-invalid/policy2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-invalid

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-modify-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-modify-downstream/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-modify-downstream-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-sync-clone

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-update-trigger-no-match/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-update-trigger-no-match/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-update-trigger-no-match-policy

--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-create-policy-invalid/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-create-policy-invalid/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-data-nosync-create-policy-invalid-policy

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-create-policy-invalid/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-create-policy-invalid/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-data-sync

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-create-policy-valid/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-create-policy-valid/policy.yaml
@@ -3,7 +3,8 @@ kind: Namespace
 metadata:
   name: poltest
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-data-sync

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/policy-2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/policy-2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: zk-kafka-address

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule-deprecated/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: zk-kafka-address

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/policy-2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/policy-2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: zk-kafka-address

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: zk-kafka-address

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/target-namespace-scope/policy-pass-3.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/target-namespace-scope/policy-pass-3.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: expiration-for-policyexceptions

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/warn-clone-change/policy.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/warn-clone-change/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: generate-update-clone

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/warn-clone-change/update-name.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/warn-clone-change/update-name.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: generate-update-clone

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/warn-clone-change/update-namespace.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/warn-clone-change/update-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: generate-update-clone

--- a/test/conformance/chainsaw/generate/validation/policy/warn-clone-change/policy.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/warn-clone-change/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: generate-update-clone

--- a/test/conformance/chainsaw/generate/validation/policy/warn-clone-change/update-name.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/warn-clone-change/update-name.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: generate-update-clone

--- a/test/conformance/chainsaw/policy-validation/cluster-policy/admission-disabled/policy-generate.yaml
+++ b/test/conformance/chainsaw/policy-validation/cluster-policy/admission-disabled/policy-generate.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: generate

--- a/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/policy-assert.yaml
+++ b/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/policy-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v2
 kind: ClusterCleanupPolicy
 metadata:
   name: test-secret-removal

--- a/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/policy.yaml
+++ b/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v2
 kind: ClusterCleanupPolicy
 metadata:
   name: test-secret-removal

--- a/test/conformance/chainsaw/reports/background/exception/policy.yaml
+++ b/test/conformance/chainsaw/reports/background/exception/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-labels

--- a/test/conformance/chainsaw/reports/background/generate/policy.yaml
+++ b/test/conformance/chainsaw/reports/background/generate/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone

--- a/test/conformance/chainsaw/validate/anchors/conditional-deprecated/policy.yaml
+++ b/test/conformance/chainsaw/validate/anchors/conditional-deprecated/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-scale

--- a/test/conformance/chainsaw/validate/anchors/conditional/policy.yaml
+++ b/test/conformance/chainsaw/validate/anchors/conditional/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-scale

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/apicalls-deprecated/subjectaccessreview/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/apicalls-deprecated/subjectaccessreview/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: check-subjectaccessreview

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/apicalls/subjectaccessreview/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/apicalls/subjectaccessreview/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: check-subjectaccessreview

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce-deprecated/csr/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce-deprecated/csr/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: validate-csr
@@ -25,7 +25,8 @@ spec:
               operator: NotEquals
               value: "angela"
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: mutate-csr

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce-deprecated/operator-anyin-boolean/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce-deprecated/operator-anyin-boolean/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: operator-anyin-boolean-cpol

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce/csr/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce/csr/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: validate-csr
@@ -25,7 +25,8 @@ spec:
               operator: NotEquals
               value: "angela"
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: mutate-csr

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce/operator-anyin-boolean/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce/operator-anyin-boolean/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: operator-anyin-boolean-cpol

--- a/test/conformance/chainsaw/verify-images/clusterpolicy/standard/notary-image-verification-secret-from-policy/policy.yaml
+++ b/test/conformance/chainsaw/verify-images/clusterpolicy/standard/notary-image-verification-secret-from-policy/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: secret-in-policy

--- a/test/conformance/chainsaw/verify-images/clusterpolicy/standard/notary-image-verification/policy.yaml
+++ b/test/conformance/chainsaw/verify-images/clusterpolicy/standard/notary-image-verification/policy.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: notary-verify-images
 ---
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -31,7 +32,8 @@ data:
     uOKpF5rWAruB5PCIrquamOejpXV9aQA/K2JQDuc0mcKz
     -----END CERTIFICATE-----
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: check-image-notary

--- a/test/conformance/chainsaw/verify-images/clusterpolicy/standard/skip-image-reference/policy.yaml
+++ b/test/conformance/chainsaw/verify-images/clusterpolicy/standard/skip-image-reference/policy.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: exclude-refs
 ---
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -31,7 +32,8 @@ data:
     uOKpF5rWAruB5PCIrquamOejpXV9aQA/K2JQDuc0mcKz
     -----END CERTIFICATE-----
 ---
-apiVersion: kyverno.io/v2beta1
+
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: verify-exclude-refs

--- a/test/conformance/chainsaw/webhook-configurations/match-conditions-fail/policy.yaml
+++ b/test/conformance/chainsaw/webhook-configurations/match-conditions-fail/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: refresh-env-var-in-pods


### PR DESCRIPTION

## Explanation

## Description

Phase 1 of deprecating the legacy `kyverno.io/v2beta1` (and `v2alpha1` GlobalContextEntry) API versions ahead of their removal in Kyverno 1.19. This change is **non-breaking**: v2beta1 (and v2alpha1) remain fully served and functional, but now emit loud, actionable deprecation warnings to users via admission webhooks, the CLI, and metrics, so clusters can inventory and migrate before removal.

### Changes

- **CRD deprecation markers**: Added `+kubebuilder:deprecatedversion:warning=...` to `ClusterPolicy`, `Policy`, `PolicyException`, `CleanupPolicy`, and `ClusterCleanupPolicy` in `api/kyverno/v2beta1`, so generated CRDs carry `deprecated: true` + `deprecationWarning`.
- **Admission warnings**: `pkg/webhooks/policy/handlers.go` now surfaces the version deprecation and deprecated-field warnings (`spec.validationFailureAction`, `spec.failurePolicy`, `spec.webhookTimeoutSeconds`, `generateExistingOnPolicyUpdate`, `mutateExistingOnPolicyUpdate`, and rule-level `verifyImages[].image`/`key`/`roots`, `attestations[].predicateType`, `validate.assert`) as admission `warnings`.
- **New metric**: `kyverno_deprecated_api_requests_total{group,version,kind,field}` (OpenTelemetry counter) records deprecated-API usage for observability/telemetry.
- **CLI warnings + `--warnings-as-errors`**: `kubectl-kyverno` now prints deprecation warnings when loading policies/exceptions with `--warnings-as-errors` (root persistent flag) it returns a non-zero exit via the `deprecations.ErrDeprecated` sentinel, so CI gates on deprecations.
- **Test fixtures migrated**: ~90 in-repo test fixtures using `v2beta1` were migrated to `v1`/`v2` (verified schema-identical for `CleanupPolicy` between v2beta1/v2). The few intentionally-kept `v2beta1` fixtures (`test/cli/test-exceptions/exceptions-deprecated/policy.yaml` and 5 new `test/cli/deprecated-versions/*` fixtures) serve as deprecation-warning assertions.
- **New tests**: `pkg/deprecations/deprecations_test.go` (version + field deprecation logic) and `cmd/cli/kubectl-kyverno/policy/deprecated_test.go` (`TestDeprecatedAPIVersionWarning`).

### Notes

- v2beta1 ↔ v2 schemas for the affected kinds are identical for this phase, so migration is purely an `apiVersion` swap.
- Full `make codegen-all && make verify-codegen` produces only the intended `deprecationWarning` CRD changes; no other generated code is affected.
- A follow-up PR (Phase 2) will remove the deprecated versions.

## Related issues

Fixes #17225

## Checklist

- [x] I have read the [contributor guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
- [x] I have verified that the code is correctly formatted, linted, and builds (including regeneration of any generated code) by running `make codegen-all`.
- [x] I have verified that new and existing tests pass by running `make test-unit`.
- [x] I have updated the documentation accordingly (a website PR with the deprecation timeline / migration guide will be opened separately).

## Proof / Test plan

- `make test-unit` (deprecations + metrics packages) — pass.
- `go test ./cmd/cli/kubectl-kyverno/policy/ -run TestDeprecatedAPIVersionWarning` — pass (all 5 v2beta1 warning fixtures).
- CLI manual check: loading a `v2beta1` policy prints a warning; with `--warnings-as-errors` the command exits non-zero.
- CRD check: `kubectl get crd clusterpolicies.kyverno.io -o jsonpath='{.spec.versions[?(@.name=="v2beta1")].deprecationWarning}'` returns the deprecation message.
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

https://github.com/kyverno/website/pull/2131
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->


