### PR TITLE
fix(cli) :- report failure when test expects fail but resource excluded

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/output.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/output.go
@@ -157,7 +157,14 @@ func printTestResult(
 							},
 							Message: color.Excluded(),
 						}
-						rc.Skip++
+
+						if test.Result == openreports.StatusFail {
+							row.Result = color.ResultFail()
+							row.IsFailure = true
+							rc.Fail++
+						} else {
+							rc.Skip++
+						}
 						testCount++
 						rows = append(rows, row)
 					}

--- a/cmd/cli/kubectl-kyverno/commands/test/output_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/output_test.go
@@ -1,0 +1,57 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/apis/v1alpha1"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/output/color"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/output/table"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/kyverno/kyverno/pkg/openreports"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintTestResult_WantFailGotExcluded(t *testing.T) {
+	color.Init(true)
+	test := v1alpha1.TestResult{
+		TestResultBase: v1alpha1.TestResultBase{
+			Policy: "test-policy",
+			Rule:   "test-rule",
+			Result: openreports.StatusFail,
+		},
+		TestResultData: v1alpha1.TestResultData{
+			Resources: []string{"test-resource"},
+		},
+	}
+	
+	mockPolicy := &kyvernov1.ClusterPolicy{}
+	mockPolicy.SetName("test-policy")
+	
+	// Create a response with empty rules, simulating an excluded resource
+	response := engineapi.EngineResponse{
+		PolicyResponse: engineapi.PolicyResponse{
+			Rules: []engineapi.RuleResponse{},
+		},
+	}
+	response = response.WithPolicy(engineapi.NewKyvernoPolicy(mockPolicy))
+	
+	responses := &TestResponse{
+		Target: map[string][]engineapi.EngineResponse{},
+		Trigger: map[string][]engineapi.EngineResponse{
+			"v1,Pod,default,test-resource": {response}, 
+		},
+	}
+	
+	var rc resultCounts
+	resultsTable := &table.Table{}
+	fs := memfs.New()
+	
+	err := printTestResult([]v1alpha1.TestResult{test}, responses, &rc, resultsTable, fs, "", true)
+	assert.NoError(t, err)
+	
+	assert.Equal(t, 1, len(resultsTable.RawRows))
+	assert.True(t, resultsTable.RawRows[0].IsFailure, "expected test to report failure when want=fail got=excluded")
+	assert.Equal(t, "Excluded", resultsTable.RawRows[0].Message)
+}


### PR DESCRIPTION
## Explanation

The `kyverno test` command incorrectly reported a test as passing when the test expected `result: fail` but the policy engine did not process the resource (because the resource was excluded from the policy match or filtered out). This fix ensures that if a resource is excluded and the test expects a failure, it will correctly report a test failure rather than marking it as a pass with the reason "Excluded".

## Related issue

Closes #11519

## Milestone of this PR

/milestone 1.13

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update the documentation and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

When a resource gets excluded in the `kyverno test` command execution, the CLI automatically generates an empty row and defaults it to a `Pass` result with the reason "Excluded". However, if the `test.Result` declared by the user was `fail`, then getting excluded means the test did not fail as expected, which should result in a test failure.

This PR adds logic inside `cmd/cli/kubectl-kyverno/commands/test/output.go` to evaluate if `test.Result == openreports.StatusFail` for excluded resources, and if so, changes `row.Result` to `Fail` and properly bumps the `rc.Fail` count.

### Proof Manifests

# Kyverno CLI test manifest showing the fix:

When a Deployment is evaluated against a Pod-only policy (so the original rule does not run on the Deployment and is excluded), the expected fail will now properly fail instead of pass.

```yaml
apiVersion: cli.kyverno.io/v1alpha1
kind: Test
metadata:
  name: priv_esc_test
policies:
  - priv-esc.yaml
resources:
  - test-deployment.yaml
results:
  - policy: disallow-privilege-escalation
    rule: privilege-escalation
    resources: 
    - test-deploy-pass
    kind: Deployment
    result: fail
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This addresses the edge case left over from #15130.