### PR TITLE
fix(cli): aggregate test errors using multierr

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -18,6 +18,7 @@ import (
 	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/spf13/cobra"
+	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -127,10 +128,8 @@ func testCommandExecute(
 
 		if len(errors) == 0 {
 			return nil
-		} else {
-			// TODO aggregate errors
-			return errors[0]
 		}
+		return multierr.Combine(errors...)
 	}
 	rc := &resultCounts{}
 	var fullTable table.Table


### PR DESCRIPTION
## Explanation

This PR aggregates multiple errors encountered when no tests are found in the `kyverno test` CLI, using `go.uber.org/multierr`. Previously, the code only returned the first error and ignored the rest, leaving a `TODO` comment. This change implements the `TODO` and properly combines the errors for better CLI reporting.

## Related issue

None.

## Milestone of this PR

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind cleanup
/kind bug

## Proposed Changes

- Uses `multierr.Combine(errors...)` in `cmd/cli/kubectl-kyverno/commands/test/command.go` instead of returning `errors[0]`.

### Proof Manifests

N/A - this is a CLI cleanup that improves error reporting.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments
