### PR TITLE
fix(gpol): re-register downstream UID in metadataCache after recreation

### DIFF
--- a/pkg/background/gpol/dynamic_watcher.go
+++ b/pkg/background/gpol/dynamic_watcher.go
@@ -505,12 +505,15 @@ func (wm *WatchManager) handleAdd(obj *unstructured.Unstructured, gvr schema.Gro
     wm.lock.Lock()
     defer wm.lock.Unlock()
 
-    wm.log.Info("Resource added", "name", obj.GetName())
-
     labels := obj.GetLabels()
-    if labels[kyverno.LabelAppManagedBy] != kyverno.ValueKyvernoApp {
+    // Filter early — only process sync-enabled gpol downstreams.
+    // Log after the filter so unrelated events don't produce noise.
+    if labels[kyverno.LabelAppManagedBy] != kyverno.ValueKyvernoApp ||
+        labels[common.GeneratePolicyLabel] == "" {
         return
     }
+
+    wm.log.Info("Resource added", "name", obj.GetName())
 
     watcher, exists := wm.dynamicWatchers[gvr]
     if !exists {
@@ -519,19 +522,32 @@ func (wm *WatchManager) handleAdd(obj *unstructured.Unstructured, gvr schema.Gro
 
     uid := obj.GetUID()
     if _, ok := watcher.metadataCache[uid]; ok {
+        // Already registered (first-time creation path via SyncWatchers). No-op.
         return
     }
 
+    // Look for a stale entry from before this resource was deleted and recreated.
+    // Only register the new UID if we actually evict an old one — this preserves
+    // the invariant: in cache ⟺ sync-enabled downstream tracked by SyncWatchers.
+    matched := false
     for oldUID, cached := range watcher.metadataCache {
         if cached.Name == obj.GetName() &&
             cached.Namespace == obj.GetNamespace() &&
-            cached.Labels[common.GeneratePolicyLabel] == labels[common.GeneratePolicyLabel] {
+            cached.Labels[common.GeneratePolicyLabel] != "" &&
+            cached.Labels[common.GeneratePolicyLabel] == labels[common.GeneratePolicyLabel] &&
+            cached.Labels[common.GeneratePolicyNamespaceLabel] == labels[common.GeneratePolicyNamespaceLabel] {
             delete(watcher.metadataCache, oldUID)
+            matched = true
             break
         }
     }
+    if !matched {
+        // Not a recreation of a tracked resource; first-time registration
+        // is owned by SyncWatchers. Leave the cache untouched.
+        return
+    }
 
-	watcher.metadataCache[uid] = Resource{
+    watcher.metadataCache[uid] = Resource{
         Name:      obj.GetName(),
         Namespace: obj.GetNamespace(),
         Labels:    labels,
@@ -690,5 +706,5 @@ func (wm *WatchManager) handleDelete(obj *unstructured.Unstructured, gvr schema.
 				}
 			}
 		}
-	}	
+	}
 }

--- a/pkg/background/gpol/dynamic_watcher.go
+++ b/pkg/background/gpol/dynamic_watcher.go
@@ -502,7 +502,44 @@ func (wm *WatchManager) startWatcherWithCache(resource *unstructured.Unstructure
 }
 
 func (wm *WatchManager) handleAdd(obj *unstructured.Unstructured, gvr schema.GroupVersionResource) {
-	wm.log.Info("Resource added", "name", obj.GetName())
+    wm.lock.Lock()
+    defer wm.lock.Unlock()
+
+    wm.log.Info("Resource added", "name", obj.GetName())
+
+    labels := obj.GetLabels()
+    if labels[kyverno.LabelAppManagedBy] != kyverno.ValueKyvernoApp {
+        return
+    }
+
+    watcher, exists := wm.dynamicWatchers[gvr]
+    if !exists {
+        return
+    }
+
+    uid := obj.GetUID()
+    if _, ok := watcher.metadataCache[uid]; ok {
+        return
+    }
+
+    for oldUID, cached := range watcher.metadataCache {
+        if cached.Name == obj.GetName() &&
+            cached.Namespace == obj.GetNamespace() &&
+            cached.Labels[common.GeneratePolicyLabel] == labels[common.GeneratePolicyLabel] {
+            delete(watcher.metadataCache, oldUID)
+            break
+        }
+    }
+
+	watcher.metadataCache[uid] = Resource{
+        Name:      obj.GetName(),
+        Namespace: obj.GetNamespace(),
+        Labels:    labels,
+        Hash:      reportutils.CalculateResourceHash(*obj),
+        Data:      obj.DeepCopy(),
+    }
+    wm.log.V(4).Info("downstream resource re-registered after recreation",
+        "name", obj.GetName(), "namespace", obj.GetNamespace(), "uid", uid)
 }
 
 func (wm *WatchManager) handleUpdate(obj *unstructured.Unstructured, gvr schema.GroupVersionResource) {
@@ -653,5 +690,5 @@ func (wm *WatchManager) handleDelete(obj *unstructured.Unstructured, gvr schema.
 				}
 			}
 		}
-	}
+	}	
 }

--- a/pkg/background/gpol/dynamic_watcher_test.go
+++ b/pkg/background/gpol/dynamic_watcher_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	eventsv1 "k8s.io/client-go/kubernetes/typed/events/v1"
 	"k8s.io/client-go/rest"
+	kyverno "github.com/kyverno/kyverno/api/kyverno"
 )
 
 type mockRESTMapper struct {
@@ -1223,30 +1224,85 @@ func (f *fullMockClient) DeleteResource(_ context.Context, _, _, _, _ string, _ 
 }
 
 func TestHandleAdd(t *testing.T) {
+	cmGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+	kyvernoLabels := func(policy string) map[string]string {
+		return map[string]string{
+			kyverno.LabelAppManagedBy:  kyverno.ValueKyvernoApp,
+			common.GeneratePolicyLabel: policy,
+		}
+	}
+
 	tests := []struct {
-		name    string
-		objName string
-		gvr     schema.GroupVersionResource
-		wantMsg string
+		name           string
+		cacheUIDs      map[types.UID]string // uid → resource name in cache before call
+		obj            *unstructured.Unstructured
+		wantCacheUIDs  []types.UID // UIDs that must be present after call
+		wantAbsentUIDs []types.UID // UIDs that must be gone after call
+		wantCacheSize  int
 	}{
 		{
-			name:    "simple add",
-			objName: "test-object",
-			gvr:     schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
-			wantMsg: "Resource added name=test-object",
+			name: "non-kyverno resource is ignored",
+			cacheUIDs: map[types.UID]string{},
+			obj:  makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "new-uid", map[string]string{"unrelated": "label"}),
+			wantCacheSize: 0,
+		},
+		{
+			name: "already registered UID is not double-inserted",
+			cacheUIDs: map[types.UID]string{"existing-uid": "cm"},
+			obj:  makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "existing-uid", kyvernoLabels("p1")),
+			wantCacheUIDs: []types.UID{"existing-uid"},
+			wantCacheSize: 1,
+		},
+		{
+			name: "recreated resource: new UID registered, old dead UID removed",
+			cacheUIDs: map[types.UID]string{"old-uid": "cm"},
+			obj:  makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "new-uid", kyvernoLabels("p1")),
+			wantCacheUIDs:  []types.UID{"new-uid"},
+			wantAbsentUIDs: []types.UID{"old-uid"},
+			wantCacheSize:  1,
+		},
+		{
+			name: "different policy's resource with same name is not evicted",
+			cacheUIDs: map[types.UID]string{"other-policy-uid": "cm"},
+			obj:  makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "new-uid", kyvernoLabels("p2")),
+			wantCacheUIDs: []types.UID{"other-policy-uid", "new-uid"},
+			wantCacheSize: 2,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			wm := &WatchManager{
-				log: logging.GlobalLogger(),
+			// build metadataCache from the name map
+			cache := map[types.UID]Resource{}
+			for uid, name := range tt.cacheUIDs {
+				obj := makeUnstructured("", "", "v1", "ConfigMap", name, "default", uid, kyvernoLabels("p1"))
+				cache[uid] = Resource{
+					Name:      name,
+					Namespace: "default",
+					Labels:    obj.GetLabels(),
+					Data:      obj,
+				}
 			}
 
-			obj := &unstructured.Unstructured{}
-			obj.SetName(tt.objName)
+			wm := &WatchManager{
+				log: logging.WithName("test"),
+				dynamicWatchers: map[schema.GroupVersionResource]*watcher{
+					cmGVR: {metadataCache: cache},
+				},
+			}
 
-			wm.handleAdd(obj, tt.gvr)
+			wm.handleAdd(tt.obj, cmGVR)
+
+			assert.Equal(t, tt.wantCacheSize, len(cache))
+			for _, uid := range tt.wantCacheUIDs {
+				_, ok := cache[uid]
+				assert.True(t, ok, "expected UID %s to be in cache", uid)
+			}
+			for _, uid := range tt.wantAbsentUIDs {
+				_, ok := cache[uid]
+				assert.False(t, ok, "expected UID %s to be absent from cache", uid)
+			}
 		})
 	}
 }

--- a/pkg/background/gpol/dynamic_watcher_test.go
+++ b/pkg/background/gpol/dynamic_watcher_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyverno/kyverno/api/kyverno"
+	kyverno "github.com/kyverno/kyverno/api/kyverno"
 	v1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/background/common"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
@@ -27,7 +27,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	eventsv1 "k8s.io/client-go/kubernetes/typed/events/v1"
 	"k8s.io/client-go/rest"
-	kyverno "github.com/kyverno/kyverno/api/kyverno"
 )
 
 type mockRESTMapper struct {
@@ -1242,32 +1241,38 @@ func TestHandleAdd(t *testing.T) {
 		wantCacheSize  int
 	}{
 		{
-			name: "non-kyverno resource is ignored",
-			cacheUIDs: map[types.UID]string{},
-			obj:  makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "new-uid", map[string]string{"unrelated": "label"}),
+			name:          "non-kyverno resource is ignored",
+			cacheUIDs:     map[types.UID]string{},
+			obj:           makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "new-uid", map[string]string{"unrelated": "label"}),
 			wantCacheSize: 0,
 		},
 		{
-			name: "already registered UID is not double-inserted",
-			cacheUIDs: map[types.UID]string{"existing-uid": "cm"},
-			obj:  makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "existing-uid", kyvernoLabels("p1")),
+			name:          "already registered UID is not double-inserted",
+			cacheUIDs:     map[types.UID]string{"existing-uid": "cm"},
+			obj:           makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "existing-uid", kyvernoLabels("p1")),
 			wantCacheUIDs: []types.UID{"existing-uid"},
 			wantCacheSize: 1,
 		},
 		{
-			name: "recreated resource: new UID registered, old dead UID removed",
-			cacheUIDs: map[types.UID]string{"old-uid": "cm"},
-			obj:  makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "new-uid", kyvernoLabels("p1")),
+			name:           "recreated resource: new UID registered, old dead UID removed",
+			cacheUIDs:      map[types.UID]string{"old-uid": "cm"},
+			obj:            makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "new-uid", kyvernoLabels("p1")),
 			wantCacheUIDs:  []types.UID{"new-uid"},
 			wantAbsentUIDs: []types.UID{"old-uid"},
 			wantCacheSize:  1,
 		},
 		{
-			name: "different policy's resource with same name is not evicted",
-			cacheUIDs: map[types.UID]string{"other-policy-uid": "cm"},
-			obj:  makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "new-uid", kyvernoLabels("p2")),
-			wantCacheUIDs: []types.UID{"other-policy-uid", "new-uid"},
-			wantCacheSize: 2,
+			name:          "different policy's resource with same name is not evicted",
+			cacheUIDs:     map[types.UID]string{"other-policy-uid": "cm"},
+			obj:           makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "new-uid", kyvernoLabels("p2")),
+			wantCacheUIDs: []types.UID{"other-policy-uid"},
+			wantCacheSize: 1,
+		},
+		{	
+			name:          "sync-disabled downstream with empty cache is not registered",
+			cacheUIDs:     map[types.UID]string{},
+			obj:           makeUnstructured("", "", "v1", "ConfigMap", "cm", "default", "some-uid", kyvernoLabels("p1")),
+			wantCacheSize: 0,
 		},
 	}
 


### PR DESCRIPTION
## Explanation

When a GeneratingPolicy with synchronize: enabled: true generates a downstream resource, Kyverno watches that resource and recreates it if a user deletes it. However, this only worked for the first deletion. Any subsequent deletion left the resource permanently absent until the next background scan.

The root cause: when Kyverno recreates a deleted resource, Kubernetes assigns it a new UID. The handleAdd event handler — which receives the watch.Added event for the recreated resource — was a no-op. It never registered the new UID in metadataCache. On the next deletion, handleDelete looked up the new UID, found nothing in the cache, and silently skipped recreation.

This PR fixes handleAdd to detect recreated Kyverno-managed resources by their labels, remove the stale dead-UID entry, and register the new UID so subsequent deletions are handled correctly.

## Related issue

Closes #17265

## Milestone of this PR

## What type of PR is this

/kind bug

## Proposed Changes

handleAdd in pkg/background/gpol/dynamic_watcher.go previously contained only a log statement. It now:

Returns early for resources not managed by Kyverno (no-op for unrelated events)
Returns early if the UID is already in the cache (first-time creation already registered by SyncWatchers)
For a recreated resource — same name, namespace, and policy label but new UID — removes the stale cache entry keyed by the old dead UID and inserts a fresh entry keyed by the new UID

### Proof Manifests

# Kubernetes resource

```yaml
apiVersion: policies.kyverno.io/v1
kind: GeneratingPolicy
metadata:
  name: sync-test
spec:
  evaluation:
    synchronize:
      enabled: true
  matchConstraints:
    resourceRules:
      - apiGroups: ['']
        apiVersions: ['v1']
        operations: ['CREATE', 'UPDATE']
        resources: ['namespaces']
  variables:
    - name: nsName
      expression: 'object.metadata.name'
  generate:
    - template:
        interpolate: cel
        value: |
          apiVersion: v1
          kind: ConfigMap
          metadata:
            name: sync-test-cm
            namespace: (( variables.nsName ))
          data:
            key: value
```

# Trigger namespace:
```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: sync-test-ns
```

# Verification steps:
# Apply policy and trigger
kubectl apply -f policy.yaml
kubectl apply -f namespace.yaml

# Wait for ConfigMap to be generated
kubectl get cm sync-test-cm -n sync-test-ns

# First deletion — should be recreated
kubectl delete cm sync-test-cm -n sync-test-ns
kubectl get cm sync-test-cm -n sync-test-ns   # must exist

# Second deletion — failed before this fix, succeeds after
kubectl delete cm sync-test-cm -n sync-test-ns
kubectl get cm sync-test-cm -n sync-test-ns   # must exist

Before fix: the second kubectl get returns NotFound.
After fix: the ConfigMap is present after both deletions.

## Checklist

- [ x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments
