### PR TITLE
fix(test): loosen chainsaw stderr checks to contains

### DIFF
--- a/test/conformance/chainsaw/globalcontext/apicall-correct-projection/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-correct-projection/chainsaw-test.yaml
@@ -35,12 +35,6 @@ spec:
           content: kubectl apply -f new-deployment.yaml
           check:
             ($error != null): true
-            # This check ensures the contents of stderr are exactly as shown.
-            (trim_space($stderr)): |-
-              Error from server: error when creating "new-deployment.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 
-              
-              resource Deployment/test-globalcontext-apicall-correct-projections/new-deployment was blocked due to the following policies 
-              
-              cpol-apicall-projections:
-                autogen-main-deployment-exists: 'validation error: rule autogen-main-deployment-exists
-                  failed'
+            (contains($stderr, 'denied the request')): true
+            (contains($stderr, 'cpol-apicall-projections')): true
+            (contains($stderr, 'autogen-main-deployment-exists')): true

--- a/test/conformance/chainsaw/globalcontext/apicall-failed/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/globalcontext/apicall-failed/chainsaw-test.yaml
@@ -36,14 +36,6 @@ spec:
             content: kubectl apply -f new-deployment.yaml
             check:
               ($error != null): true
-              # This check ensures the contents of stderr are exactly as shown.
-              (trim_space($stderr)): |-
-                Error from server: error when creating "new-deployment.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 
-        
-                resource Deployment/test-globalcontext-apicall-failed/new-deployment was blocked due to the following policies 
-                
-                cpol-apicall-failed:
-                  autogen-main-deployment-exists: 'failed to check deny conditions: failed to substitute
-                    variables in condition key: failed to resolve deploymentCount at path : failed
-                    to marshal APICall data for context entry deploymentCount: failed to GET resource
-                    with raw url: /apis/apps/v1/namespaces/default/unknown: permission denied: unknown'
+              (contains($stderr, 'denied the request')): true
+              (contains($stderr, 'cpol-apicall-failed')): true
+              (contains($stderr, 'permission denied')): true

--- a/test/conformance/chainsaw/globalcontext/gctxentry-not-exist/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/globalcontext/gctxentry-not-exist/chainsaw-test.yaml
@@ -32,14 +32,6 @@ spec:
             content: kubectl apply -f new-deployment.yaml
             check:
               ($error != null): true
-              # This check ensures the contents of stderr are exactly as shown.
-              (trim_space($stderr)): |-
-                Error from server: error when creating "new-deployment.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 
-        
-                resource Deployment/test-globalcontext-gctxentry-not-exist/new-deployment was blocked due to the following policies 
-                
-                cpol-gctxentry-not-exist:
-                  autogen-main-deployment-exists: 'failed to check deny conditions: failed to substitute
-                    variables in condition key: failed to resolve deploymentCount at path : failed
-                    to marshal APICall data for context entry deploymentCount: failed to fetch entry
-                    key=non-existent-gctx'
+              (contains($stderr, 'denied the request')): true
+              (contains($stderr, 'cpol-gctxentry-not-exist')): true
+              (contains($stderr, 'non-existent-gctx')): true

--- a/test/conformance/chainsaw/globalcontext/resource-correct-projection/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/globalcontext/resource-correct-projection/chainsaw-test.yaml
@@ -35,12 +35,6 @@ spec:
           content: kubectl apply -f new-deployment.yaml
           check:
             ($error != null): true
-            # This check ensures the contents of stderr are exactly as shown.
-            (trim_space($stderr)): |-
-              Error from server: error when creating "new-deployment.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 
-              
-              resource Deployment/test-globalcontext-resource-correct-projections/new-deployment was blocked due to the following policies 
-              
-              cpol-resource-projections:
-                autogen-main-deployment-exists: 'validation error: rule autogen-main-deployment-exists
-                  failed'
+            (contains($stderr, 'denied the request')): true
+            (contains($stderr, 'cpol-resource-projections')): true
+            (contains($stderr, 'autogen-main-deployment-exists')): true

--- a/test/conformance/chainsaw/policy-validation/cluster-policy/invalid-pod-security-exceptions/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/policy-validation/cluster-policy/invalid-pod-security-exceptions/chainsaw-test.yaml
@@ -12,24 +12,23 @@ spec:
             content: kubectl apply -f exception-1.yaml
             check:
               ($error != null): true
-              # This check ensures the contents of stderr are exactly as shown.
-              (trim_space($stderr)): |-
-                Error from server: error when creating "exception-1.yaml": admission webhook "kyverno-svc.kyverno.svc" denied the request: [spec.podSecurity[0].controlName: Invalid value: "Capabilities": exclude.images must be specified for the container level control, spec.podSecurity[3].controlName: Invalid value: "Privilege Escalation": exclude.images must be specified for the container level control]
+              (contains($stderr, 'denied the request')): true
+              (contains($stderr, 'exclude.images must be specified')): true
     - name: Apply the second policy exception
       try:
         - script:
             content: kubectl apply -f exception-2.yaml
             check:
               ($error != null): true
-              # This check ensures the contents of stderr are exactly as shown.
-              (trim_space($stderr)): |-
-                Error from server: error when creating "exception-2.yaml": admission webhook "kyverno-svc.kyverno.svc" denied the request: spec.podSecurity[0].values: Forbidden: values is required
+              (contains($stderr, 'denied the request')): true
+              (contains($stderr, 'spec.podSecurity[0].values')): true
+              (contains($stderr, 'values is required')): true
     - name: Apply the third policy exception
       try:
         - script:
             content: kubectl apply -f exception-3.yaml
             check:
               ($error != null): true
-              # This check ensures the contents of stderr are exactly as shown.
-              (trim_space($stderr)): |-
-                Error from server: error when creating "exception-3.yaml": admission webhook "kyverno-svc.kyverno.svc" denied the request: spec.podSecurity[0].restrictedField: Forbidden: restrictedField is required
+              (contains($stderr, 'denied the request')): true
+              (contains($stderr, 'spec.podSecurity[0].restrictedField')): true
+              (contains($stderr, 'restrictedField is required')): true

--- a/test/conformance/chainsaw/policy-validation/cluster-policy/invalid-pod-security-exceptions/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/policy-validation/cluster-policy/invalid-pod-security-exceptions/chainsaw-test.yaml
@@ -14,6 +14,8 @@ spec:
               ($error != null): true
               (contains($stderr, 'denied the request')): true
               (contains($stderr, 'exclude.images must be specified')): true
+              (contains($stderr, 'Capabilities')): true
+              (contains($stderr, 'Privilege Escalation')): true
     - name: Apply the second policy exception
       try:
         - script:

--- a/test/conformance/chainsaw/policy-validation/cluster-policy/invalid-pod-security-rule/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/policy-validation/cluster-policy/invalid-pod-security-rule/chainsaw-test.yaml
@@ -12,15 +12,15 @@ spec:
         content: kubectl apply -f policy-1.yaml
         check:
           ($error != null): true
-          # This check ensures the contents of stderr are exactly as shown.  
-          (trim_space($stderr)): |-
-            Error from server: error when creating "policy-1.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: spec.rules[0].podSecurity.exclude[0].values: Forbidden: values is required
+          (contains($stderr, 'denied the request')): true
+          (contains($stderr, 'spec.rules[0].podSecurity.exclude[0].values')): true
+          (contains($stderr, 'values is required')): true
   - name: Apply the second policy
     try:
     - script:
         content: kubectl apply -f policy-2.yaml
         check:
           ($error != null): true
-          # This check ensures the contents of stderr are exactly as shown.  
-          (trim_space($stderr)): |-
-            Error from server: error when creating "policy-2.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: spec.rules[0].podSecurity.exclude[0].restrictedField: Forbidden: restrictedField is required
+          (contains($stderr, 'denied the request')): true
+          (contains($stderr, 'spec.rules[0].podSecurity.exclude[0].restrictedField')): true
+          (contains($stderr, 'restrictedField is required')): true

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/check-message-upon-resource-failure-deprecated/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/check-message-upon-resource-failure-deprecated/chainsaw-test.yaml
@@ -42,5 +42,6 @@ spec:
          ($error != null): true
          (contains($stderr, 'denied the request')): true
          (contains($stderr, 'require-ns-owner-label')): true
+         (contains($stderr, 'check-for-namespace-owner-label')): true
          (contains($stderr, 'uw.systems/owner')): true
          (contains($stderr, 'preconditions-check')): false

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/check-message-upon-resource-failure-deprecated/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/check-message-upon-resource-failure-deprecated/chainsaw-test.yaml
@@ -39,14 +39,8 @@ spec:
     - script:
        content: kubectl apply -f resource.yaml
        check:
-         # This check ensures the contents of stderr are exactly as shown.
-         (trim_space($stderr)): |-
-           Error from server: error when creating "resource.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 
-
-           resource Namespace//asdfhl was blocked due to the following policies 
-
-           require-ns-owner-label:
-             check-for-namespace-owner-label: 'validation error: The label `uw.systems/owner`
-               is required. Check policy at https://github.com/utilitywarehouse/system-manifests/tree/master/kyverno/policies/namespaces/require-ns-owner-label.yaml
-               for allowed label values. rule check-for-namespace-owner-label failed at path
-               /metadata/labels/uw.systems/owner/'
+         ($error != null): true
+         (contains($stderr, 'denied the request')): true
+         (contains($stderr, 'require-ns-owner-label')): true
+         (contains($stderr, 'uw.systems/owner')): true
+         (contains($stderr, 'preconditions-check')): false

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/check-message-upon-resource-failure/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/check-message-upon-resource-failure/chainsaw-test.yaml
@@ -42,5 +42,6 @@ spec:
          ($error != null): true
          (contains($stderr, 'denied the request')): true
          (contains($stderr, 'require-ns-owner-label')): true
+         (contains($stderr, 'check-for-namespace-owner-label')): true
          (contains($stderr, 'uw.systems/owner')): true
          (contains($stderr, 'preconditions-check')): false

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/check-message-upon-resource-failure/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/check-message-upon-resource-failure/chainsaw-test.yaml
@@ -39,14 +39,8 @@ spec:
     - script:
        content: kubectl apply -f resource.yaml
        check:
-         # This check ensures the contents of stderr are exactly as shown.
-         (trim_space($stderr)): |-
-           Error from server: error when creating "resource.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 
-
-           resource Namespace//asdfhl was blocked due to the following policies 
-
-           require-ns-owner-label:
-             check-for-namespace-owner-label: 'validation error: The label `uw.systems/owner`
-               is required. Check policy at https://github.com/utilitywarehouse/system-manifests/tree/master/kyverno/policies/namespaces/require-ns-owner-label.yaml
-               for allowed label values. rule check-for-namespace-owner-label failed at path
-               /metadata/labels/uw.systems/owner/'
+         ($error != null): true
+         (contains($stderr, 'denied the request')): true
+         (contains($stderr, 'require-ns-owner-label')): true
+         (contains($stderr, 'uw.systems/owner')): true
+         (contains($stderr, 'preconditions-check')): false

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/invalid-jmespath-variable-substitution-deprecated/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/invalid-jmespath-variable-substitution-deprecated/chainsaw-test.yaml
@@ -26,14 +26,6 @@ spec:
         content: kubectl apply -f pod.yaml  
         check:  
           ($error != null): true
-          # This check ensures the contents of stderr are exactly as shown.  
-          (trim_space($stderr)): |-
-            Error from server: error when creating "pod.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 
-        
-            resource Pod/default/test was blocked due to the following policies 
-            
-            test-panic:
-              test-panic: 'failed to check deny conditions: failed to substitute variables in
-                condition key: failed to resolve image at path : jmespath value must be a string
-                image {{ request.object.spec.[containers,initContainers, ephemeralContainers][].image[]
-                }}: <nil>'
+          (contains($stderr, 'denied the request')): true
+          (contains($stderr, 'test-panic')): true
+          (contains($stderr, 'jmespath value must be a string')): true

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/invalid-jmespath-variable-substitution/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/invalid-jmespath-variable-substitution/chainsaw-test.yaml
@@ -26,14 +26,6 @@ spec:
         content: kubectl apply -f pod.yaml  
         check:  
           ($error != null): true
-          # This check ensures the contents of stderr are exactly as shown.  
-          (trim_space($stderr)): |-
-            Error from server: error when creating "pod.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 
-        
-            resource Pod/default/test was blocked due to the following policies 
-            
-            test-panic:
-              test-panic: 'failed to check deny conditions: failed to substitute variables in
-                condition key: failed to resolve image at path : jmespath value must be a string
-                image {{ request.object.spec.[containers,initContainers, ephemeralContainers][].image[]
-                }}: <nil>'
+          (contains($stderr, 'denied the request')): true
+          (contains($stderr, 'test-panic')): true
+          (contains($stderr, 'jmespath value must be a string')): true

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/variable-substitution-failure-messages-deprecated/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/variable-substitution-failure-messages-deprecated/chainsaw-test.yaml
@@ -26,17 +26,8 @@ spec:
         content: kubectl apply -f pod.yaml  
         check:  
           ($error != null): true
-          # This check ensures the contents of stderr are exactly as shown.  
-          (trim_space($stderr)): |-
-            Error from server: error when creating "pod.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 
-
-            resource Pod/default/ba was blocked due to the following policies 
-
-            uid-groups-fsgroup-validate:
-              check-runasuser: 'validation error: Running with specific user IDs 9999 | 4000.
-                The fields spec.securityContext.runAsGroup, spec.containers[*].securityContext.runAsGroup,
-                spec.initContainers[*].securityContext.runAsGroup, and spec.ephemeralContainers[*].securityContext.runAsGroup
-                must be set to one of the 9999 | 4000 values. rule check-runasuser[0] failed at
-                path /spec/containers/0/securityContext/runAsUser/ rule check-runasuser[1] failed
-                at path /spec/containers/0/securityContext/runAsUser/'
+          (contains($stderr, 'denied the request')): true
+          (contains($stderr, 'uid-groups-fsgroup-validate')): true
+          (contains($stderr, 'check-runasuser')): true
+          (contains($stderr, '9999 | 4000')): true
        

--- a/test/conformance/chainsaw/validate/clusterpolicy/cornercases/variable-substitution-failure-messages/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/cornercases/variable-substitution-failure-messages/chainsaw-test.yaml
@@ -26,17 +26,8 @@ spec:
         content: kubectl apply -f pod.yaml  
         check:  
           ($error != null): true
-          # This check ensures the contents of stderr are exactly as shown.  
-          (trim_space($stderr)): |-
-            Error from server: error when creating "pod.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 
-
-            resource Pod/default/ba was blocked due to the following policies 
-
-            uid-groups-fsgroup-validate:
-              check-runasuser: 'validation error: Running with specific user IDs 9999 | 4000.
-                The fields spec.securityContext.runAsGroup, spec.containers[*].securityContext.runAsGroup,
-                spec.initContainers[*].securityContext.runAsGroup, and spec.ephemeralContainers[*].securityContext.runAsGroup
-                must be set to one of the 9999 | 4000 values. rule check-runasuser[0] failed at
-                path /spec/containers/0/securityContext/runAsUser/ rule check-runasuser[1] failed
-                at path /spec/containers/0/securityContext/runAsUser/'
+          (contains($stderr, 'denied the request')): true
+          (contains($stderr, 'uid-groups-fsgroup-validate')): true
+          (contains($stderr, 'check-runasuser')): true
+          (contains($stderr, '9999 | 4000')): true
        


### PR DESCRIPTION
## Explanation

This is a test-only fix, cherry-picked from #17235 onto `release-1.19`. A few chainsaw tests required the full kubectl error text to match exactly. so it fails when the same deny is wrapped onto one line

https://github.com/kyverno/kyverno/actions/runs/32730089560

## Related issue

Related to #17330

## Milestone of this PR

/milestone 1.19.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind failing-test

## Proposed Changes

Switch 12 chainsaw tests from exact `trim_space($stderr)` to `contains(...)`. No Kyverno behavior change.

The checks still require the command to fail, and they still assert the distinctive text:
- `9999 | 4000` for variable substitution
- `preconditions-check` must not appear for the skipped-policy case
- policy / rule / reason everywhere else

### Proof Manifests

```yaml

# before
($error != null): true
(trim_space($stderr)): |-
  Error from server: ... autogen-main-deployment-exists
    failed

# after
($error != null): true
(contains($stderr, 'denied the request')): true
(contains($stderr, 'cpol-apicall-projections')): true
(contains($stderr, 'autogen-main-deployment-exists')): true
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

Same change as #17235 on main. Do not close #17330 with this PR.