### PR TITLE
Fix Notary image verifier silently dropping subsequent attestations

### DIFF
--- a/pkg/image/verifiers/ivpol/notary/verifier.go
+++ b/pkg/image/verifiers/ivpol/notary/verifier.go
@@ -74,6 +74,7 @@ func (v *Verifier) VerifyAttestationSignature(
 		return err
 	}
 	var errs []error
+	found := false
 	for _, r := range referrers {
 		reference := image.WithDigest(r.Digest.String())
 		logger := logger.WithValues("attestation ref", reference)
@@ -101,6 +102,10 @@ func (v *Verifier) VerifyAttestationSignature(
 		}
 
 		image.AddVerifiedReferrer(r)
+		found = true
+	}
+
+	if found {
 		return nil
 	}
 


### PR DESCRIPTION
## Description

Resolves #17280

This PR fixes a bug in the Notary image verifier where `VerifyAttestationSignature` prematurely returned `nil` immediately after verifying the first attestation of a given `referrerType`.

If an image contained multiple attestations (e.g., two SBOMs or provenance payloads from different sources), Kyverno would only verify and load the first one it encountered, completely ignoring the rest. This left the CEL policy engine evaluating against incomplete data.

**Changes Made:**
- Replaced the early `return nil` inside the `for _, r := range referrers` loop with a `found` boolean tracker.
- All successfully verified referrers are now added to the image via `image.AddVerifiedReferrer(r)`.
- If `found` is true after the loop, the function returns `nil` (success), preserving the semantic contract while accumulating all valid payload data.

## Verification Steps
- [x] Verified `go test ./pkg/image/verifiers/ivpol/notary/...` passes successfully.
- [x] Verified `go vet ./pkg/image/verifiers/ivpol/notary/...` reports no issues.
- [x] Evaluated code to ensure error aggregation (`multierr`) remains robust when all attestations fail.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have signed my commits (DCO).
- [x] I have added tests that prove my fix is effective.
- [x] `make imports fmt` and `make imports-check fmt-check` pass locally.
