### PR TITLE
fix(reports): filter rule status in GenerationEngineResponseToReportR…

### DIFF
--- a/pkg/utils/report/results.go
+++ b/pkg/utils/report/results.go
@@ -325,11 +325,11 @@ func MutationEngineResponseToReportResults(response engineapi.EngineResponse) []
 func GenerationEngineResponseToReportResults(response engineapi.EngineResponse) []openreportsv1alpha1.ReportResult {
 	results := make([]openreportsv1alpha1.ReportResult, 0, len(response.PolicyResponse.Rules))
 	for _, ruleResult := range response.PolicyResponse.Rules {
+		if !ReportingCfg.IsStatusAllowed(ruleResult.Status()) {
+			continue
+		}
 		result := ToPolicyReportResult(response.Policy(), ruleResult, nil)
 		if generatedResources := ruleResult.GeneratedResources(); len(generatedResources) != 0 {
-			if !ReportingCfg.IsStatusAllowed(ruleResult.Status()) {
-				continue
-			}
 			property := make([]string, 0, len(generatedResources))
 			for _, r := range generatedResources {
 				property = append(property, getResourceInfo(r.GroupVersionKind(), r.GetName(), r.GetNamespace()))

--- a/pkg/utils/report/results_test.go
+++ b/pkg/utils/report/results_test.go
@@ -314,3 +314,50 @@ func TestToPolicyReportResult_ConcurrentAccess(t *testing.T) {
 		assert.Equal(t, "resource is compliant", r.Description, "goroutine %d", i)
 	}
 }
+
+func Test_GenerationEngineResponseToReportResults(t *testing.T) {
+	oldReportingCfg := ReportingCfg
+	defer func() {
+		ReportingCfg = oldReportingCfg
+	}()
+	ReportingCfg = nil
+	NewReportingConfig([]string{"fail"}, "generate")
+
+	// 1. Create a Skip rule result with empty generated resources
+	skipProps := map[string]string{}
+	skipRule := engineapi.NewRuleResponse(
+		"generate-skip",
+		engineapi.Generation,
+		"rule skipped",
+		engineapi.RuleStatusSkip,
+		skipProps,
+	)
+
+	// 2. Create a Fail rule result with empty generated resources
+	failProps := map[string]string{}
+	failRule := engineapi.NewRuleResponse(
+		"generate-fail",
+		engineapi.Generation,
+		"rule failed",
+		engineapi.RuleStatusFail,
+		failProps,
+	)
+
+	// Create engine response with both rules and policy
+	pol := engineapi.NewKyvernoPolicy(&kyvernov1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-policy",
+		},
+	})
+	er := engineapi.EngineResponse{}.WithPolicy(pol)
+	er.PolicyResponse.Rules = append(er.PolicyResponse.Rules, *skipRule, *failRule)
+
+	// Call GenerationEngineResponseToReportResults
+	results := GenerationEngineResponseToReportResults(er)
+
+	// Assertions
+	// We expect only 1 result (failRule), and skipRule should be filtered out
+	assert.Equal(t, 1, len(results))
+	assert.Equal(t, "generate-fail", results[0].Rule)
+	assert.Equal(t, openreportsv1alpha1.Result(openreports.StatusFail), results[0].Result)
+}


### PR DESCRIPTION
### What

Follow up #17321  ,fix `--allowedResults` filtering in the generate-rule reporting path.

### Why

`GenerationEngineResponseToReportResults` previously performed the `IsStatusAllowed()` check only when generated resources were present. As a result, generate rule results with empty generated resources, such as `skip` or `error` results, could bypass the configured status filter and be included in reports.

The status check is now performed before processing each rule result, making the generate reporting path consistent with the validate and mutate paths.

### How Tested

Added a regression test covering generate rule results with empty generated resources:

* Configures reporting to allow only `fail`.
* Verifies a `skip` result is filtered out.
* Verifies a `fail` result is retained.

Validation performed:

* `go test -v ./pkg/utils/report/...` ✅
* `make imports-check fmt-check` ✅
