### PR TITLE
Fix silent dropping of negative priorities in CEL reconcilers

### DIFF
--- a/pkg/cel/policies/gpol/engine/engine.go
+++ b/pkg/cel/policies/gpol/engine/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -143,10 +144,9 @@ func (e *engineImpl) generate(
 		genericpolex := make([]engineapi.GenericException, 0, len(exceptions))
 		keys := make([]string, 0, len(exceptions))
 
-		var (
-			highestPriority int
-			selectedIndex   int
-		)
+		highestPriority := math.MinInt
+		var selectedIndex int
+
 		for i, ex := range exceptions {
 			key, err := cache.MetaNamespaceKeyFunc(ex)
 			if err != nil {
@@ -163,11 +163,16 @@ func (e *engineImpl) generate(
 			genericpolex = append(genericpolex, engineapi.NewCELPolicyException(ex))
 
 			// evaluate exception priority from label
+			p := 0
 			if val, ok := ex.GetLabels()[reportutils.LabelPolicyExceptionPriority]; ok {
-				if p, err := strconv.Atoi(val); err == nil && p > highestPriority {
-					highestPriority = p
-					selectedIndex = i
+				if parsed, err := strconv.Atoi(val); err == nil {
+					p = parsed
 				}
+			}
+
+			if p > highestPriority {
+				highestPriority = p
+				selectedIndex = i
 			}
 		}
 		// determine final result based on highest-priority exception

--- a/pkg/cel/policies/mpol/engine/engine.go
+++ b/pkg/cel/policies/mpol/engine/engine.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -217,10 +218,9 @@ func (e *engineImpl) handlePolicy(ctx context.Context, mpol Policy, attr admissi
 		exceptions := make([]engineapi.GenericException, 0, len(result.Exceptions))
 		keys := make([]string, 0, len(result.Exceptions))
 
-		var (
-			highestPriority int
-			selectedIndex   int
-		)
+		highestPriority := math.MinInt
+		var selectedIndex int
+
 		for i, ex := range result.Exceptions {
 			key, err := cache.MetaNamespaceKeyFunc(ex)
 			if err != nil {
@@ -240,11 +240,16 @@ func (e *engineImpl) handlePolicy(ctx context.Context, mpol Policy, attr admissi
 			exceptions = append(exceptions, engineapi.NewCELPolicyException(ex))
 
 			// evaluate exception priority from label
+			p := 0
 			if val, ok := ex.GetLabels()[reportutils.LabelPolicyExceptionPriority]; ok {
-				if p, err := strconv.Atoi(val); err == nil && p > highestPriority {
-					highestPriority = p
-					selectedIndex = i
+				if parsed, err := strconv.Atoi(val); err == nil {
+					p = parsed
 				}
+			}
+
+			if p > highestPriority {
+				highestPriority = p
+				selectedIndex = i
 			}
 		}
 		// determine final result based on highest-priority exception

--- a/pkg/cel/policies/vpol/engine/engine.go
+++ b/pkg/cel/policies/vpol/engine/engine.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -141,10 +142,9 @@ func (e *engineImpl) handlePolicy(ctx context.Context, policy Policy, jsonPayloa
 		exceptions := make([]engineapi.GenericException, 0, len(result.Exceptions))
 		keys := make([]string, 0, len(result.Exceptions))
 
-		var (
-			highestPriority int
-			selectedIndex   int
-		)
+		highestPriority := math.MinInt
+		var selectedIndex int
+
 		for i, ex := range result.Exceptions {
 			key, err := cache.MetaNamespaceKeyFunc(ex)
 			if err != nil {
@@ -164,11 +164,16 @@ func (e *engineImpl) handlePolicy(ctx context.Context, policy Policy, jsonPayloa
 			exceptions = append(exceptions, engineapi.NewCELPolicyException(ex))
 
 			// evaluate exception priority from label
+			p := 0
 			if val, ok := ex.GetLabels()[reportutils.LabelPolicyExceptionPriority]; ok {
-				if p, err := strconv.Atoi(val); err == nil && p > highestPriority {
-					highestPriority = p
-					selectedIndex = i
+				if parsed, err := strconv.Atoi(val); err == nil {
+					p = parsed
 				}
+			}
+
+			if p > highestPriority {
+				highestPriority = p
+				selectedIndex = i
 			}
 		}
 		// determine final result based on highest-priority exception


### PR DESCRIPTION
## Explanation
Fix a bug in the CEL policy engines (`vpol`, `mpol`, and `gpol`) where policies containing exception rules with negative priorities were ignored. The loop evaluating priorities incorrectly initialized `highestPriority` to `0`, which caused any exceptions with negative priority to be silently dropped. This fix uses `math.MinInt` for initialization, ensuring negative priorities are handled properly, and provides a default of `0` when no valid priority label exists.

## Related issue
Fixes #17319

## Milestone of this PR
/milestone TBD

## What type of PR is this
/kind bug

## Proposed Changes
- Import `math` in `pkg/cel/policies/vpol/engine/engine.go`, `pkg/cel/policies/mpol/engine/engine.go`, and `pkg/cel/policies/gpol/engine/engine.go`.
- Initialize `highestPriority` to `math.MinInt` instead of `0`.
- Explicitly default to `0` priority if a priority label is missing or invalid.

### Proof Manifests
Not applicable.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments
N/A
