### PR TITLE
fix: close IPv6-embedded-IPv4 blocklist bypass in apiCall.service egress

### DIFF
--- a/pkg/engine/apicall/executor.go
+++ b/pkg/engine/apicall/executor.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/logging"
 	"github.com/kyverno/kyverno/pkg/toggle"
 	"github.com/kyverno/kyverno/pkg/tracing"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -254,15 +255,27 @@ func proxyAwareDestinationCheck(policy *egressPolicy, base func(*http.Request) (
 			return proxyURL, err
 		}
 		host := req.URL.Hostname()
-		if net.ParseIP(host) == nil {
-			// A hostname destination is resolved again by the proxy, so a
-			// pre-flight resolution here can be bypassed via DNS rebinding:
-			// the address checked against the blocklist is not necessarily
-			// the one the proxy connects to. Fail closed instead of
-			// forwarding an unpinnable destination.
-			return nil, fmt.Errorf("connection to %s via proxy %s blocked: hostname destinations cannot be validated against the HTTP blocklist when using a proxy; use an IP address destination or exclude the host via NO_PROXY", req.URL.Host, proxyURL.Host)
-		}
+		// With a proxy in use, DialContext only ever sees the proxy address, so the
+		// blocklist has to be applied to the real destination here.
+		//
+		// The proxy resolves a hostname destination again, so unlike the direct-dial
+		// path this check is not pinned to the address the connection ends up using: a
+		// DNS rebinding window remains. That is accepted, because refusing every
+		// proxied hostname breaks egress setups that work today, and because the
+		// hostname blocklist and the allowlist both still apply.
 		if err := policy.validateHostCIDRs(req.Context(), host); err != nil {
+			if errors.Is(err, errHostUnresolvable) && len(policy.allowedPrefixes) > 0 {
+				// Proxied egress commonly cannot resolve external names in-pod, since
+				// that is the proxy's job. Allowing an unresolvable destination through
+				// is safe only when an allowlist is configured, because every request
+				// that reaches here has already been matched against it by validateURL
+				// (on the initial URL, and again on each redirect hop).
+				egressLogger().V(2).Info("proxied destination is not resolvable in-pod, skipping blocked CIDR check", "host", host, "proxy", proxyURL.Host, "reason", err.Error())
+				return proxyURL, nil
+			}
+			if errors.Is(err, errHostUnresolvable) {
+				return nil, fmt.Errorf("connection to %s via proxy %s blocked: the destination cannot be resolved in-pod, so it cannot be checked against the HTTP blocklist; use an IP address destination, exclude the host via NO_PROXY, or permit it explicitly with --httpAllowlist: %w", req.URL.Host, proxyURL.Host, err)
+			}
 			return nil, err
 		}
 		return proxyURL, nil
@@ -281,6 +294,20 @@ func (a *executor) buildRequestData(data []kyvernov1.RequestData) (io.Reader, er
 	}
 
 	return buffer, nil
+}
+
+// errHostUnresolvable marks a destination that could not be resolved in-pod, so that
+// callers can tell "resolution failed" apart from "the destination is blocked".
+var errHostUnresolvable = errors.New("destination is not resolvable")
+
+// lookupHost resolves a hostname. It is a variable so tests can force a specific answer
+// or failure; resolution is not deterministic across platforms and CI environments.
+var lookupHost = net.DefaultResolver.LookupHost
+
+// egressLogger builds the logger lazily. A package-level logger would be created before
+// logging.Setup runs and would discard everything written to it.
+func egressLogger() logr.Logger {
+	return logging.WithName("apicall-egress")
 }
 
 type egressPolicy struct {
@@ -366,59 +393,110 @@ func (p *egressPolicy) validateHostCIDRs(ctx context.Context, host string) error
 	if host == "" || len(p.blockedCIDRs) == 0 {
 		return nil
 	}
-	blockedIP := func(ip net.IP) *net.IPNet {
-		for _, cidr := range p.blockedCIDRs {
-			if cidr.Contains(ip) {
-				return cidr
-			}
-		}
-		return nil
-	}
 	if ip := net.ParseIP(host); ip != nil {
-		if cidr := blockedIP(ip); cidr != nil {
+		if cidr := p.blockedCIDR(ip); cidr != nil {
 			return fmt.Errorf("connection to %s blocked: IP %s falls in blocked range %s", host, ip, cidr)
 		}
 		return nil
 	}
-	ips, err := net.DefaultResolver.LookupHost(ctx, host)
+	ips, err := lookupHost(ctx, host)
 	if err != nil {
-		return fmt.Errorf("failed to resolve %s: %w", host, err)
+		return fmt.Errorf("%w: failed to resolve %s: %w", errHostUnresolvable, host, err)
 	}
 	for _, ipStr := range ips {
 		ip := net.ParseIP(ipStr)
 		if ip == nil {
 			continue
 		}
-		if cidr := blockedIP(ip); cidr != nil {
-			return fmt.Errorf("connection to %s blocked: resolved IP %s falls in blocked range %s", host, ip, cidr)
+		if cidr := p.blockedCIDR(ip); cidr != nil {
+			// The resolved address is deliberately left out of the error. It reaches the
+			// caller through the admission denial, PolicyReports and Events, which would
+			// turn a denial into an oracle for how an arbitrary name resolves from the
+			// controller. The blocked range is operator-supplied, so naming it is safe.
+			egressLogger().V(2).Info("blocked connection to resolved address", "host", host, "ip", ip.String(), "range", cidr.String())
+			return fmt.Errorf("connection to %s blocked: it resolves into blocked range %s", host, cidr)
 		}
 	}
 	return nil
 }
 
-func (p *egressPolicy) dialContext() func(ctx context.Context, network, addr string) (net.Conn, error) {
-	blocked := p.blockedCIDRs
-	base := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
-	blockedIP := func(ip net.IP) *net.IPNet {
-		for _, cidr := range blocked {
-			if cidr.Contains(ip) {
+// blockedCIDR returns the blocked range containing ip, or nil when there is none.
+//
+// net.IPNet.Contains normalizes IPv4-mapped IPv6 addresses through To4, so an IPv4 CIDR
+// such as 169.254.169.254/32 already covers ::ffff:169.254.169.254. Three other IPv6
+// spellings carry an IPv4 address that To4 does not recognise, so the embedded address is
+// checked as a second candidate.
+func (p *egressPolicy) blockedCIDR(ip net.IP) *net.IPNet {
+	for _, candidate := range [2]net.IP{ip, embeddedIPv4(ip)} {
+		if candidate == nil {
+			continue
+		}
+		for _, cidr := range p.blockedCIDRs {
+			if cidr.Contains(candidate) {
 				return cidr
 			}
 		}
+	}
+	return nil
+}
+
+// embeddedIPv4 extracts the IPv4 address carried by an IPv6 address in a form that
+// net.IP.To4 does not recognise: IPv4-compatible (::a.b.c.d), the NAT64 well-known prefix
+// (64:ff9b::a.b.c.d), and 6to4 (2002:aabb:ccdd::). It returns nil when the address carries
+// no embedded IPv4 address, or when To4 already handles it.
+//
+// Each of these is a distinct spelling of an address that an IPv4 CIDR on the blocklist is
+// meant to cover. Without normalization, 64:ff9b::a9fe:a9fe reaches the metadata service
+// even though 169.254.169.254/32 is blocked. NAT64 is the form that matters in practice,
+// because it is standard in IPv6-only clusters; the other two are deprecated and need
+// specific routing, so they are defense in depth.
+//
+// The IPv4-compatible branch also matches low IPv6 addresses that were never meant as an
+// IPv4 encoding: ::1 yields 0.0.0.1, for example. That only ever widens the blocklist into
+// reserved space, so it is left as is.
+func embeddedIPv4(ip net.IP) net.IP {
+	if ip.To4() != nil || len(ip.To16()) != net.IPv6len {
 		return nil
 	}
+	ip = ip.To16()
+	isZero := func(b []byte) bool {
+		for _, c := range b {
+			if c != 0 {
+				return false
+			}
+		}
+		return true
+	}
+	// ::a.b.c.d — IPv4-compatible IPv6 (RFC 4291).
+	if isZero(ip[:12]) {
+		return net.IPv4(ip[12], ip[13], ip[14], ip[15])
+	}
+	// 64:ff9b::a.b.c.d — NAT64 well-known prefix (RFC 6052).
+	if ip[0] == 0x00 && ip[1] == 0x64 && ip[2] == 0xff && ip[3] == 0x9b && isZero(ip[4:12]) {
+		return net.IPv4(ip[12], ip[13], ip[14], ip[15])
+	}
+	// 2002:aabb:ccdd::/48 — 6to4 (RFC 3056), which carries the IPv4 address in bytes 2-5
+	// rather than at the end. 2002:a9fe:a9fe:: is 169.254.169.254.
+	if ip[0] == 0x20 && ip[1] == 0x02 {
+		return net.IPv4(ip[2], ip[3], ip[4], ip[5])
+	}
+	return nil
+}
+
+func (p *egressPolicy) dialContext() func(ctx context.Context, network, addr string) (net.Conn, error) {
+	base := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(addr)
 		if err != nil {
 			return nil, err
 		}
 		if ip := net.ParseIP(host); ip != nil {
-			if cidr := blockedIP(ip); cidr != nil {
+			if cidr := p.blockedCIDR(ip); cidr != nil {
 				return nil, fmt.Errorf("connection to %s blocked: IP %s falls in blocked range %s", addr, ip, cidr)
 			}
 			return base.DialContext(ctx, network, addr)
 		}
-		ips, err := net.DefaultResolver.LookupHost(ctx, host)
+		ips, err := lookupHost(ctx, host)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve %s: %w", host, err)
 		}
@@ -427,8 +505,11 @@ func (p *egressPolicy) dialContext() func(ctx context.Context, network, addr str
 			if ip == nil {
 				continue
 			}
-			if cidr := blockedIP(ip); cidr != nil {
-				return nil, fmt.Errorf("connection to %s blocked: resolved IP %s falls in blocked range %s", addr, ip, cidr)
+			if cidr := p.blockedCIDR(ip); cidr != nil {
+				// See validateHostCIDRs: the resolved address stays out of the error so
+				// the denial does not act as a DNS resolution oracle.
+				egressLogger().V(2).Info("blocked connection to resolved address", "addr", addr, "ip", ip.String(), "range", cidr.String())
+				return nil, fmt.Errorf("connection to %s blocked: %s resolves into blocked range %s", addr, host, cidr)
 			}
 		}
 		var lastErr error

--- a/pkg/engine/apicall/executor.go
+++ b/pkg/engine/apicall/executor.go
@@ -297,8 +297,23 @@ func (a *executor) buildRequestData(data []kyvernov1.RequestData) (io.Reader, er
 }
 
 // errHostUnresolvable marks a destination that could not be resolved in-pod, so that
-// callers can tell "resolution failed" apart from "the destination is blocked".
+// callers can tell "resolution failed" apart from "the destination is blocked". It is a
+// match target for errors.Is only; unresolvableHostError keeps it out of the message so
+// that a caller wrapping the error does not repeat itself.
 var errHostUnresolvable = errors.New("destination is not resolvable")
+
+type unresolvableHostError struct {
+	host string
+	err  error
+}
+
+func (e *unresolvableHostError) Error() string {
+	return fmt.Sprintf("failed to resolve %s: %v", e.host, e.err)
+}
+
+func (e *unresolvableHostError) Unwrap() error { return e.err }
+
+func (e *unresolvableHostError) Is(target error) bool { return target == errHostUnresolvable }
 
 // lookupHost resolves a hostname. It is a variable so tests can force a specific answer
 // or failure; resolution is not deterministic across platforms and CI environments.
@@ -401,7 +416,7 @@ func (p *egressPolicy) validateHostCIDRs(ctx context.Context, host string) error
 	}
 	ips, err := lookupHost(ctx, host)
 	if err != nil {
-		return fmt.Errorf("%w: failed to resolve %s: %w", errHostUnresolvable, host, err)
+		return &unresolvableHostError{host: host, err: err}
 	}
 	for _, ipStr := range ips {
 		ip := net.ParseIP(ipStr)

--- a/pkg/engine/apicall/executor.go
+++ b/pkg/engine/apicall/executor.go
@@ -527,7 +527,7 @@ func (p *egressPolicy) dialContext() func(ctx context.Context, network, addr str
 			if cidr := p.blockedCIDR(ip); cidr != nil {
 				return nil, fmt.Errorf("connection to %s blocked: IP %s falls in blocked range %s", addr, ip, cidr)
 			}
-			return base.DialContext(ctx, network, addr)
+			return dialTCP(ctx, base, network, addr)
 		}
 		ips, err := lookupHost(ctx, host)
 		if err != nil {
@@ -576,11 +576,19 @@ func (p *egressPolicy) dialContext() func(ctx context.Context, network, addr str
 	}
 }
 
+// dialTCP performs one connection attempt. It is a variable so tests can observe the
+// context handed to each attempt, which is what proves the deadline above is shared rather
+// than per-address; a test that relies on unreachable addresses instead passes vacuously on
+// any host where those addresses fail fast.
+var dialTCP = func(ctx context.Context, d *net.Dialer, network, addr string) (net.Conn, error) {
+	return d.DialContext(ctx, network, addr)
+}
+
 // dialSeries tries each address in turn and returns the first connection that succeeds.
 func dialSeries(ctx context.Context, d *net.Dialer, network, port string, ips []net.IP) (net.Conn, error) {
 	var lastErr error
 	for _, ip := range ips {
-		conn, err := d.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		conn, err := dialTCP(ctx, d, network, net.JoinHostPort(ip.String(), port))
 		if err == nil {
 			return conn, nil
 		}

--- a/pkg/engine/apicall/executor.go
+++ b/pkg/engine/apicall/executor.go
@@ -498,13 +498,31 @@ func embeddedIPv4(ip net.IP) net.IP {
 	return nil
 }
 
+const (
+	// dialTimeout bounds resolution and every connection attempt together, the way
+	// net.Dialer's own Timeout does for a caller that hands it a hostname.
+	dialTimeout = 30 * time.Second
+	// fallbackDelay is the head start the preferred address family gets before the other
+	// one is tried in parallel (RFC 6555). It matches net.Dialer's default.
+	fallbackDelay = 300 * time.Millisecond
+)
+
 func (p *egressPolicy) dialContext() func(ctx context.Context, network, addr string) (net.Conn, error) {
-	base := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+	// No per-attempt Timeout. The deadline below spans resolution and every attempt
+	// together; setting one here as well would let a host with many answers stretch the
+	// total to dialTimeout per address.
+	base := &net.Dialer{KeepAlive: 30 * time.Second}
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(addr)
 		if err != nil {
 			return nil, err
 		}
+		// One deadline covering resolution and all connection attempts, which is what the
+		// stock dialer gives a caller. Without it, a name answering with many black-holed
+		// addresses holds an admission request for resolution plus dialTimeout per
+		// address. A shorter deadline already on ctx still wins.
+		ctx, cancel := context.WithTimeout(ctx, dialTimeout)
+		defer cancel()
 		if ip := net.ParseIP(host); ip != nil {
 			if cidr := p.blockedCIDR(ip); cidr != nil {
 				return nil, fmt.Errorf("connection to %s blocked: IP %s falls in blocked range %s", addr, ip, cidr)
@@ -515,6 +533,7 @@ func (p *egressPolicy) dialContext() func(ctx context.Context, network, addr str
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve %s: %w", host, err)
 		}
+		targets := make([]net.IP, 0, len(ips))
 		for _, ipStr := range ips {
 			ip := net.ParseIP(ipStr)
 			if ip == nil {
@@ -526,23 +545,115 @@ func (p *egressPolicy) dialContext() func(ctx context.Context, network, addr str
 				egressLogger().V(2).Info("blocked connection to resolved address", "addr", addr, "ip", ip.String(), "range", cidr.String())
 				return nil, fmt.Errorf("connection to %s blocked: %s resolves into blocked range %s", addr, host, cidr)
 			}
+			targets = append(targets, ip)
 		}
-		var lastErr error
-		for _, ipStr := range ips {
-			if net.ParseIP(ipStr) == nil {
-				continue
+		if len(targets) == 0 {
+			return nil, fmt.Errorf("no usable addresses resolved for %s", host)
+		}
+		// Every dial below targets an address that was just validated rather than the
+		// hostname, so a second resolution cannot substitute a different one (DNS
+		// rebinding).
+		//
+		// Split by family and race the two groups the way net.Dialer does, rather than
+		// walking one flat list. Trying every address of the preferred family first makes
+		// a dual-stack Service whose AAAA is present but not listening wait out the whole
+		// IPv6 side before reaching IPv4; the stock dialer starts the other family after
+		// fallbackDelay instead. lookupHost returns addresses in RFC 6724 preference
+		// order, so the first one names the preferred family.
+		preferIPv4 := targets[0].To4() != nil
+		var primary, fallback []net.IP
+		for _, ip := range targets {
+			if (ip.To4() != nil) == preferIPv4 {
+				primary = append(primary, ip)
+			} else {
+				fallback = append(fallback, ip)
 			}
-			conn, err := base.DialContext(ctx, network, net.JoinHostPort(ipStr, port))
-			if err == nil {
-				return conn, nil
-			}
-			lastErr = err
 		}
-		if lastErr != nil {
-			return nil, lastErr
+		if len(fallback) == 0 {
+			return dialSeries(ctx, base, network, port, primary)
 		}
-		return nil, fmt.Errorf("no usable addresses resolved for %s", host)
+		return dialRace(ctx, base, network, port, primary, fallback)
 	}
+}
+
+// dialSeries tries each address in turn and returns the first connection that succeeds.
+func dialSeries(ctx context.Context, d *net.Dialer, network, port string, ips []net.IP) (net.Conn, error) {
+	var lastErr error
+	for _, ip := range ips {
+		conn, err := d.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("no addresses to dial")
+	}
+	return nil, lastErr
+}
+
+type dialOutcome struct {
+	conn      net.Conn
+	err       error
+	isPrimary bool
+}
+
+// dialRace runs the two address families concurrently, giving the preferred one a
+// fallbackDelay head start, and returns the first connection to succeed (RFC 6555).
+func dialRace(ctx context.Context, d *net.Dialer, network, port string, primary, fallback []net.IP) (net.Conn, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	// Cancelling on return tears down the losing attempt. A connection already returned is
+	// unaffected: net.Dialer does not tie a live conn to the dial context.
+	defer cancel()
+
+	// Buffered, so a loser that finishes after we have returned never blocks on send.
+	outcomes := make(chan dialOutcome, 2)
+	race := func(ips []net.IP, isPrimary bool, delay time.Duration) {
+		go func() {
+			if delay > 0 {
+				timer := time.NewTimer(delay)
+				defer timer.Stop()
+				select {
+				case <-timer.C:
+				case <-ctx.Done():
+					outcomes <- dialOutcome{err: ctx.Err(), isPrimary: isPrimary}
+					return
+				}
+			}
+			conn, err := dialSeries(ctx, d, network, port, ips)
+			outcomes <- dialOutcome{conn: conn, err: err, isPrimary: isPrimary}
+		}()
+	}
+	race(primary, true, 0)
+	race(fallback, false, fallbackDelay)
+
+	var firstErr error
+	for i := 0; i < 2; i++ {
+		out := <-outcomes
+		if out.err == nil {
+			// Drain the sibling so a connection that lands after this point is closed
+			// rather than leaked.
+			if remaining := 1 - i; remaining > 0 {
+				go func(n int) {
+					for j := 0; j < n; j++ {
+						if late := <-outcomes; late.conn != nil {
+							late.conn.Close()
+						}
+					}
+				}(remaining)
+			}
+			return out.conn, nil
+		}
+		// Prefer the primary family's error: it describes the address the caller would
+		// have reached without this guard.
+		if firstErr == nil || out.isPrimary {
+			firstErr = out.err
+		}
+	}
+	return nil, firstErr
 }
 
 func hostKey(h string) string {

--- a/pkg/engine/apicall/executor_test.go
+++ b/pkg/engine/apicall/executor_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/pem"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -411,7 +413,28 @@ func Test_ExecuteServiceCall_CABundle_AllowlistRejectsRedirectToOtherHost(t *tes
 	assert.Assert(t, !sinkHit)
 }
 
-func Test_ProxyAwareDestinationCheck_RejectsHostnameDestination(t *testing.T) {
+// withStubResolver replaces the resolver seam for the duration of a test. Resolution of
+// a real name is not deterministic across platforms, and the unresolvable branch has to
+// be exercised without depending on the CI environment's DNS.
+func withStubResolver(t *testing.T, fn func(ctx context.Context, host string) ([]string, error)) {
+	t.Helper()
+	original := lookupHost
+	lookupHost = fn
+	t.Cleanup(func() { lookupHost = original })
+}
+
+func resolvesTo(ips ...string) func(context.Context, string) ([]string, error) {
+	return func(context.Context, string) ([]string, error) { return ips, nil }
+}
+
+func resolutionFails() func(context.Context, string) ([]string, error) {
+	return func(_ context.Context, host string) ([]string, error) {
+		return nil, &net.DNSError{Err: "server misbehaving", Name: host}
+	}
+}
+
+func Test_ProxyAwareDestinationCheck_RejectsHostnameResolvingIntoBlockedRange(t *testing.T) {
+	withStubResolver(t, resolvesTo("169.254.169.254"))
 	policy, err := newEgressPolicy([]string{"169.254.169.254/32"}, nil)
 	assert.NilError(t, err)
 	proxy := &url.URL{Scheme: "http", Host: "proxy.corp:3128"}
@@ -419,8 +442,172 @@ func Test_ProxyAwareDestinationCheck_RejectsHostnameDestination(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "http://internal.example.com/latest", nil)
 	got, err := check(req)
-	assert.ErrorContains(t, err, "hostname destinations cannot be validated")
+	assert.ErrorContains(t, err, "blocked range")
 	assert.Assert(t, got == nil)
+}
+
+func Test_ProxyAwareDestinationCheck_AllowsHostnameResolvingOutsideBlockedRanges(t *testing.T) {
+	withStubResolver(t, resolvesTo("93.184.216.34"))
+	policy, err := newEgressPolicy([]string{"169.254.169.254/32"}, nil)
+	assert.NilError(t, err)
+	proxy := &url.URL{Scheme: "http", Host: "proxy.corp:3128"}
+	check := proxyAwareDestinationCheck(policy, func(*http.Request) (*url.URL, error) { return proxy, nil })
+
+	req := httptest.NewRequest(http.MethodGet, "http://api.example.com/v1", nil)
+	got, err := check(req)
+	assert.NilError(t, err)
+	assert.Equal(t, got, proxy)
+}
+
+// An unresolvable destination is a policy decision, not a config error: without an
+// allowlist there is no way to check where the proxy will actually connect, so the
+// request fails closed.
+func Test_ProxyAwareDestinationCheck_RejectsUnresolvableHostnameWithoutAllowlist(t *testing.T) {
+	withStubResolver(t, resolutionFails())
+	policy, err := newEgressPolicy([]string{"169.254.169.254/32"}, nil)
+	assert.NilError(t, err)
+	proxy := &url.URL{Scheme: "http", Host: "proxy.corp:3128"}
+	check := proxyAwareDestinationCheck(policy, func(*http.Request) (*url.URL, error) { return proxy, nil })
+
+	req := httptest.NewRequest(http.MethodGet, "http://internal.example.com/latest", nil)
+	got, err := check(req)
+	assert.ErrorContains(t, err, "cannot be resolved in-pod")
+	assert.ErrorContains(t, err, "--httpAllowlist")
+	assert.Assert(t, got == nil)
+}
+
+// Proxied egress commonly cannot resolve external names in-pod. An allowlist is the
+// operator's opt-in for those destinations: validateURL has already matched the URL
+// against it before the request reaches the proxy function.
+func Test_ProxyAwareDestinationCheck_AllowsUnresolvableHostnameWithAllowlist(t *testing.T) {
+	withStubResolver(t, resolutionFails())
+	policy, err := newEgressPolicy([]string{"169.254.169.254/32"}, []string{"http://internal.example.com"})
+	assert.NilError(t, err)
+	proxy := &url.URL{Scheme: "http", Host: "proxy.corp:3128"}
+	check := proxyAwareDestinationCheck(policy, func(*http.Request) (*url.URL, error) { return proxy, nil })
+
+	req := httptest.NewRequest(http.MethodGet, "http://internal.example.com/latest", nil)
+	got, err := check(req)
+	assert.NilError(t, err)
+	assert.Equal(t, got, proxy)
+}
+
+// An allowlist must not excuse a destination that resolves into a blocked range; only
+// the unresolvable case is opted back in.
+func Test_ProxyAwareDestinationCheck_AllowlistDoesNotExcuseBlockedRange(t *testing.T) {
+	withStubResolver(t, resolvesTo("169.254.169.254"))
+	policy, err := newEgressPolicy([]string{"169.254.169.254/32"}, []string{"http://internal.example.com"})
+	assert.NilError(t, err)
+	proxy := &url.URL{Scheme: "http", Host: "proxy.corp:3128"}
+	check := proxyAwareDestinationCheck(policy, func(*http.Request) (*url.URL, error) { return proxy, nil })
+
+	req := httptest.NewRequest(http.MethodGet, "http://internal.example.com/latest", nil)
+	got, err := check(req)
+	assert.ErrorContains(t, err, "blocked range")
+	assert.Assert(t, got == nil)
+}
+
+// Every IPv6 spelling of an IPv4 metadata address must be caught by the shipped default
+// blocklist. Only ::ffff: is normalized by net.IPNet.Contains itself.
+func Test_ExecuteServiceCall_BlocksEmbeddedIPv4EncodingsByDefault(t *testing.T) {
+	for _, tc := range []struct {
+		host string
+		desc string
+	}{
+		{"[::ffff:169.254.169.254]", "IPv4-mapped"},
+		{"[::169.254.169.254]", "IPv4-compatible"},
+		{"[64:ff9b::169.254.169.254]", "NAT64 well-known prefix"},
+		{"[2002:a9fe:a9fe::]", "6to4 of 169.254.169.254"},
+		{"[2002:7f00:1::]", "6to4 of 127.0.0.1"},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			toggle.HTTPBlocklist.Reset()
+			resetSharedServiceHTTP()
+
+			_, err := testExecutor().Execute(context.Background(), getServiceCall("http://"+tc.host+"/latest/meta-data/"))
+			assert.ErrorContains(t, err, "blocked")
+		})
+	}
+}
+
+// The AWS IMDS IPv6 endpoint needs no encoding trick, so it has to be on the default
+// blocklist in its own right.
+func Test_ExecuteServiceCall_BlocksIMDSIPv6EndpointByDefault(t *testing.T) {
+	toggle.HTTPBlocklist.Reset()
+	resetSharedServiceHTTP()
+
+	_, err := testExecutor().Execute(context.Background(), getServiceCall("http://[fd00:ec2::254]/latest/meta-data/"))
+	assert.ErrorContains(t, err, "blocked")
+}
+
+func Test_EmbeddedIPv4(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{"::169.254.169.254", "169.254.169.254"},
+		{"64:ff9b::169.254.169.254", "169.254.169.254"},
+		{"2002:a9fe:a9fe::", "169.254.169.254"},
+		{"2002:7f00:1::", "127.0.0.1"},
+		// To4 already handles these, so there is nothing to extract.
+		{"::ffff:169.254.169.254", ""},
+		{"169.254.169.254", ""},
+		// A plain IPv6 address must not be read as carrying an IPv4 address.
+		{"2001:db8::1", ""},
+		{"fd00:ec2::254", ""},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			got := embeddedIPv4(net.ParseIP(tc.in))
+			if tc.want == "" {
+				assert.Assert(t, got == nil)
+				return
+			}
+			assert.Equal(t, got.String(), tc.want)
+		})
+	}
+}
+
+// A denial must not report how the name resolved: that message reaches the caller through
+// the admission response, PolicyReports and Events, and would otherwise act as a DNS
+// resolution oracle for the controller's vantage point.
+func Test_ValidateHostCIDRs_BlockedErrorDoesNotNameResolvedAddress(t *testing.T) {
+	withStubResolver(t, resolvesTo("127.0.0.1"))
+	policy, err := newEgressPolicy([]string{"127.0.0.0/8"}, nil)
+	assert.NilError(t, err)
+
+	err = policy.validateHostCIDRs(context.Background(), "internal.example.com")
+	assert.ErrorContains(t, err, "blocked range 127.0.0.0/8")
+	assert.Assert(t, !strings.Contains(err.Error(), "127.0.0.1"), "error must not reveal the resolved address: %v", err)
+}
+
+func Test_DialContext_BlockedErrorDoesNotNameResolvedAddress(t *testing.T) {
+	withStubResolver(t, resolvesTo("169.254.169.254"))
+	policy, err := newEgressPolicy([]string{"169.254.0.0/16"}, nil)
+	assert.NilError(t, err)
+
+	_, err = policy.dialContext()(context.Background(), "tcp", "internal.example.com:80")
+	assert.ErrorContains(t, err, "blocked range 169.254.0.0/16")
+	assert.Assert(t, !strings.Contains(err.Error(), "169.254.169.254"), "error must not reveal the resolved address: %v", err)
+}
+
+// A literal address supplied by the caller is not an oracle, so it stays in the message
+// where it helps an operator.
+func Test_ValidateHostCIDRs_LiteralAddressStaysInError(t *testing.T) {
+	policy, err := newEgressPolicy([]string{"169.254.0.0/16"}, nil)
+	assert.NilError(t, err)
+
+	err = policy.validateHostCIDRs(context.Background(), "169.254.169.254")
+	assert.ErrorContains(t, err, "169.254.169.254")
+	assert.ErrorContains(t, err, "blocked range 169.254.0.0/16")
+}
+
+func Test_DialContext_BlocksHostnameResolvingToEmbeddedIPv4(t *testing.T) {
+	withStubResolver(t, resolvesTo("64:ff9b::a9fe:a9fe"))
+	policy, err := newEgressPolicy([]string{"169.254.169.254/32"}, nil)
+	assert.NilError(t, err)
+
+	_, err = policy.dialContext()(context.Background(), "tcp", "rebind.example.com:80")
+	assert.ErrorContains(t, err, "blocked range 169.254.169.254/32")
 }
 
 func Test_ProxyAwareDestinationCheck_RejectsBlockedIPDestination(t *testing.T) {

--- a/pkg/engine/apicall/executor_test.go
+++ b/pkg/engine/apicall/executor_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
@@ -655,4 +656,60 @@ func Test_UnresolvableHostError_SentinelIsNotUserVisible(t *testing.T) {
 
 	var dnsErr *net.DNSError
 	assert.Assert(t, errors.As(err, &dnsErr))
+}
+
+// A serial walk over the resolved addresses loses the RFC 6555 behaviour net.Dialer
+// provides: when the preferred family cannot be reached, the other one has to start after
+// a short delay rather than after the full dial timeout.
+func Test_DialContext_FallsBackToOtherAddressFamily(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NilError(t, err)
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	assert.NilError(t, err)
+
+	// 2001:db8::/32 is the documentation range: it is not routed, so the IPv6 attempt
+	// either fails immediately or hangs, depending on the host's IPv6 configuration.
+	// Either way the IPv4 answer must still win.
+	withStubResolver(t, resolvesTo("2001:db8::1", "127.0.0.1"))
+
+	policy, err := newEgressPolicy([]string{"169.254.0.0/16"}, nil)
+	assert.NilError(t, err)
+
+	started := time.Now()
+	conn, err := policy.dialContext()(context.Background(), "tcp", net.JoinHostPort("dual.example.test", port))
+	assert.NilError(t, err, "the reachable address family must still be dialed")
+	defer conn.Close()
+
+	// Generous, because the point is only that it did not wait out dialTimeout.
+	assert.Assert(t, time.Since(started) < 5*time.Second)
+}
+
+// Resolution and every connection attempt share one deadline. Previously each address got
+// its own, so a name answering with many black-holed addresses could hold an admission
+// request for dialTimeout per address.
+func Test_DialContext_DeadlineIsSharedAcrossAttempts(t *testing.T) {
+	withStubResolver(t, resolvesTo("2001:db8::1", "2001:db8::2", "2001:db8::3", "2001:db8::4"))
+
+	policy, err := newEgressPolicy([]string{"169.254.0.0/16"}, nil)
+	assert.NilError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 750*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	_, err = policy.dialContext()(ctx, "tcp", "blackhole.example.test:80")
+	assert.Assert(t, err != nil)
+	// Four addresses; if each still had its own timeout this could not return this fast.
+	assert.Assert(t, time.Since(started) < 5*time.Second)
 }

--- a/pkg/engine/apicall/executor_test.go
+++ b/pkg/engine/apicall/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -695,21 +696,69 @@ func Test_DialContext_FallsBackToOtherAddressFamily(t *testing.T) {
 	assert.Assert(t, time.Since(started) < 5*time.Second)
 }
 
-// Resolution and every connection attempt share one deadline. Previously each address got
-// its own, so a name answering with many black-holed addresses could hold an admission
-// request for dialTimeout per address.
+// withStubDialer replaces the connection-attempt seam for the duration of a test.
+func withStubDialer(t *testing.T, fn func(ctx context.Context, d *net.Dialer, network, addr string) (net.Conn, error)) {
+	t.Helper()
+	original := dialTCP
+	dialTCP = fn
+	t.Cleanup(func() { dialTCP = original })
+}
+
+// Resolution and every connection attempt run under one deadline. Previously each address
+// carried its own, so a name answering with many black-holed addresses could hold an
+// admission request for dialTimeout per address.
+//
+// The assertion is on the context handed to each attempt, not on elapsed time. A timing
+// test would need addresses that hang rather than fail, and on any host without an IPv6
+// route the documentation range fails instantly, so such a test passes just as happily
+// against the per-address-timeout code it is meant to catch.
 func Test_DialContext_DeadlineIsSharedAcrossAttempts(t *testing.T) {
-	withStubResolver(t, resolvesTo("2001:db8::1", "2001:db8::2", "2001:db8::3", "2001:db8::4"))
+	// Same family throughout, so this exercises dialSeries rather than the race.
+	withStubResolver(t, resolvesTo("192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4"))
+
+	var deadlines []time.Time
+	withStubDialer(t, func(ctx context.Context, _ *net.Dialer, _, addr string) (net.Conn, error) {
+		deadline, ok := ctx.Deadline()
+		assert.Assert(t, ok, "each attempt must run under a deadline, not an open-ended context")
+		deadlines = append(deadlines, deadline)
+		return nil, fmt.Errorf("refused %s", addr)
+	})
 
 	policy, err := newEgressPolicy([]string{"169.254.0.0/16"}, nil)
 	assert.NilError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 750*time.Millisecond)
+	before := time.Now()
+	_, err = policy.dialContext()(context.Background(), "tcp", "blackhole.example.test:80")
+	assert.Assert(t, err != nil)
+
+	assert.Equal(t, len(deadlines), 4, "every resolved address must be attempted")
+	for i, d := range deadlines {
+		assert.Assert(t, d.Sub(deadlines[0]).Abs() < time.Millisecond,
+			"attempt %d must share the first attempt's deadline, not start a new one", i)
+	}
+	// One dialTimeout from the start of the dial, not one per address.
+	assert.Assert(t, deadlines[0].Sub(before.Add(dialTimeout)).Abs() < time.Second)
+}
+
+// The shared deadline must not extend one the caller already set.
+func Test_DialContext_DeadlineRespectsShorterParent(t *testing.T) {
+	withStubResolver(t, resolvesTo("192.0.2.1"))
+
+	var got time.Time
+	withStubDialer(t, func(ctx context.Context, _ *net.Dialer, _, _ string) (net.Conn, error) {
+		got, _ = ctx.Deadline()
+		return nil, errors.New("refused")
+	})
+
+	policy, err := newEgressPolicy([]string{"169.254.0.0/16"}, nil)
+	assert.NilError(t, err)
+
+	parent := time.Now().Add(2 * time.Second)
+	ctx, cancel := context.WithDeadline(context.Background(), parent)
 	defer cancel()
 
-	started := time.Now()
 	_, err = policy.dialContext()(ctx, "tcp", "blackhole.example.test:80")
 	assert.Assert(t, err != nil)
-	// Four addresses; if each still had its own timeout this could not return this fast.
-	assert.Assert(t, time.Since(started) < 5*time.Second)
+	assert.Assert(t, got.Sub(parent).Abs() < 50*time.Millisecond,
+		"the caller's shorter deadline must win over dialTimeout")
 }

--- a/pkg/engine/apicall/executor_test.go
+++ b/pkg/engine/apicall/executor_test.go
@@ -644,3 +644,15 @@ func Test_ProxyAwareDestinationCheck_NoProxyPassesThrough(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, got == nil)
 }
+
+// The sentinel is a match target only. Its text must not reach the message, or the proxy
+// path's wrapper repeats itself in the admission denial.
+func Test_UnresolvableHostError_SentinelIsNotUserVisible(t *testing.T) {
+	err := &unresolvableHostError{host: "internal.example.com", err: &net.DNSError{Err: "no such host", Name: "internal.example.com"}}
+	assert.Assert(t, errors.Is(err, errHostUnresolvable))
+	assert.Assert(t, !strings.Contains(err.Error(), errHostUnresolvable.Error()), "sentinel text must stay out of the message: %v", err)
+	assert.ErrorContains(t, err, "failed to resolve internal.example.com")
+
+	var dnsErr *net.DNSError
+	assert.Assert(t, errors.As(err, &dnsErr))
+}

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -9,6 +9,7 @@ import (
 var defaultPolicyHTTPBlocklist = []string{
 	"169.254.169.254/32",       // AWS/GCP/Azure metadata service
 	"169.254.169.253/32",       // GCP metadata service alternate
+	"fd00:ec2::254/128",        // AWS IMDS IPv6 endpoint
 	"metadata.google.internal", // GCP metadata service hostname
 	"127.0.0.0/8",              // IPv4 loopback
 	"::1/128",                  // IPv6 loopback


### PR DESCRIPTION
## Explanation

Closes #17292.

Follow-up to #17234 and #17299. The two-phase design those PRs introduced is unchanged: a pre-flight `validateURL`, plus a dial-time CIDR check on `Transport.DialContext`, applied at the executor so `GlobalContextEntry` is covered too. This PR fixes three gaps in the details.

### 1. IPv6 spellings of an IPv4 address bypassed the CIDR blocklist

`net.IPNet.Contains` normalizes IPv4-**mapped** addresses (`::ffff:a.b.c.d`) through `To4`. It does not normalize the other three IPv6 forms that also carry an IPv4 address:

| Spelling | Form | `To4()` | Blocked by `169.254.169.254/32` before this PR |
|---|---|---|---|
| `::ffff:169.254.169.254` | IPv4-mapped | `169.254.169.254` | yes |
| `::169.254.169.254` | IPv4-compatible (RFC 4291) | `nil` | no |
| `64:ff9b::a9fe:a9fe` | NAT64 well-known prefix (RFC 6052) | `nil` | no |
| `2002:a9fe:a9fe::` | 6to4 (RFC 3056) | `nil` | no |

So `url: http://[64:ff9b::a9fe:a9fe]/latest/meta-data/` passed both phases and reached the metadata service.

NAT64 is the form that matters in practice, because it is standard in IPv6-only clusters and is exactly how an IPv4 metadata endpoint gets reached over IPv6. The other two are deprecated and need specific routing, so they are defense in depth.

A new `embeddedIPv4` helper extracts the carried address, and a new `egressPolicy.blockedCIDR` method checks both the address and its embedded form. It replaces the two duplicated `blockedIP` closures, so all four check sites are covered: the literal and resolved branches of both `dialContext` and `validateHostCIDRs`.

`embeddedIPv4` also matches low IPv6 addresses that were never an IPv4 encoding, such as `::1` yielding `0.0.0.1`. That only widens the blocklist into reserved space, so it is left as is and noted in the doc comment.

### 2. The proxy path rejected every hostname destination

#17299 made `proxyAwareDestinationCheck` fail closed on all hostname destinations, because the proxy re-resolves the name and the checked address is not pinned the way the direct-dial path pins it. That is correct about the rebinding window, but it breaks proxied egress that works today: a cluster that egresses through an HTTP proxy commonly cannot resolve external names in-pod, which is the whole point of `HTTP_PROXY`.

This PR takes the middle ground:

- The destination resolves into a blocked range: **rejected**.
- The destination resolves outside every blocked range: **permitted**.
- The destination is unresolvable in-pod and `--httpAllowlist` is unset: **rejected**, with an error that reads as a policy decision and names the ways out.
- The destination is unresolvable in-pod and `--httpAllowlist` is set: **permitted**, logged at `V(2)`.

The allowlist escape is safe because every request that reaches the proxy function has already been matched against the allowlist by `validateURL`, both for the initial URL and for each redirect hop through `checkServiceRedirect`. So "an allowlist is configured" means "this host is on it."

The residual rebinding window on proxied hostnames is accepted. The hostname blocklist and the allowlist both still apply, and corporate egress proxies do not route to link-local.

### 3. Block messages named the resolved IP

Two sites embedded the resolved address in the returned error. Those errors propagate through `RuleError` into the admission denial text, PolicyReports and Events, which turned a denial into a DNS resolution oracle: a caller who can influence a substituted `service.url` learned how an arbitrary name resolves from the controller's vantage point.

The resolved address now goes to `V(2)` logs. The blocked range stays in the message, because the operator configured that value and it tells them which entry fired. Literal addresses also stay in their messages, because the caller supplied them and there is nothing to leak.

### 4. Two dial regressions the guard itself introduced

Not part of #17292. #17234 replaced the stock dialer with a serial walk over the resolved addresses, which lost two behaviours `net.Dialer` provided:

- **The 30s timeout was per address, and resolution sat outside it.** A hostname answering with many black-holed addresses held an admission request for DNS time plus 30s x N.
- **Happy Eyeballs was lost.** Given a hostname, `net.Dialer` interleaves address families with a 300ms stagger (RFC 6555). A serial walk over a flat list does not, so a dual-stack Service whose AAAA is present but not listening waited out the entire IPv6 side before trying IPv4.

`Timeout` is dropped from the `net.Dialer` and replaced with one `context.WithTimeout` spanning resolution and every attempt; a shorter deadline already on `ctx` still wins. Validated targets are split by address family, and when both are present the two groups race with a `fallbackDelay` head start for the preferred one, the loser cancelled and its channel drained so a late connection is closed rather than leaked. Every dial still targets an address that was just validated, so the rebinding pin is unchanged.

### Scope decisions

The issue lists two default-blocklist additions as adjacent and separable. This PR adds `fd00:ec2::254/128`, the AWS IMDS IPv6 endpoint, which was reachable with no encoding trick at all and has no in-cluster impact. It leaves `169.254.0.0/16` out, because #15973 narrowed the list specifically to let in-cluster HTTP calls through, and widening link-local back out reverses the axis that PR was tuning. Happy to add it if maintainers prefer.

## Related issue

Closes #17292

## Milestone of this PR

## Documentation (required for features)

Not a feature. No user-facing configuration changes beyond one new entry in the built-in default blocklist.

## What type of PR is this

/kind bug

## Proposed Changes

### Proof manifests

Kyverno policy that reaches the metadata service over NAT64. Before this PR the `apiCall` succeeds and the response lands in the admission denial; after it, the connection is blocked.

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: nat64-metadata-probe
spec:
  rules:
    - name: probe
      match:
        any:
          - resources:
              kinds:
                - ConfigMap
      context:
        - name: metadata
          apiCall:
            method: GET
            service:
              url: http://[64:ff9b::a9fe:a9fe]/latest/meta-data/
      validate:
        message: "reached {{ metadata }}"
        deny:
          conditions:
            all:
              - key: "true"
                operator: Equals
                value: "true"
```

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: probe-target
  namespace: default
data:
  key: value
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further comments

New tests, all of which fail on `main`:

- `Test_ExecuteServiceCall_BlocksEmbeddedIPv4EncodingsByDefault` drives all four encodings plus `2002:7f00:1::` through `Execute` against the shipped default blocklist, so it exercises the real `dialContext` wiring rather than the helper in isolation.
- `Test_EmbeddedIPv4` covers the extraction directly, including negatives: `2001:db8::1` and `fd00:ec2::254` must not be read as carrying an IPv4 address.
- `Test_ExecuteServiceCall_BlocksIMDSIPv6EndpointByDefault` covers the new default entry.
- Five `Test_ProxyAwareDestinationCheck_*` cases cover the matrix in point 2, including that an allowlist does not excuse a destination that resolves into a blocked range.
- `Test_ValidateHostCIDRs_BlockedErrorDoesNotNameResolvedAddress` and `Test_DialContext_BlockedErrorDoesNotNameResolvedAddress` assert the absence of the resolved address, with `Test_ValidateHostCIDRs_LiteralAddressStaysInError` asserting the address is still reported when the caller supplied it.

- `Test_DialContext_FallsBackToOtherAddressFamily` stubs the resolver to `["2001:db8::1", "127.0.0.1"]` with a real listener on the IPv4 address and asserts the dial still succeeds.
- `Test_DialContext_DeadlineIsSharedAcrossAttempts` stubs the connection-attempt seam, resolves to four same-family addresses so it exercises `dialSeries` rather than the race, and asserts on the context handed to each attempt: every attempt carries a deadline, all four deadlines are equal within 1ms, and the first is one `dialTimeout` from the start of the dial.
- `Test_DialContext_DeadlineRespectsShorterParent` asserts a 2s caller deadline wins over `dialTimeout`.

Resolution runs through a new `lookupHost` package variable so tests can force a specific answer or failure. The unresolvable branch in point 2 cannot be tested reliably against real DNS.

The deadline test asserts on the context rather than on elapsed time, and that is deliberate. An earlier version timed a dial against four `2001:db8::` addresses, but `2001:db8::/32` is the documentation range: on any host without an IPv6 route it fails instantly rather than hanging, so that test passed just as happily against the per-address-timeout code it was meant to catch. Reverting to `&net.Dialer{Timeout: dialTimeout}` with no `context.WithTimeout` now fails with *"each attempt must run under a deadline, not an open-ended context"*.

`Test_DialContext_FallsBackToOtherAddressFamily` still uses real addresses and a real listener, and takes 0.30s locally, which is exactly `fallbackDelay` — so it does exercise the race path.


