### PR TITLE
ci: paginate milestone lookup in assign-milestone workflow

### DIFF
--- a/.github/workflows/assign-milestone.yaml
+++ b/.github/workflows/assign-milestone.yaml
@@ -91,7 +91,7 @@ jobs:
           fi
           echo "Previous release tag: $previous_tag"
 
-          milestone_number=$(gh api "repos/${GITHUB_REPOSITORY}/milestones?state=all&per_page=100" \
+          milestone_number=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/milestones?state=all&per_page=100" \
             --jq ".[] | select(.title == \"${milestone_title}\") | .number" | head -n1)
 
           if [[ -z "$milestone_number" ]]; then


### PR DESCRIPTION
## Description

The [Assign milestone run for the v1.19.0 tag](https://github.com/kyverno/kyverno/actions/runs/32351114570/job/96370266308) failed with:

```
Milestone "Kyverno Release 1.19.0" does not exist. Create it before releasing...
```

But the milestone **does exist** ([#124](https://github.com/kyverno/kyverno/milestone/124)). The repo now has **108 milestones**, and the lookup fetches only the first page (`per_page=100` without `--paginate`), so any milestone beyond the first 100 is never found.

Fix: add `--paginate` to the `gh api` milestone lookup.

## Related

Introduced in #16661. The v1.19.0 assignment will be run manually since re-running the failed job would still use the workflow file at the tag.