### PR TITLE
fix: skip get/list/watch permission check for connect-only subresources in CEL policy status controller

### DIFF
--- a/pkg/controllers/policystatus/controller.go
+++ b/pkg/controllers/policystatus/controller.go
@@ -3,8 +3,8 @@ package policystatus
 import (
 	"context"
 	baseerrors "errors"
-	"strings"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"

--- a/pkg/controllers/policystatus/controller.go
+++ b/pkg/controllers/policystatus/controller.go
@@ -3,6 +3,7 @@ package policystatus
 import (
 	"context"
 	baseerrors "errors"
+	"strings"
 	"fmt"
 	"time"
 
@@ -462,6 +463,12 @@ func (c controller) resolveGVRs(rules []admissionregistrationv1.NamedRuleWithOpe
 func (c controller) permissionsCheck(ctx context.Context, gvrs []metav1.GroupVersionResource) []error {
 	var errs []error
 	for _, gvr := range gvrs {
+		// Connect-only subresources (e.g. pods/exec, pods/attach, pods/portforward)
+		// do not support get/list/watch verbs. Skip the permission check for
+		// subresources, otherwise CEL policies matching them are stuck not-ready.
+		if strings.Contains(gvr.Resource, "/") {
+			continue
+		}
 		for _, verb := range []string{"get", "list", "watch"} {
 			result, err := c.authChecker.Check(ctx, gvr.Group, gvr.Version, gvr.Resource, "", "", "", verb)
 			if baseerrors.Is(err, auth.ErrNoServiceAccount) {

--- a/pkg/controllers/policystatus/controller_test.go
+++ b/pkg/controllers/policystatus/controller_test.go
@@ -394,3 +394,94 @@ func TestReconcileBeta1Conditions_RBACGatedOnBackground(t *testing.T) {
 		})
 	}
 }
+
+
+// TestReconcileConditions_RBACSkipsConnectOnlySubresources verifies that the
+// RBACPermissionsGranted condition is reported as satisfied when the matched
+// resource is a connect-only subresource (e.g. pods/exec, pods/attach,
+// pods/portforward). These subresources do not meaningfully support the
+// get/list/watch verbs that the condition checks, so the check must be
+// skipped — otherwise CEL policies matching them are stuck not-ready forever.
+//
+// The SubjectAccessReview reactor denies every review, so a normal resource
+// (pods) fails the condition while the connect-only subresource (pods/exec)
+// passes because the check is skipped.
+func TestReconcileConditions_RBACSkipsConnectOnlySubresources(t *testing.T) {
+	t.Parallel()
+
+	execRule := []admissionregistrationv1.NamedRuleWithOperations{
+		{
+			RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"pods/exec"},
+				},
+			},
+		},
+	}
+	podsRule := []admissionregistrationv1.NamedRuleWithOperations{
+		{
+			RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"pods"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		rules    []admissionregistrationv1.NamedRuleWithOperations
+		wantRBAC metav1.ConditionStatus
+	}{
+		{
+			name:     "connect-only subresource is skipped",
+			rules:    execRule,
+			wantRBAC: metav1.ConditionTrue,
+		},
+		{
+			name:     "regular resource still fails when SAR is denied",
+			rules:    podsRule,
+			wantRBAC: metav1.ConditionFalse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			dc := dclient.NewEmptyFakeClient()
+			kube := dc.GetKubeClient().(*kubefake.Clientset)
+			// Deny every SubjectAccessReview.
+			kube.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, &authorizationv1.SubjectAccessReview{
+					Status: authorizationv1.SubjectAccessReviewStatus{Allowed: false, Reason: "denied by test"},
+				}, nil
+			})
+
+			c := controller{
+				dclient: dc,
+				client:  versionedfake.NewSimpleClientset(),
+				authChecker: auth.NewSubjectChecker(
+					dc.GetKubeClient().AuthorizationV1().SubjectAccessReviews(),
+					"system:serviceaccount:kyverno:reports-controller",
+					nil,
+				),
+				polStateRecorder: webhook.NewStateRecorder(nil),
+			}
+
+			status := &policiesv1beta1.ConditionStatus{}
+			c.reconcileRBACPermissionsCondition(ctx, status, admissionregistrationv1.MatchResources{ResourceRules: tt.rules}, true)
+
+			cond := findCondition(status.Conditions, policiesv1beta1.PolicyConditionTypeRBACPermissionsGranted)
+			require.NotNil(t, cond, "RBACPermissionsGranted condition should always be set")
+			assert.Equal(t, tt.wantRBAC, cond.Status, "RBACPermissionsGranted status")
+		})
+	}
+}


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it

CEL `GeneratingPolicy` whose `matchConstraints` includes a connect-only subresource such as `pods/exec`, `pods/attach`, or `pods/portforward` never becomes ready. The `RBACPermissionsGranted` condition is permanently `False` because `pkg/controllers/policystatus` hardcodes checking `get`, `list`, and `watch` permissions for every matched GVR. Connect-only subresources do not meaningfully support these verbs.

This PR skips the `get`/`list`/`watch` permission check for subresources (resources containing `/` like `pods/exec`). The reports controller only needs tracking permissions on the parent resource for background scanning — subresources are not scanned as separate objects.

## Which issue(s) this PR fixes
Fixes #17227

## Special notes for your reviewer
The fix is minimal: a four-line guard inside `permissionsCheck` that skips the verb iteration when the GVR's resource field contains a `/` (indicating a subresource).

## Does this PR introduce a user-facing change?
```release-note
CEL policies matching connect-only subresources (pods/exec, pods/attach, pods/portforward) no longer get stuck in a not-ready state.
```

## Signed-off-by
waterWang <waterwang@proton.me>
