### PR TITLE
fix: return after writing 500 in Probe health check handler

### DIFF
--- a/pkg/webhooks/handlers/probe.go
+++ b/pkg/webhooks/handlers/probe.go
@@ -10,6 +10,7 @@ func Probe(check func(context.Context) bool) http.HandlerFunc {
 		if check != nil {
 			if !check(r.Context()) {
 				w.WriteHeader(http.StatusInternalServerError)
+				return
 			}
 		}
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

When the `Probe` health check handler evaluates to `false`, it writes `http.StatusInternalServerError (500)` but then falls through to `w.WriteHeader(http.StatusOK)`, causing a superfluous `http: superfluous response.WriteHeader call` warning.

This fix adds a `return` statement after the 500 status write, so the handler exits immediately on a failed health check.

## Which issue(s) this PR fixes:

Fixes #17287

## Special notes for your reviewer:

The `Probe` handler is used by health endpoints including:
- Admission Controller `/healthz` and `/readyz`
- Cleanup Controller `/healthz` and `/readyz`

## Does this PR introduce a user-facing change?

```release-note
fix: return after writing 500 in Probe health check handler to prevent superfluous WriteHeader call
```
