### PR TITLE
fix(pkg/policy): use RetryOnConflict for unlabelDownstream

### DIFF
--- a/pkg/policy/generate.go
+++ b/pkg/policy/generate.go
@@ -17,9 +17,11 @@ import (
 	engineutils "github.com/kyverno/kyverno/pkg/utils/engine"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	"go.uber.org/multierr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/util/retry"
 )
 
 // generateBatchSize is the maximum number of RuleContext entries per UpdateRequest.
@@ -278,12 +280,25 @@ func (pc *policyController) unlabelDownstream(selector updatedResource) {
 			}
 
 			for _, obj := range updated.Items {
-				labels := obj.GetLabels()
-				delete(labels, common.GeneratePolicyLabel)
-				delete(labels, common.GeneratePolicyNamespaceLabel)
-				delete(labels, common.GenerateRuleLabel)
-				obj.SetLabels(labels)
-				_, err = pc.client.UpdateResource(context.TODO(), obj.GetAPIVersion(), obj.GetKind(), obj.GetNamespace(), &obj, false)
+				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					target, err := pc.client.GetResource(context.TODO(), obj.GetAPIVersion(), obj.GetKind(), obj.GetNamespace(), obj.GetName())
+					if err != nil {
+						if apierrors.IsNotFound(err) {
+							return nil
+						}
+						return err
+					}
+					labels := target.GetLabels()
+					if labels == nil {
+						return nil
+					}
+					delete(labels, common.GeneratePolicyLabel)
+					delete(labels, common.GeneratePolicyNamespaceLabel)
+					delete(labels, common.GenerateRuleLabel)
+					target.SetLabels(labels)
+					_, err = pc.client.UpdateResource(context.TODO(), target.GetAPIVersion(), target.GetKind(), target.GetNamespace(), target, false)
+					return err
+				})
 				if err != nil {
 					utilruntime.HandleError(fmt.Errorf("failed to un-label old targets %s/%s/%s/%s: %v", obj.GetAPIVersion(), obj.GetKind(), obj.GetNamespace(), obj.GetName(), err))
 					continue

--- a/pkg/policy/generate_test.go
+++ b/pkg/policy/generate_test.go
@@ -1,0 +1,68 @@
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kyverno/kyverno/pkg/background/common"
+	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	"github.com/kyverno/kyverno/pkg/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestUnlabelDownstream(t *testing.T) {
+	// Create a mock unstructured object with Kyverno tracking labels
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("v1")
+	u.SetKind("ConfigMap")
+	u.SetNamespace("default")
+	u.SetName("target-cm")
+	u.SetUID(types.UID("downstream-uid"))
+	u.SetLabels(map[string]string{
+		common.GeneratePolicyLabel:          "test-policy",
+		common.GeneratePolicyNamespaceLabel: "default",
+		common.GenerateRuleLabel:            "test-rule",
+		"other-label":                       "keep-me",
+	})
+
+	// Setup fake client with the mock object
+	client, err := dclient.NewFakeClient(runtime.NewScheme(), nil, u)
+	require.NoError(t, err)
+	client.SetDiscovery(dclient.NewFakeDiscoveryClient(nil))
+
+	// Initialize the policy controller
+	controller := &policyController{
+		client: client,
+		log:    logging.WithName("policy-test"),
+	}
+
+	// Create the selector to trigger unlabelDownstream
+	selector := updatedResource{
+		policy:          "test-policy",
+		policyNamespace: "default",
+		ruleResources: []ruleResource{
+			{
+				rule:  "test-rule",
+				kinds: []string{"ConfigMap"},
+			},
+		},
+	}
+
+	// Call the function
+	controller.unlabelDownstream(selector)
+
+	// Fetch the updated resource and verify labels
+	target, err := client.GetResource(context.TODO(), "v1", "ConfigMap", "default", "target-cm")
+	require.NoError(t, err)
+
+	labels := target.GetLabels()
+	assert.NotNil(t, labels)
+	assert.Equal(t, "keep-me", labels["other-label"], "Other labels should not be removed")
+	assert.NotContains(t, labels, common.GeneratePolicyLabel, "GeneratePolicyLabel should be removed")
+	assert.NotContains(t, labels, common.GeneratePolicyNamespaceLabel, "GeneratePolicyNamespaceLabel should be removed")
+	assert.NotContains(t, labels, common.GenerateRuleLabel, "GenerateRuleLabel should be removed")
+}


### PR DESCRIPTION
### Context
Fixes #17278

During policy evaluation, `unlabelDownstream` removes tracking labels from generated resources when the parent policy/rule is updated or deleted. Previously, this used a direct `UpdateResource` on the object originally fetched by `ListResource`. If the generated resource was modified concurrently (e.g., by another controller updating its status), the Kubernetes API Server would reject the label update with a `409 Conflict`. Because this error was not retried, the generated resource was permanently orphaned and retained its Kyverno tracking labels.

### Changes Made
*   Wrapped the read-modify-write operation inside `unlabelDownstream` in `pkg/policy/generate.go` with `retry.RetryOnConflict`.
*   Added an explicit `GetResource` step inside the retry loop to always fetch the latest `ResourceVersion`.
*   Added nil-safety guards for `GetLabels()` and `apierrors.IsNotFound` to cleanly exit if the resource was deleted concurrently.

### Verification Steps
* Ran `go fmt ./pkg/policy/...`
* Ran `go vet ./pkg/policy/...` 
* Ran `go test ./pkg/policy/...` — all existing unit tests pass without regression.

### PR Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md) guide
- [x] I have run `make imports fmt` and verified formatting
- [x] I have run `go test` and all checks pass locally
- [x] I have provided a clean, minimal, and backwards-compatible patch
