### PR TITLE
ci: repair dead path globs in PR auto-labelling config

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -74,9 +74,7 @@ area/image-verify:
         - any-glob-to-any-file:
             - pkg/engine/image_verify.go
             - pkg/engine/image_verify_test.go
-            - pkg/imageverification/**
-            - pkg/imageverifycache/**
-            - pkg/images/**
+            - pkg/image/**
 
 area/cosign:
   color: 3F51B5
@@ -84,7 +82,8 @@ area/cosign:
   rules:
     - changed-files:
         - any-glob-to-any-file:
-            - pkg/cosign/**
+            - pkg/image/verifiers/cpol/cosign/**
+            - pkg/image/verifiers/ivpol/cosign/**
 
 area/notary:
   color: 3F51B5
@@ -92,7 +91,8 @@ area/notary:
   rules:
     - changed-files:
         - any-glob-to-any-file:
-            - pkg/notary/**
+            - pkg/image/verifiers/cpol/notary/**
+            - pkg/image/verifiers/ivpol/notary/**
 
 # ── Area: CEL (cyan #00BCD4) ─────────────────────────────────────────────────
 # ── CEL ─────────────────────────────────────────────────────────────────────
@@ -297,7 +297,7 @@ area/registry:
   rules:
     - changed-files:
         - any-glob-to-any-file:
-            - pkg/registryclient/**
+            - pkg/engine/factories/registryclientfactory.go
             - cmd/internal/registry.go
 
 # ── Area: Infrastructure (blue-grey #607D8B) ────────────────────────────────
@@ -463,7 +463,6 @@ kind/documentation:
             - README.md
             - ROADMAP.md
             - SECURITY.md
-            - Kyverno_Architecture_Roadmap.md
 
 # ── Kind: CI & Build (dark magenta #8E24AA) ─────────────────────────────────
 kind/ci:
@@ -485,7 +484,6 @@ kind/codegen:
         - any-glob-to-any-file:
             - hack/**
             - scripts/**
-            - cmd/tools/**
 
 # ── Kind: Dependencies (brown #795548) ──────────────────────────────────────
 kind/dependencies:


### PR DESCRIPTION
## Explanation

The **PR Labelling** workflow renders `.github/labels.yml` into an `actions/labeler`
config so that every PR automatically picks up its `area/*` and `kind/*` labels.

8 of the 111 path globs in that file point at directories and files that no longer exist.
`actions/labeler` does not warn about a glob that matches nothing — it simply never applies
the label, so this has been failing silently and maintainers have been labelling those PRs
by hand.

Worst affected: **`area/cosign` and `area/notary` have exactly one glob each, and both are
dead**, so neither label could ever be applied automatically.

This is a fix to existing behaviour. It touches only CI configuration — no Kyverno runtime
code, and no user-facing behaviour.

## Related issue

Closes #17244

cc @JimBugwadia — this is repo-hygiene automation drift rather than a product bug, so
flagging it for your visibility.

## Milestone of this PR

<!-- happy to add a milestone if you'd like one on this -->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

<!-- Not applicable: CI configuration only, no user-facing behaviour change. -->

## What type of PR is this

/kind bug

## Proposed Changes

Each dead glob is repointed at where the code actually moved, or removed when the code left
the repository:

| Label | Was (dead) | Now | Why |
|---|---|---|---|
| `area/image-verify` | `pkg/imageverification/**`<br>`pkg/imageverifycache/**`<br>`pkg/images/**` | `pkg/image/**` | packages regrouped under `pkg/image/` in #15451 and #15673 |
| `area/cosign` | `pkg/cosign/**` | `pkg/image/verifiers/cpol/cosign/**`<br>`pkg/image/verifiers/ivpol/cosign/**` | verifiers centralised in #15451 |
| `area/notary` | `pkg/notary/**` | `pkg/image/verifiers/cpol/notary/**`<br>`pkg/image/verifiers/ivpol/notary/**` | verifiers centralised in #15451 |
| `area/registry` | `pkg/registryclient/**` | `pkg/engine/factories/registryclientfactory.go` | library moved out to the Kyverno SDK in #16439; the factory is what remains in tree |
| `kind/codegen` | `cmd/tools/**` | *(removed)* | directory removed in #15211 |
| `kind/documentation` | `Kyverno_Architecture_Roadmap.md` | *(removed)* | never existed in this repo — `git log --all` finds no such file |

`labels.yml` was last updated in #15654 (2026-03-19). The refactors that moved these
packages landed before it, the same day, and after it, and none of them updated the
matchers.

**Label names, colors and descriptions are unchanged**, so the `Sync Label Colors` workflow
(which reads only `color` and `description`) is unaffected, and no label is created,
renamed or deleted.

### Proof Manifests

Kubernetes/CLI manifests don't apply to a CI config change, so here is the equivalent
proof — every glob in `.github/labels.yml` resolved against `git ls-files`, before and
after this PR:

```
before:  8/111 globs match zero tracked files
after:   0/109 globs match zero tracked files
```

Labels actually produced for representative changed files, before vs. after:

```
pkg/image/verifiers/cpol/cosign/cosign.go
  before: (none)
  after : area/cosign, area/image-verify

pkg/image/verifiers/ivpol/notary/notary.go
  before: (none)
  after : area/image-verify, area/notary

pkg/image/verification/cache/cache.go
  before: (none)
  after : area/image-verify

pkg/engine/factories/registryclientfactory.go
  before: area/engine
  after : area/engine, area/registry
```

I also re-ran the exact transformation the workflow performs
(`.rules` extracted for every label that has them) against the edited file: it still yields
a well-formed labeler config for all 50 rule-bearing labels.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

Two things I deliberately left out, happy to fold either in if you'd prefer:

1. **A guard so this cannot rot again.** The check is cheap — resolve every glob in
   `labels.yml` against `git ls-files` and fail if any matches nothing. That would have
   caught all 8 of these at the PR that moved the code. I kept it out of this PR to keep
   the diff to the fix itself, but I'm glad to add it as a follow-up.
2. **`pkg/cel/libs/imageverify/**` under `area/image-verify`.** It is image-verification
   code and arguably belongs there, but it was never in the config, so adding it would be
   new coverage rather than a repair. Currently it picks up `area/cel`.

This class of problem — automation quietly drifting out of sync with a restructured repo —
is the same one described in #16665, which is what led me to audit the labeller config in
the first place.
