### PR TITLE
fix(report): prevent nil pointer panic in IsPolicyReportable for typed nil policies

### DIFF
--- a/pkg/utils/report/create_ephemeral.go
+++ b/pkg/utils/report/create_ephemeral.go
@@ -3,6 +3,7 @@ package report
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 
 	"github.com/kyverno/kyverno/api/kyverno"
@@ -13,7 +14,7 @@ import (
 )
 
 func IsPolicyReportable(pol metav1.Object) bool {
-	if pol == nil { // invalid behavior
+	if pol == nil || (reflect.ValueOf(pol).Kind() == reflect.Ptr && reflect.ValueOf(pol).IsNil()) {
 		return false
 	}
 	labels := pol.GetLabels()

--- a/pkg/utils/report/create_ephemeral_test.go
+++ b/pkg/utils/report/create_ephemeral_test.go
@@ -1,0 +1,62 @@
+package report
+
+import (
+	"testing"
+
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsPolicyReportable_NilInterface(t *testing.T) {
+	// A bare nil interface must return false.
+	assert.False(t, IsPolicyReportable(nil))
+}
+
+func TestIsPolicyReportable_TypedNilPointer(t *testing.T) {
+	// A typed nil (*kyvernov1.ClusterPolicy)(nil) stored in a metav1.Object
+	// interface is NOT equal to nil — the old guard missed this case and
+	// would panic on pol.GetLabels(). The fix must return false instead.
+	var cp *kyvernov1.ClusterPolicy
+	assert.False(t, IsPolicyReportable(cp), "typed nil pointer must return false without panicking")
+}
+
+func TestIsPolicyReportable_TypedNilPolicy(t *testing.T) {
+	// Same scenario via the namespaced Policy type.
+	var p *kyvernov1.Policy
+	assert.False(t, IsPolicyReportable(p), "typed nil *Policy must return false without panicking")
+}
+
+func TestIsPolicyReportable_ValidPolicyNoLabel(t *testing.T) {
+	// A fully initialised policy with no exclude-reporting label must return true.
+	cp := &kyvernov1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-policy",
+		},
+	}
+	assert.True(t, IsPolicyReportable(cp))
+}
+
+func TestIsPolicyReportable_ValidPolicyWithExcludeLabel(t *testing.T) {
+	// A policy carrying the LabelExcludeReporting label must return false.
+	cp := &kyvernov1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-policy",
+			Labels: map[string]string{
+				"reports.kyverno.io/disabled": "true",
+			},
+		},
+	}
+	assert.False(t, IsPolicyReportable(cp))
+}
+
+func TestIsPolicyReportable_ValidPolicyEmptyLabels(t *testing.T) {
+	// Initialised policy with an explicit but empty label map must return true.
+	cp := &kyvernov1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-policy",
+			Labels: map[string]string{},
+		},
+	}
+	assert.True(t, IsPolicyReportable(cp))
+}


### PR DESCRIPTION
## What this PR does / why we need it

`IsPolicyReportable` in `pkg/utils/report/create_ephemeral.go` guards
against nil inputs with `pol == nil`. In Go, this check only catches a
**bare nil interface**. When a concrete typed nil (e.g.
`(*kyvernov1.ClusterPolicy)(nil)`) is assigned to a `metav1.Object`
interface, the interface value is **not nil** - it carries type metadata
but a nil data pointer. The existing guard passes through silently, and
the immediately following `pol.GetLabels()` call panics with a nil
pointer dereference at runtime.

This function is called from 10 production sites across webhook
handlers, background controllers, and the mutation pipeline - all of
which pass policy interfaces that could be typed nils.

**Fix:** use `reflect.ValueOf(pol).IsNil()` guarded by a
`Kind() == reflect.Ptr` check. This is the canonical Go pattern for
catching typed nils and is already established in this codebase at
`pkg/background/common/labels.go:42` (`MutateLabelsSet`).

Fixes #17256

## Which issue(s) this PR fixes

Fixes #17256

## Changes

### pkg/utils/report/create_ephemeral.go

Added `"reflect"` import and updated the nil guard:

    -    if pol == nil { // invalid behavior
    +    if pol == nil || (reflect.ValueOf(pol).Kind() == reflect.Ptr && reflect.ValueOf(pol).IsNil()) {

### pkg/utils/report/create_ephemeral_test.go (new file)

Six unit tests covering:
- bare nil interface -> false
- typed nil *ClusterPolicy -> false  (the panic case)
- typed nil *Policy -> false
- valid policy, no exclude label -> true
- valid policy with reports.kyverno.io/disabled label -> false
- valid policy with empty labels map -> true

## PR Checklist

- [x] Commits are signed with Signed-off-by (DCO compliant)
- [x] The change is minimal and scoped to a single function (+3/-1 production lines)
- [x] No API types, CRDs, or generated code were modified
- [x] All existing tests continue to pass
- [x] New unit tests directly reproduce and verify the fix
- [x] Code style matches the surrounding codebase (same reflect pattern as labels.go)
- [x] No backward-incompatible changes
