### PR TITLE
fix: avoid data race in image evaluator prefetch

### DIFF
--- a/pkg/image/verification/evaluator/policy.go
+++ b/pkg/image/verification/evaluator/policy.go
@@ -180,8 +180,12 @@ func (c *compiledPolicy) Evaluate(ctx context.Context, ictx imagedataloader.Imag
 		return result, err
 	}
 
-	if err := ictx.AddImages(ctx, imgList, c.authOpts, c.nameOpts); err != nil {
-		return nil, err
+	// Prefetch image data through Get() one image at a time to avoid triggering
+	// racy concurrent map writes in the SDK AddImages() implementation.
+	for _, image := range imgList {
+		if _, err := ictx.Get(ctx, image, c.authOpts, c.nameOpts); err != nil {
+			return nil, err
+		}
 	}
 
 	data[engine.ImagesKey] = filteredImages


### PR DESCRIPTION
## Summary
- replace `ictx.AddImages(...)` prefetch in IVPol evaluator with per-image `ictx.Get(...)`
- avoid triggering concurrent map writes in SDK `imageContext.AddImages`
- preserve existing evaluator behavior and error propagation

## Validation
- `go test -race ./pkg/image/verification/evaluator -count=1`

## Context
This fixes the race seen in CI on PR #17294 (Unit tests, race detector) in `pkg/image/verification/evaluator`.
