### PR TITLE
fix: use correct function name constant in jpTimeAdd error messages

### DIFF
--- a/pkg/engine/jmespath/time.go
+++ b/pkg/engine/jmespath/time.go
@@ -100,9 +100,9 @@ func jpTimeToCron(arguments []interface{}) (interface{}, error) {
 }
 
 func jpTimeAdd(arguments []interface{}) (interface{}, error) {
-	if t, err := getTimeArg(timeToCron, arguments, 0); err != nil {
+	if t, err := getTimeArg(timeAdd, arguments, 0); err != nil {
 		return nil, err
-	} else if d, err := getDurationArg(timeToCron, arguments, 1); err != nil {
+	} else if d, err := getDurationArg(timeAdd, arguments, 1); err != nil {
 		return nil, err
 	} else {
 		return t.Add(d).Format(time.RFC3339), nil

--- a/pkg/engine/jmespath/time_test.go
+++ b/pkg/engine/jmespath/time_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
+	"strings"
 )
 
 func Test_TimeSince(t *testing.T) {
@@ -95,6 +96,34 @@ func Test_TimeAdd(t *testing.T) {
 			assert.Assert(t, ok)
 
 			assert.Equal(t, result, tc.expectedResult)
+		})
+	}
+}
+
+
+func Test_TimeAddErrorMessages(t *testing.T) {
+	testCases := []struct {
+		test     string
+		expected string
+	}{
+		{
+			test:     "time_add(1, '3h')",
+			expected: "time_add",
+		},
+		{
+			test:     "time_add('2021-01-02T15:04:05-07:00', 1)",
+			expected: "time_add",
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			query, err := jmespathInterface.Query(tc.test)
+			assert.NilError(t, err)
+
+			_, err = query.Search("")
+			assert.ErrorContains(t, err, tc.expected)
+			assert.Assert(t, !strings.Contains(err.Error(), "time_to_cron"),
+				"error should not contain time_to_cron")
 		})
 	}
 }


### PR DESCRIPTION
### Problem

The `jpTimeAdd` JMESPath function currently uses the `timeToCron` function-name constant when validating its arguments. As a result, validation errors produced by `time_add` incorrectly identify the failing function as `time_to_cron`.

For example, an invalid second argument produces:
```
JMESPath function 'time_to_cron': argument #2 is not of type string
```

### Fix

Changed `timeToCron` → `timeAdd` in both `getTimeArg()` and `getDurationArg()` calls inside `jpTimeAdd()` in `pkg/engine/jmespath/time.go`.

### Testing

Added `Test_TimeAddErrorMessages` in `pkg/engine/jmespath/time_test.go` covering:
- Invalid first argument type → error contains `time_add`
- Invalid second argument type → error contains `time_add`
- Error does not contain `time_to_cron`

Fixes #17314