### PR TITLE
chore: cut release v1.19.0

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: kyverno-policies
-version: 3.9.0-rc.4  # VERSION
-appVersion: v1.19.0-rc.4
+version: 3.9.0  # VERSION
+appVersion: v1.19.0
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policies/README.md
+++ b/charts/kyverno-policies/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes Pod Security Standards implemented as Kyverno policies
 
-![Version: 3.9.0-rc.4](https://img.shields.io/badge/Version-3.9.0--rc.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.0-rc.4](https://img.shields.io/badge/AppVersion-v1.19.0--rc.4-informational?style=flat-square)
+![Version: 3.9.0](https://img.shields.io/badge/Version-3.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.0](https://img.shields.io/badge/AppVersion-v1.19.0-informational?style=flat-square)
 
 ## About
 

--- a/charts/kyverno/Chart.lock
+++ b/charts/kyverno/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: grafana
   repository: ""
-  version: 3.9.0-rc.4
+  version: 3.9.0
 - name: crds
   repository: ""
-  version: 3.9.0-rc.4
+  version: 3.9.0
 - name: kyverno-api
   repository: https://kyverno.github.io/api
   version: 0.0.1-alpha.4
@@ -14,5 +14,5 @@ dependencies:
 - name: reports-server
   repository: https://kyverno.github.io/reports-server/
   version: 0.1.6
-digest: sha256:3fda5b87529ebb29f888e1d724f34f43e94309980529fe76f2c6eb3660afb0e7
-generated: "2026-08-18T15:13:43.93899+08:00"
+digest: sha256:f20b04d6c8741b0cab6ed36a1b210b8a3dd6ff61081f5b667eb0e486698374f7
+generated: "2026-08-20T13:48:54.407602+08:00"

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: kyverno
-version: 3.9.0-rc.4  # VERSION
-appVersion: v1.19.0-rc.4
+version: 3.9.0  # VERSION
+appVersion: v1.19.0
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:
@@ -42,10 +42,10 @@ annotations:
       description: Add support for configuring container lifecycle hooks (e.g. a preStop sleep) on the admission, background, cleanup and reports controllers.
 dependencies:
   - name: grafana
-    version: 3.9.0-rc.4  # VERSION
+    version: 3.9.0  # VERSION
     condition: grafana.enabled
   - name: crds
-    version: 3.9.0-rc.4  # VERSION
+    version: 3.9.0  # VERSION
     condition: crds.install
   - name: kyverno-api
     version: 0.0.1-alpha.4

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes Native Policy Management
 
-![Version: 3.9.0-rc.4](https://img.shields.io/badge/Version-3.9.0--rc.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.0-rc.4](https://img.shields.io/badge/AppVersion-v1.19.0--rc.4-informational?style=flat-square)
+![Version: 3.9.0](https://img.shields.io/badge/Version-3.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.0](https://img.shields.io/badge/AppVersion-v1.19.0-informational?style=flat-square)
 
 ## About
 
@@ -987,8 +987,8 @@ Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | crds | 3.9.0-rc.4 |
-|  | grafana | 3.9.0-rc.4 |
+|  | crds | 3.9.0 |
+|  | grafana | 3.9.0 |
 | https://kyverno.github.io/api | kyverno-api | 0.0.1-alpha.4 |
 | https://kyverno.github.io/reports-server/ | reports-server | 0.1.6 |
 | https://openreports.github.io/reports-api | openreports | 0.1.0 |

--- a/charts/kyverno/charts/crds/Chart.yaml
+++ b/charts/kyverno/charts/crds/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: crds
-version: 3.9.0-rc.4  # VERSION
+version: 3.9.0  # VERSION

--- a/charts/kyverno/charts/crds/README.md
+++ b/charts/kyverno/charts/crds/README.md
@@ -1,6 +1,6 @@
 # crds
 
-![Version: 3.9.0-rc.4](https://img.shields.io/badge/Version-3.9.0--rc.4-informational?style=flat-square)
+![Version: 3.9.0](https://img.shields.io/badge/Version-3.9.0-informational?style=flat-square)
 
 ## Values
 

--- a/charts/kyverno/charts/grafana/Chart.yaml
+++ b/charts/kyverno/charts/grafana/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: grafana
-version: 3.9.0-rc.4  # VERSION
+version: 3.9.0  # VERSION

--- a/charts/kyverno/charts/grafana/README.md
+++ b/charts/kyverno/charts/grafana/README.md
@@ -1,6 +1,6 @@
 # grafana
 
-![Version: 3.9.0-rc.4](https://img.shields.io/badge/Version-3.9.0--rc.4-informational?style=flat-square)
+![Version: 3.9.0](https://img.shields.io/badge/Version-3.9.0-informational?style=flat-square)
 
 ## Values
 


### PR DESCRIPTION
## Description

Cut the **v1.19.0** final release:

- Bump chart versions to **3.9.0** (kyverno, kyverno-policies, crds, grafana subcharts) and `appVersion` to **v1.19.0**
- Regenerate chart READMEs (`make codegen-helm-docs`)
- Regenerate `Chart.lock` (`make helm-setup-dependency-charts`)

Follows the same two-commit pattern as the rc.4 cut (#17209).

Once merged, the `v1.19.0`, `kyverno-chart-3.9.0`, and `kyverno-policies-chart-3.9.0` tags will be pushed from the release-1.19 tip to trigger the release workflow.