### PR TITLE
fix: apply HTTP blocklist to apiCall.service executor (cherry-pick #17234)

### DIFF
--- a/pkg/engine/apicall/apiCall_test.go
+++ b/pkg/engine/apicall/apiCall_test.go
@@ -79,6 +79,7 @@ func buildTestServer(responseData []byte, useChunked bool) *httptest.Server {
 }
 
 func Test_serviceGetRequest(t *testing.T) {
+	withEmptyEgressBlocklist(t)
 	testfn := func(t *testing.T, useChunked bool) {
 		serverResponse := []byte(`{ "day": "Sunday" }`)
 		s := buildTestServer(serverResponse, useChunked)
@@ -141,6 +142,7 @@ func Test_serviceGetRequest(t *testing.T) {
 }
 
 func Test_servicePostRequest(t *testing.T) {
+	withEmptyEgressBlocklist(t)
 	serverResponse := []byte(`{ "day": "Monday" }`)
 	s := buildTestServer(serverResponse, false)
 	defer s.Close()
@@ -219,6 +221,7 @@ func Test_servicePostRequest(t *testing.T) {
 }
 
 func Test_fallbackToDefault(t *testing.T) {
+	withEmptyEgressBlocklist(t)
 	serverResponse := []byte(`Error from server (NotFound): the server could not find the requested resource`)
 	defaultResponse := []byte(`{ "day": "Monday" }`)
 	s := buildTestServer(serverResponse, false)
@@ -275,6 +278,7 @@ func buildEchoHeaderTestServer() *httptest.Server {
 }
 
 func Test_serviceHeaders(t *testing.T) {
+	withEmptyEgressBlocklist(t)
 	s := buildEchoHeaderTestServer()
 	defer s.Close()
 
@@ -396,6 +400,7 @@ func Test_CrossNamespaceAccess_WithVariableSubstitution(t *testing.T) {
 }
 
 func Test_contextCancellation(t *testing.T) {
+	withEmptyEgressBlocklist(t)
 	// Server that delays response longer than our context timeout
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(5 * time.Second)

--- a/pkg/engine/apicall/executor.go
+++ b/pkg/engine/apicall/executor.go
@@ -6,12 +6,20 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/toggle"
 	"github.com/kyverno/kyverno/pkg/tracing"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -73,7 +81,15 @@ func (a *executor) executeServiceCall(ctx context.Context, apiCall *kyvernov1.AP
 		return nil, fmt.Errorf("missing service for APICall %s", a.name)
 	}
 
-	client, err := a.buildHTTPClient(apiCall.Service)
+	policy, transport, err := getServiceHTTP()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load HTTP blocklist/allowlist for APICall %s: %w", a.name, err)
+	}
+	if err := policy.validateURL(apiCall.Service.URL); err != nil {
+		return nil, fmt.Errorf("failed to validate URL for APICall %s: %w", a.name, err)
+	}
+
+	client, err := a.buildHTTPClient(policy, transport, apiCall.Service)
 	if err != nil {
 		return nil, err
 	}
@@ -160,27 +176,88 @@ func (a *executor) addHTTPHeaders(req *http.Request, headers []kyvernov1.HTTPHea
 	return nil
 }
 
-func (a *executor) buildHTTPClient(service *kyvernov1.ServiceCall) (*http.Client, error) {
+func (a *executor) buildHTTPClient(policy *egressPolicy, base http.RoundTripper, service *kyvernov1.ServiceCall) (*http.Client, error) {
 	timeout := a.config.GetTimeout()
 	if service == nil || service.CABundle == "" {
-		return &http.Client{
-			Timeout: timeout,
-		}, nil
+		return &http.Client{Transport: base, Timeout: timeout, CheckRedirect: checkServiceRedirect(policy)}, nil
 	}
 	caCertPool := x509.NewCertPool()
 	if ok := caCertPool.AppendCertsFromPEM([]byte(service.CABundle)); !ok {
 		return nil, fmt.Errorf("failed to parse PEM CA bundle for APICall %s", a.name)
 	}
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			RootCAs:    caCertPool,
-			MinVersion: tls.VersionTLS12,
-		},
-	}
+	transport := newServiceTransport(policy)
+	transport.TLSClientConfig = &tls.Config{RootCAs: caCertPool, MinVersion: tls.VersionTLS12}
 	return &http.Client{
-		Transport: tracing.Transport(transport, otelhttp.WithFilter(tracing.RequestFilterIsInSpan)),
-		Timeout:   timeout,
+		Transport:     tracing.Transport(transport, otelhttp.WithFilter(tracing.RequestFilterIsInSpan)),
+		Timeout:       timeout,
+		CheckRedirect: checkServiceRedirect(policy),
 	}, nil
+}
+
+func checkServiceRedirect(policy *egressPolicy) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return policy.validateURL(req.URL.String())
+	}
+}
+
+var (
+	serviceHTTPMu        sync.Mutex
+	serviceHTTPPolicy    *egressPolicy
+	serviceHTTPTransport http.RoundTripper
+)
+
+func getServiceHTTP() (*egressPolicy, http.RoundTripper, error) {
+	serviceHTTPMu.Lock()
+	defer serviceHTTPMu.Unlock()
+	if serviceHTTPPolicy != nil {
+		return serviceHTTPPolicy, serviceHTTPTransport, nil
+	}
+	policy, err := newEgressPolicy(toggle.HTTPBlocklist.Values(), toggle.HTTPAllowlist.Values())
+	if err != nil {
+		return nil, nil, err
+	}
+	serviceHTTPPolicy = policy
+	serviceHTTPTransport = tracing.Transport(newServiceTransport(policy), otelhttp.WithFilter(tracing.RequestFilterIsInSpan))
+	return serviceHTTPPolicy, serviceHTTPTransport, nil
+}
+
+func resetSharedServiceHTTP() {
+	serviceHTTPMu.Lock()
+	defer serviceHTTPMu.Unlock()
+	serviceHTTPPolicy = nil
+	serviceHTTPTransport = nil
+}
+
+func newServiceTransport(policy *egressPolicy) *http.Transport {
+	var transport *http.Transport
+	if base, ok := http.DefaultTransport.(*http.Transport); ok && base != nil {
+		transport = base.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
+	if policy != nil && len(policy.blockedCIDRs) > 0 {
+		transport.DialContext = policy.dialContext()
+		if base := transport.Proxy; base != nil {
+			transport.Proxy = proxyAwareDestinationCheck(policy, base)
+		}
+	}
+	return transport
+}
+
+func proxyAwareDestinationCheck(policy *egressPolicy, base func(*http.Request) (*url.URL, error)) func(*http.Request) (*url.URL, error) {
+	return func(req *http.Request) (*url.URL, error) {
+		proxyURL, err := base(req)
+		if err != nil || proxyURL == nil {
+			return proxyURL, err
+		}
+		if err := policy.validateHostCIDRs(req.Context(), req.URL.Hostname()); err != nil {
+			return nil, err
+		}
+		return proxyURL, nil
+	}
 }
 
 func (a *executor) buildRequestData(data []kyvernov1.RequestData) (io.Reader, error) {
@@ -195,4 +272,187 @@ func (a *executor) buildRequestData(data []kyvernov1.RequestData) (io.Reader, er
 	}
 
 	return buffer, nil
+}
+
+type egressPolicy struct {
+	blockedCIDRs    []*net.IPNet
+	blockedHosts    map[string]struct{}
+	allowedPrefixes []*url.URL
+}
+
+func newEgressPolicy(blocklist, allowlist []string) (*egressPolicy, error) {
+	p := &egressPolicy{blockedHosts: make(map[string]struct{})}
+	for _, entry := range blocklist {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if !strings.Contains(entry, "/") {
+			p.blockedHosts[hostKey(entry)] = struct{}{}
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR %q in httpBlocklist: %w", entry, err)
+		}
+		p.blockedCIDRs = append(p.blockedCIDRs, ipNet)
+	}
+	for _, entry := range allowlist {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		u, err := url.Parse(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid httpAllowlist URL %q: %w", entry, err)
+		}
+		if u.Scheme == "" || u.Host == "" {
+			return nil, fmt.Errorf("httpAllowlist entry %q must include scheme and host (e.g. https://api.example.com)", entry)
+		}
+		p.allowedPrefixes = append(p.allowedPrefixes, u)
+	}
+	return p, nil
+}
+
+func (p *egressPolicy) validateURL(rawURL string) error {
+	if len(p.blockedHosts) == 0 && len(p.allowedPrefixes) == 0 {
+		return nil
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if len(p.allowedPrefixes) > 0 && !p.allowed(u) {
+		return fmt.Errorf("URL %q is not permitted: no matching allowlist entry", rawURL)
+	}
+	if _, blocked := p.blockedHosts[hostKey(u.Hostname())]; blocked {
+		return fmt.Errorf("URL %q is blocked: hostname %q is on the blocklist", rawURL, u.Hostname())
+	}
+	return nil
+}
+
+func (p *egressPolicy) allowed(u *url.URL) bool {
+	host, port := hostKey(u.Hostname()), urlPort(u)
+	for _, e := range p.allowedPrefixes {
+		if u.Scheme == e.Scheme && hostKey(e.Hostname()) == host && urlPort(e) == port && pathAllowed(u.Path, e.Path) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathAllowed(reqPath, entryPath string) bool {
+	if entryPath == "" || entryPath == "/" {
+		return true
+	}
+	entryPath = path.Clean(entryPath)
+	reqPath = path.Clean("/" + reqPath)
+	if reqPath == entryPath {
+		return true
+	}
+	return strings.HasPrefix(reqPath, entryPath) && len(reqPath) > len(entryPath) && reqPath[len(entryPath)] == '/'
+}
+
+func (p *egressPolicy) validateHostCIDRs(ctx context.Context, host string) error {
+	if host == "" || len(p.blockedCIDRs) == 0 {
+		return nil
+	}
+	blockedIP := func(ip net.IP) *net.IPNet {
+		for _, cidr := range p.blockedCIDRs {
+			if cidr.Contains(ip) {
+				return cidr
+			}
+		}
+		return nil
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if cidr := blockedIP(ip); cidr != nil {
+			return fmt.Errorf("connection to %s blocked: IP %s falls in blocked range %s", host, ip, cidr)
+		}
+		return nil
+	}
+	ips, err := net.DefaultResolver.LookupHost(ctx, host)
+	if err != nil {
+		return fmt.Errorf("failed to resolve %s: %w", host, err)
+	}
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			continue
+		}
+		if cidr := blockedIP(ip); cidr != nil {
+			return fmt.Errorf("connection to %s blocked: resolved IP %s falls in blocked range %s", host, ip, cidr)
+		}
+	}
+	return nil
+}
+
+func (p *egressPolicy) dialContext() func(ctx context.Context, network, addr string) (net.Conn, error) {
+	blocked := p.blockedCIDRs
+	base := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+	blockedIP := func(ip net.IP) *net.IPNet {
+		for _, cidr := range blocked {
+			if cidr.Contains(ip) {
+				return cidr
+			}
+		}
+		return nil
+	}
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		if ip := net.ParseIP(host); ip != nil {
+			if cidr := blockedIP(ip); cidr != nil {
+				return nil, fmt.Errorf("connection to %s blocked: IP %s falls in blocked range %s", addr, ip, cidr)
+			}
+			return base.DialContext(ctx, network, addr)
+		}
+		ips, err := net.DefaultResolver.LookupHost(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve %s: %w", host, err)
+		}
+		for _, ipStr := range ips {
+			ip := net.ParseIP(ipStr)
+			if ip == nil {
+				continue
+			}
+			if cidr := blockedIP(ip); cidr != nil {
+				return nil, fmt.Errorf("connection to %s blocked: resolved IP %s falls in blocked range %s", addr, ip, cidr)
+			}
+		}
+		var lastErr error
+		for _, ipStr := range ips {
+			if net.ParseIP(ipStr) == nil {
+				continue
+			}
+			conn, err := base.DialContext(ctx, network, net.JoinHostPort(ipStr, port))
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, fmt.Errorf("no usable addresses resolved for %s", host)
+	}
+}
+
+func hostKey(h string) string {
+	return strings.ToLower(strings.TrimRight(h, "."))
+}
+
+func urlPort(u *url.URL) string {
+	if p := u.Port(); p != "" {
+		return p
+	}
+	if u.Scheme == "https" {
+		return "443"
+	}
+	if u.Scheme == "http" {
+		return "80"
+	}
+	return ""
 }

--- a/pkg/engine/apicall/executor_test.go
+++ b/pkg/engine/apicall/executor_test.go
@@ -6,10 +6,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/toggle"
 	"gotest.tools/v3/assert"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -123,6 +125,7 @@ func Test_ExecuteK8sAPICall_Success(t *testing.T) {
 }
 
 func Test_ExecuteServiceCall_AllowsMissingScopedTokenWhenAuthorizationMissing(t *testing.T) {
+	withEmptyEgressBlocklist(t)
 	missingTokenPath := scopedTokenPath + ".missing"
 	oldPath := scopedTokenPath
 	scopedTokenPath = missingTokenPath
@@ -159,4 +162,183 @@ func contains(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func withEmptyEgressBlocklist(t *testing.T) {
+	t.Helper()
+	assert.NilError(t, toggle.HTTPBlocklist.Parse(""))
+	resetSharedServiceHTTP()
+	t.Cleanup(func() {
+		toggle.HTTPBlocklist.Reset()
+		resetSharedServiceHTTP()
+	})
+}
+
+func testExecutor() *executor {
+	return NewExecutor(logr.Discard(), "test", &mockClient{}, apiConfig)
+}
+
+func getServiceCall(url string) *kyvernov1.APICall {
+	return &kyvernov1.APICall{Method: "GET", Service: &kyvernov1.ServiceCall{URL: url}}
+}
+
+func Test_ExecuteServiceCall_BlocksLoopbackByDefault(t *testing.T) {
+	toggle.HTTPBlocklist.Reset()
+	resetSharedServiceHTTP()
+
+	var gotHit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, err := testExecutor().Execute(context.Background(), getServiceCall(srv.URL))
+	assert.ErrorContains(t, err, "blocked")
+	assert.Assert(t, !gotHit)
+}
+
+func Test_NewEgressPolicy_BareIPIsHostname(t *testing.T) {
+	p, err := newEgressPolicy([]string{"169.254.169.254", "169.254.169.254/32"}, nil)
+	assert.NilError(t, err)
+	assert.Equal(t, len(p.blockedCIDRs), 1)
+	assert.Equal(t, len(p.blockedHosts), 1)
+}
+
+func Test_ExecuteServiceCall_BlocksMetadataHostByDefault(t *testing.T) {
+	toggle.HTTPBlocklist.Reset()
+	resetSharedServiceHTTP()
+
+	_, err := testExecutor().Execute(context.Background(), getServiceCall("http://169.254.169.254/latest/meta-data/"))
+	assert.ErrorContains(t, err, "blocked")
+}
+
+func Test_ExecuteServiceCall_AllowlistRejectsOtherHosts(t *testing.T) {
+	withEmptyEgressBlocklist(t)
+	assert.NilError(t, toggle.HTTPAllowlist.Parse("https://api.example.com"))
+	t.Cleanup(func() {
+		toggle.HTTPAllowlist.Reset()
+		resetSharedServiceHTTP()
+	})
+
+	_, err := testExecutor().Execute(context.Background(), getServiceCall("https://not-allowed.example.org/data"))
+	assert.ErrorContains(t, err, "not permitted")
+}
+
+func Test_ExecuteServiceCall_AllowlistRejectsPathTraversal(t *testing.T) {
+	withEmptyEgressBlocklist(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	assert.NilError(t, toggle.HTTPAllowlist.Parse(srv.URL+"/v1/"))
+	t.Cleanup(func() {
+		toggle.HTTPAllowlist.Reset()
+		resetSharedServiceHTTP()
+	})
+
+	_, err := testExecutor().Execute(context.Background(), getServiceCall(srv.URL+"/v1/../admin"))
+	assert.ErrorContains(t, err, "not permitted")
+
+	_, err = testExecutor().Execute(context.Background(), getServiceCall(srv.URL+"/v1/%2e%2e/admin"))
+	assert.ErrorContains(t, err, "not permitted")
+}
+
+func Test_ExecuteServiceCall_AllowlistRejectsRedirectToOtherHost(t *testing.T) {
+	withEmptyEgressBlocklist(t)
+
+	var sinkHit bool
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sinkHit = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"leaked":true}`))
+	}))
+	defer sink.Close()
+
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, sink.URL, http.StatusFound)
+	}))
+	defer src.Close()
+
+	assert.NilError(t, toggle.HTTPAllowlist.Parse(src.URL))
+	t.Cleanup(func() {
+		toggle.HTTPAllowlist.Reset()
+		resetSharedServiceHTTP()
+	})
+
+	_, err := testExecutor().Execute(context.Background(), getServiceCall(src.URL))
+	assert.ErrorContains(t, err, "not permitted")
+	assert.Assert(t, !sinkHit)
+}
+
+func Test_ExecuteServiceCall_BlocksIPv4MappedMetadataByDefault(t *testing.T) {
+	toggle.HTTPBlocklist.Reset()
+	resetSharedServiceHTTP()
+
+	_, err := testExecutor().Execute(context.Background(), getServiceCall("http://[::ffff:169.254.169.254]/latest/meta-data/"))
+	assert.ErrorContains(t, err, "blocked")
+}
+
+func Test_ProxyAwareDestinationCheck_BlocksProxiedRequestToBlockedCIDR(t *testing.T) {
+	policy, err := newEgressPolicy([]string{"127.0.0.0/8", "::1/128", "169.254.0.0/16"}, nil)
+	assert.NilError(t, err)
+	proxyURL := &url.URL{Scheme: "http", Host: "proxy.corp:3128"}
+	withProxy := func(*http.Request) (*url.URL, error) { return proxyURL, nil }
+
+	proxyFn := proxyAwareDestinationCheck(policy, withProxy)
+
+	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data/", nil)
+	assert.NilError(t, err)
+	_, err = proxyFn(req)
+	assert.ErrorContains(t, err, "blocked")
+
+	req, err = http.NewRequest(http.MethodGet, "http://localhost:9999/", nil)
+	assert.NilError(t, err)
+	_, err = proxyFn(req)
+	assert.ErrorContains(t, err, "blocked")
+}
+
+func Test_ProxyAwareDestinationCheck_AllowsProxiedRequestToPermittedHost(t *testing.T) {
+	policy, err := newEgressPolicy([]string{"169.254.0.0/16"}, nil)
+	assert.NilError(t, err)
+	proxyURL := &url.URL{Scheme: "http", Host: "proxy.corp:3128"}
+	withProxy := func(*http.Request) (*url.URL, error) { return proxyURL, nil }
+
+	req, err := http.NewRequest(http.MethodGet, "http://8.8.8.8/", nil)
+	assert.NilError(t, err)
+	got, err := proxyAwareDestinationCheck(policy, withProxy)(req)
+	assert.NilError(t, err)
+	assert.Equal(t, got, proxyURL)
+}
+
+func Test_ProxyAwareDestinationCheck_DirectRequestsUnaffected(t *testing.T) {
+	policy, err := newEgressPolicy([]string{"127.0.0.0/8"}, nil)
+	assert.NilError(t, err)
+	noProxy := func(*http.Request) (*url.URL, error) { return nil, nil }
+
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:9999/", nil)
+	assert.NilError(t, err)
+	got, err := proxyAwareDestinationCheck(policy, noProxy)(req)
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil)
+}
+
+func Test_ExecuteServiceCall_BlocklistRejectsRedirectToMetadataHost(t *testing.T) {
+	withEmptyEgressBlocklist(t)
+	assert.NilError(t, toggle.HTTPBlocklist.Parse("metadata.google.internal"))
+	resetSharedServiceHTTP()
+	t.Cleanup(func() {
+		toggle.HTTPBlocklist.Reset()
+		resetSharedServiceHTTP()
+	})
+
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://metadata.google.internal/latest/meta-data/", http.StatusFound)
+	}))
+	defer src.Close()
+
+	_, err := testExecutor().Execute(context.Background(), getServiceCall(src.URL))
+	assert.ErrorContains(t, err, "blocked")
 }

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -7,8 +7,8 @@ import (
 )
 
 var defaultPolicyHTTPBlocklist = []string{
-	"169.254.169.254",          // AWS/GCP/Azure metadata service
-	"169.254.169.253",          // GCP metadata service alternate
+	"169.254.169.254/32",       // AWS/GCP/Azure metadata service
+	"169.254.169.253/32",       // GCP metadata service alternate
 	"metadata.google.internal", // GCP metadata service hostname
 	"127.0.0.0/8",              // IPv4 loopback
 	"::1/128",                  // IPv6 loopback
@@ -57,10 +57,10 @@ const (
 	defaultAllowHTTPInNamespacedPolicies     = false
 	// http blocklist / allowlist flag names
 	HTTPBlocklistFlagName    = "httpBlocklist"
-	HTTPBlocklistDescription = "Comma-separated list of CIDR ranges or hostnames blocked from CEL http.Get/Post calls. Overrides the built-in defaults when set. Example: '169.254.169.254,metadata.google.internal'."
+	HTTPBlocklistDescription = "Comma-separated list of CIDR ranges or hostnames blocked from CEL http.Get/Post and apiCall.service calls. Overrides the built-in defaults when set. Example: '169.254.169.254,metadata.google.internal'."
 	httpBlocklistEnvVar      = "FLAG_HTTP_BLOCKLIST"
 	HTTPAllowlistFlagName    = "httpAllowlist"
-	HTTPAllowlistDescription = "Comma-separated list of URL prefixes (scheme+host[+path]) permitted in CEL http.Get/Post calls. When set, only matching URLs are allowed. Example: 'https://api.example.com,https://webhook.corp/v1/'."
+	HTTPAllowlistDescription = "Comma-separated list of URL prefixes (scheme+host[+path]) permitted in CEL http.Get/Post and apiCall.service calls. When set, only matching URLs are allowed. Example: 'https://api.example.com,https://webhook.corp/v1/'."
 	httpAllowlistEnvVar      = "FLAG_HTTP_ALLOWLIST"
 )
 


### PR DESCRIPTION
## Description

Cherry-pick of #17234 (`8b6686abf`) to `release-1.19`.

The SSRF blocklist was only enforced on CEL `http.Get`/`Post`. Classic `apiCall.service` and `GlobalContextEntry` used a plain HTTP client with no egress filter. This applies the same `httpBlocklist`/`httpAllowlist` to that path.

### Conflict resolution

One trivial conflict in `pkg/engine/apicall/executor.go` (`buildHTTPClient` no-CABundle branch): took the incoming version that wires the blocklist transport and redirect check into the client.

### Validation

`go test -race ./pkg/engine/apicall/... ./pkg/toggle/...` passes locally.