### PR TITLE
fix: harden apiCall.service egress proxy path and cover CABundle branch

### DIFF
--- a/pkg/engine/apicall/executor.go
+++ b/pkg/engine/apicall/executor.go
@@ -253,7 +253,16 @@ func proxyAwareDestinationCheck(policy *egressPolicy, base func(*http.Request) (
 		if err != nil || proxyURL == nil {
 			return proxyURL, err
 		}
-		if err := policy.validateHostCIDRs(req.Context(), req.URL.Hostname()); err != nil {
+		host := req.URL.Hostname()
+		if net.ParseIP(host) == nil {
+			// A hostname destination is resolved again by the proxy, so a
+			// pre-flight resolution here can be bypassed via DNS rebinding:
+			// the address checked against the blocklist is not necessarily
+			// the one the proxy connects to. Fail closed instead of
+			// forwarding an unpinnable destination.
+			return nil, fmt.Errorf("connection to %s via proxy %s blocked: hostname destinations cannot be validated against the HTTP blocklist when using a proxy; use an IP address destination or exclude the host via NO_PROXY", req.URL.Host, proxyURL.Host)
+		}
+		if err := policy.validateHostCIDRs(req.Context(), host); err != nil {
 			return nil, err
 		}
 		return proxyURL, nil

--- a/pkg/engine/apicall/executor_test.go
+++ b/pkg/engine/apicall/executor_test.go
@@ -2,6 +2,7 @@ package apicall
 
 import (
 	"context"
+	"encoding/pem"
 	"errors"
 	"io"
 	"net/http"
@@ -341,4 +342,118 @@ func Test_ExecuteServiceCall_BlocklistRejectsRedirectToMetadataHost(t *testing.T
 
 	_, err := testExecutor().Execute(context.Background(), getServiceCall(src.URL))
 	assert.ErrorContains(t, err, "blocked")
+}
+
+func caBundlePEM(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+	cert := srv.Certificate()
+	assert.Assert(t, cert != nil)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+}
+
+func getServiceCallWithCA(url, caBundle string) *kyvernov1.APICall {
+	return &kyvernov1.APICall{Method: "GET", Service: &kyvernov1.ServiceCall{URL: url, CABundle: caBundle}}
+}
+
+func Test_ExecuteServiceCall_CABundle_Success(t *testing.T) {
+	withEmptyEgressBlocklist(t)
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	got, err := testExecutor().Execute(context.Background(), getServiceCallWithCA(srv.URL, caBundlePEM(t, srv)))
+	assert.NilError(t, err)
+	assert.Assert(t, got != nil)
+}
+
+func Test_ExecuteServiceCall_CABundle_BlocksLoopbackByDefault(t *testing.T) {
+	toggle.HTTPBlocklist.Reset()
+	resetSharedServiceHTTP()
+
+	var gotHit bool
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, err := testExecutor().Execute(context.Background(), getServiceCallWithCA(srv.URL, caBundlePEM(t, srv)))
+	assert.ErrorContains(t, err, "blocked")
+	assert.Assert(t, !gotHit)
+}
+
+func Test_ExecuteServiceCall_CABundle_AllowlistRejectsRedirectToOtherHost(t *testing.T) {
+	withEmptyEgressBlocklist(t)
+
+	var sinkHit bool
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sinkHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sink.Close()
+
+	src := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, sink.URL, http.StatusFound)
+	}))
+	defer src.Close()
+
+	assert.NilError(t, toggle.HTTPAllowlist.Parse(src.URL))
+	t.Cleanup(func() {
+		toggle.HTTPAllowlist.Reset()
+		resetSharedServiceHTTP()
+	})
+
+	_, err := testExecutor().Execute(context.Background(), getServiceCallWithCA(src.URL, caBundlePEM(t, src)))
+	assert.ErrorContains(t, err, "not permitted")
+	assert.Assert(t, !sinkHit)
+}
+
+func Test_ProxyAwareDestinationCheck_RejectsHostnameDestination(t *testing.T) {
+	policy, err := newEgressPolicy([]string{"169.254.169.254/32"}, nil)
+	assert.NilError(t, err)
+	proxy := &url.URL{Scheme: "http", Host: "proxy.corp:3128"}
+	check := proxyAwareDestinationCheck(policy, func(*http.Request) (*url.URL, error) { return proxy, nil })
+
+	req := httptest.NewRequest(http.MethodGet, "http://internal.example.com/latest", nil)
+	got, err := check(req)
+	assert.ErrorContains(t, err, "hostname destinations cannot be validated")
+	assert.Assert(t, got == nil)
+}
+
+func Test_ProxyAwareDestinationCheck_RejectsBlockedIPDestination(t *testing.T) {
+	policy, err := newEgressPolicy([]string{"169.254.169.254/32"}, nil)
+	assert.NilError(t, err)
+	proxy := &url.URL{Scheme: "http", Host: "proxy.corp:3128"}
+	check := proxyAwareDestinationCheck(policy, func(*http.Request) (*url.URL, error) { return proxy, nil })
+
+	req := httptest.NewRequest(http.MethodGet, "http://169.254.169.254/latest", nil)
+	got, err := check(req)
+	assert.ErrorContains(t, err, "blocked")
+	assert.Assert(t, got == nil)
+}
+
+func Test_ProxyAwareDestinationCheck_AllowsPermittedIPDestination(t *testing.T) {
+	policy, err := newEgressPolicy([]string{"169.254.169.254/32"}, nil)
+	assert.NilError(t, err)
+	proxy := &url.URL{Scheme: "http", Host: "proxy.corp:3128"}
+	check := proxyAwareDestinationCheck(policy, func(*http.Request) (*url.URL, error) { return proxy, nil })
+
+	req := httptest.NewRequest(http.MethodGet, "http://10.0.0.10/api", nil)
+	got, err := check(req)
+	assert.NilError(t, err)
+	assert.Equal(t, got, proxy)
+}
+
+func Test_ProxyAwareDestinationCheck_NoProxyPassesThrough(t *testing.T) {
+	policy, err := newEgressPolicy([]string{"169.254.169.254/32"}, nil)
+	assert.NilError(t, err)
+	check := proxyAwareDestinationCheck(policy, func(*http.Request) (*url.URL, error) { return nil, nil })
+
+	req := httptest.NewRequest(http.MethodGet, "http://internal.example.com/latest", nil)
+	got, err := check(req)
+	assert.NilError(t, err)
+	assert.Assert(t, got == nil)
 }


### PR DESCRIPTION
## Description

Follow-up to #17234, addressing the two review findings surfaced by Copilot on the release-1.19 cherry-pick (#17298):

### 1. Proxy DNS-rebinding gap (fail closed)

`proxyAwareDestinationCheck` validated hostname destinations with the controller's resolver, then handed the original hostname to the proxy — which resolves it **again**. Attacker-controlled DNS could answer an allowed IP to the check and a blocked IP (e.g. `169.254.169.254`) to the proxy. Unlike the direct-dial path (which pins and dials the vetted IPs), the checked address was not the one the proxy connects to.

Since the destination cannot be pinned through a proxy without breaking TLS SNI/verification, the check now **fails closed**: when a proxy is selected and CIDR filtering is active, hostname destinations are rejected with an actionable error (use an IP-literal destination or exclude the host via `NO_PROXY`). IP-literal destinations remain allowed — the proxy CONNECTs to the exact checked address, so nothing re-resolves.

This only affects deployments running Kyverno with `HTTP(S)_PROXY` configured *and* a non-empty CIDR blocklist (on by default) *and* service API calls addressed by hostname through that proxy.

### 2. Missing CABundle-branch test coverage

The custom-CA transport branch enforces the blocklist and redirect checks, but no test exercised it. Added regression tests:
- `CABundle_BlocksLoopbackByDefault` — blocklist enforced at dial time through the CA transport
- `CABundle_AllowlistRejectsRedirectToOtherHost` — redirect check on the CA branch
- `CABundle_Success` — happy path with a custom CA
- 4 unit tests for `proxyAwareDestinationCheck` (hostname reject, blocked IP reject, allowed IP pass, no-proxy passthrough)

## Validation

`go test -race ./pkg/engine/apicall/...` and golangci-lint pass locally.

## Related

- #17234 (original fix), #17298 (release-1.19 cherry-pick where the findings were raised)