### PR TITLE
fix(jmespath): correct function name for invalid time_add arguments

### DIFF
--- a/pkg/engine/jmespath/time.go
+++ b/pkg/engine/jmespath/time.go
@@ -100,9 +100,9 @@ func jpTimeToCron(arguments []interface{}) (interface{}, error) {
 }
 
 func jpTimeAdd(arguments []interface{}) (interface{}, error) {
-	if t, err := getTimeArg(timeToCron, arguments, 0); err != nil {
+	if t, err := getTimeArg(timeAdd, arguments, 0); err != nil {
 		return nil, err
-	} else if d, err := getDurationArg(timeToCron, arguments, 1); err != nil {
+	} else if d, err := getDurationArg(timeAdd, arguments, 1); err != nil {
 		return nil, err
 	} else {
 		return t.Add(d).Format(time.RFC3339), nil

--- a/pkg/engine/jmespath/time_test.go
+++ b/pkg/engine/jmespath/time_test.go
@@ -3,6 +3,7 @@ package jmespath
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -531,4 +532,17 @@ func Test_jpTimeBetween(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_TimeAdd_ValidationErrors(t *testing.T) {
+	t.Run("invalid first argument type", func(t *testing.T) {
+		_, err := jpTimeAdd([]interface{}{12345, "3h"})
+		assert.ErrorContains(t, err, "time_add")
+		assert.Assert(t, !strings.Contains(err.Error(), "time_to_cron"), "error should not mention time_to_cron")
+	})
+	t.Run("invalid second argument type", func(t *testing.T) {
+		_, err := jpTimeAdd([]interface{}{"2021-01-02T15:04:05-07:00", 3})
+		assert.ErrorContains(t, err, "time_add")
+		assert.Assert(t, !strings.Contains(err.Error(), "time_to_cron"), "error should not mention time_to_cron")
+	})
 }


### PR DESCRIPTION
## What

Fix the incorrect JMESPath function name reported in validation errors from `time_add`.

`jpTimeAdd()` was passing `timeToCron` instead of `timeAdd` to the argument validation helpers.

## Why

When `time_add` receives an invalid argument, the resulting error incorrectly identifies the function as `time_to_cron`.

This is misleading for users because the error originates from `time_add`. Using the correct `timeAdd` constant ensures validation errors report the actual function being called.

## Testing

Added regression tests covering invalid first and second arguments to `time_add`.

Tested with:

```bash
go test -count=1 ./pkg/engine/jmespath/...
```

All tests passed.

Fixes #17112
