### PR TITLE
fix(engine): classify anchor errors correctly

### DIFF
--- a/pkg/engine/anchor/error.go
+++ b/pkg/engine/anchor/error.go
@@ -1,8 +1,8 @@
 package anchor
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 )
 
 // anchorError is the const specification of anchor errors
@@ -30,6 +30,9 @@ const (
 type validateAnchorError struct {
 	err     anchorError
 	message string
+	// cause is the underlying error this anchor error was built from, if any.
+	// It is exposed through Unwrap so that errors.As can walk the chain.
+	cause error
 }
 
 // Error implements error interface
@@ -37,11 +40,29 @@ func (e validateAnchorError) Error() string {
 	return e.message
 }
 
+// Unwrap implements the errors.Unwrap contract, returning the underlying cause
+// this anchor error was built from. It returns nil for anchor errors that are
+// not derived from another error.
+func (e validateAnchorError) Unwrap() error {
+	return e.cause
+}
+
 // newNegationAnchorError returns a new instance of validateAnchorError
 func newValidateAnchorError(err anchorError, prefix, msg string) validateAnchorError {
 	return validateAnchorError{
 		err:     err,
 		message: fmt.Sprintf("%s: %s", prefix, msg),
+	}
+}
+
+// wrapValidateAnchorError returns a new instance of validateAnchorError that
+// keeps a reference to the error it was built from. The rendered message is
+// identical to newValidateAnchorError(err, prefix, cause.Error()).
+func wrapValidateAnchorError(err anchorError, prefix string, cause error) validateAnchorError {
+	return validateAnchorError{
+		err:     err,
+		message: fmt.Sprintf("%s: %s", prefix, cause.Error()),
+		cause:   cause,
 	}
 }
 
@@ -60,30 +81,42 @@ func newGlobalAnchorError(msg string) validateAnchorError {
 	return newValidateAnchorError(globalAnchorErr, globalAnchorErrMsg, msg)
 }
 
-// isError checks if error matches the given error type
-func isError(err error, code anchorError, msg string) bool {
-	if err != nil {
-		if t, ok := err.(validateAnchorError); ok {
-			return t.err == code
-		} else {
-			// TODO: we shouldn't need this, error is not properly propagated
-			return strings.Contains(err.Error(), msg)
-		}
+// wrapConditionalAnchorError returns a conditional anchor error wrapping cause
+func wrapConditionalAnchorError(cause error) validateAnchorError {
+	return wrapValidateAnchorError(conditionalAnchorErr, conditionalAnchorErrMsg, cause)
+}
+
+// wrapGlobalAnchorError returns a global anchor error wrapping cause
+func wrapGlobalAnchorError(cause error) validateAnchorError {
+	return wrapValidateAnchorError(globalAnchorErr, globalAnchorErrMsg, cause)
+}
+
+// isError checks if err, or any error it wraps, is an anchor error of the given
+// type. Classification is based on the error type only: the error message is
+// never inspected, so an unrelated error cannot be misclassified just because
+// its text happens to contain an anchor error message.
+func isError(err error, code anchorError) bool {
+	if err == nil {
+		return false
+	}
+	var target validateAnchorError
+	if errors.As(err, &target) {
+		return target.err == code
 	}
 	return false
 }
 
 // IsNegationAnchorError checks if error is a negation anchor error
 func IsNegationAnchorError(err error) bool {
-	return isError(err, negationAnchorErr, negationAnchorErrMsg)
+	return isError(err, negationAnchorErr)
 }
 
 // IsConditionalAnchorError checks if error is a conditional anchor error
 func IsConditionalAnchorError(err error) bool {
-	return isError(err, conditionalAnchorErr, conditionalAnchorErrMsg)
+	return isError(err, conditionalAnchorErr)
 }
 
 // IsGlobalAnchorError checks if error is a global anchor error
 func IsGlobalAnchorError(err error) bool {
-	return isError(err, globalAnchorErr, globalAnchorErrMsg)
+	return isError(err, globalAnchorErr)
 }

--- a/pkg/engine/anchor/error_test.go
+++ b/pkg/engine/anchor/error_test.go
@@ -2,6 +2,7 @@ package anchor
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -163,7 +164,7 @@ func TestIsNegationAnchorError(t *testing.T) {
 		args: args{
 			err: errors.New("negation anchor matched in resource: test"),
 		},
-		want: true,
+		want: false,
 	}, {
 		args: args{
 			err: newConditionalAnchorError("test"),
@@ -206,7 +207,7 @@ func TestIsConditionalAnchorError(t *testing.T) {
 		args: args{
 			err: errors.New("conditional anchor mismatch: test"),
 		},
-		want: true,
+		want: false,
 	}, {
 		args: args{
 			err: newConditionalAnchorError("test"),
@@ -249,7 +250,7 @@ func TestIsGlobalAnchorError(t *testing.T) {
 		args: args{
 			err: errors.New("global anchor mismatch: test"),
 		},
-		want: true,
+		want: false,
 	}, {
 		args: args{
 			err: newConditionalAnchorError("test"),
@@ -270,6 +271,301 @@ func TestIsGlobalAnchorError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsGlobalAnchorError(tt.args.err); got != tt.want {
 				t.Errorf("IsGlobalAnchorError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// maskedError wraps an error while deliberately replacing the rendered message.
+// It models an error chain where the anchor error text is no longer visible, so
+// only type-based classification can succeed.
+type maskedError struct {
+	inner error
+}
+
+func (m maskedError) Error() string { return "an internal error occurred" }
+
+func (m maskedError) Unwrap() error { return m.inner }
+
+// Test_isError_doesNotClassifyByMessage is the regression test for the removed
+// strings.Contains fallback. Unrelated errors whose text happens to contain an
+// anchor error message must never be classified as anchor errors, because that
+// text can originate from resource content (see validateResourceElement, which
+// formats resource values into its error messages).
+func Test_isError_doesNotClassifyByMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{{
+		name: "conditional message, unrelated error",
+		err:  errors.New("conditional anchor mismatch: unrelated error"),
+	}, {
+		name: "global message, unrelated error",
+		err:  errors.New("global anchor mismatch: unrelated error"),
+	}, {
+		name: "negation message, unrelated error",
+		err:  errors.New("negation anchor matched in resource: unrelated error"),
+	}, {
+		name: "anchor message embedded in a resource value",
+		err:  errors.New("resource value 'conditional anchor mismatch' does not match 'platform' at path /metadata/annotations/owner/"),
+	}, {
+		name: "anchor message as a substring",
+		err:  errors.New("x-global anchor mismatch-y"),
+	}, {
+		name: "anchor message wrapped in an unrelated error",
+		err:  fmt.Errorf("failed to validate: %w", errors.New("negation anchor matched in resource: test")),
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsConditionalAnchorError(tt.err); got {
+				t.Errorf("IsConditionalAnchorError() = %v, want false", got)
+			}
+			if got := IsGlobalAnchorError(tt.err); got {
+				t.Errorf("IsGlobalAnchorError() = %v, want false", got)
+			}
+			if got := IsNegationAnchorError(tt.err); got {
+				t.Errorf("IsNegationAnchorError() = %v, want false", got)
+			}
+		})
+	}
+}
+
+// Test_isError_classifiesWrappedAnchorErrors verifies that classification walks
+// the error chain. Anchor errors are routinely aggregated by the validate
+// package (multierr.Combine inside a *PatternError) before reaching skip() and
+// fail(), so they are seldom directly type-assertable at the call site.
+func Test_isError_classifiesWrappedAnchorErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		wantCondition bool
+		wantGlobal    bool
+		wantNegation  bool
+	}{{
+		name:          "conditional, direct",
+		err:           newConditionalAnchorError("test"),
+		wantCondition: true,
+	}, {
+		name:          "conditional, wrapped with %w",
+		err:           fmt.Errorf("context: %w", newConditionalAnchorError("test")),
+		wantCondition: true,
+	}, {
+		name:          "conditional, wrapped and message masked",
+		err:           maskedError{inner: newConditionalAnchorError("test")},
+		wantCondition: true,
+	}, {
+		name:          "conditional, joined with an unrelated error",
+		err:           errors.Join(errors.New("unrelated"), newConditionalAnchorError("test")),
+		wantCondition: true,
+	}, {
+		name:          "conditional, nested two levels deep",
+		err:           fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", newConditionalAnchorError("test"))),
+		wantCondition: true,
+	}, {
+		name:       "global, direct",
+		err:        newGlobalAnchorError("test"),
+		wantGlobal: true,
+	}, {
+		name:       "global, wrapped with %w",
+		err:        fmt.Errorf("context: %w", newGlobalAnchorError("test")),
+		wantGlobal: true,
+	}, {
+		name:       "global, wrapped and message masked",
+		err:        maskedError{inner: newGlobalAnchorError("test")},
+		wantGlobal: true,
+	}, {
+		name:       "global, joined with an unrelated error",
+		err:        errors.Join(errors.New("unrelated"), newGlobalAnchorError("test")),
+		wantGlobal: true,
+	}, {
+		name:         "negation, direct",
+		err:          newNegationAnchorError("test"),
+		wantNegation: true,
+	}, {
+		name:         "negation, wrapped with %w",
+		err:          fmt.Errorf("context: %w", newNegationAnchorError("test")),
+		wantNegation: true,
+	}, {
+		name:         "negation, wrapped and message masked",
+		err:          maskedError{inner: newNegationAnchorError("test")},
+		wantNegation: true,
+	}, {
+		name:         "negation, joined with an unrelated error",
+		err:          errors.Join(errors.New("unrelated"), newNegationAnchorError("test")),
+		wantNegation: true,
+	}, {
+		name: "nil error",
+		err:  nil,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsConditionalAnchorError(tt.err); got != tt.wantCondition {
+				t.Errorf("IsConditionalAnchorError() = %v, want %v", got, tt.wantCondition)
+			}
+			if got := IsGlobalAnchorError(tt.err); got != tt.wantGlobal {
+				t.Errorf("IsGlobalAnchorError() = %v, want %v", got, tt.wantGlobal)
+			}
+			if got := IsNegationAnchorError(tt.err); got != tt.wantNegation {
+				t.Errorf("IsNegationAnchorError() = %v, want %v", got, tt.wantNegation)
+			}
+		})
+	}
+}
+
+// Test_wrapValidateAnchorError checks that the wrapping constructors preserve
+// the cause for errors.As traversal while rendering exactly the same message as
+// the string based constructors, so downstream messages are unchanged.
+func Test_wrapValidateAnchorError(t *testing.T) {
+	cause := errors.New("resource value does not match")
+
+	tests := []struct {
+		name    string
+		got     validateAnchorError
+		want    validateAnchorError
+		wantMsg string
+	}{{
+		name:    "conditional",
+		got:     wrapConditionalAnchorError(cause),
+		want:    newConditionalAnchorError(cause.Error()),
+		wantMsg: "conditional anchor mismatch: resource value does not match",
+	}, {
+		name:    "global",
+		got:     wrapGlobalAnchorError(cause),
+		want:    newGlobalAnchorError(cause.Error()),
+		wantMsg: "global anchor mismatch: resource value does not match",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// message must be identical to the non wrapping constructor
+			if tt.got.Error() != tt.want.Error() {
+				t.Errorf("Error() = %v, want %v", tt.got.Error(), tt.want.Error())
+			}
+			if tt.got.Error() != tt.wantMsg {
+				t.Errorf("Error() = %v, want %v", tt.got.Error(), tt.wantMsg)
+			}
+			// the anchor type must be preserved
+			if tt.got.err != tt.want.err {
+				t.Errorf("err = %v, want %v", tt.got.err, tt.want.err)
+			}
+			// the cause must stay reachable
+			if !errors.Is(tt.got, cause) {
+				t.Errorf("errors.Is(got, cause) = false, want true")
+			}
+			if got := tt.got.Unwrap(); got != cause {
+				t.Errorf("Unwrap() = %v, want %v", got, cause)
+			}
+		})
+	}
+}
+
+// Test_validateAnchorError_Unwrap checks that anchor errors built without a
+// cause report no cause, so errors.As stops cleanly at them.
+func Test_validateAnchorError_Unwrap(t *testing.T) {
+	tests := []struct {
+		name string
+		err  validateAnchorError
+	}{
+		{name: "negation", err: newNegationAnchorError("test")},
+		{name: "conditional", err: newConditionalAnchorError("test")},
+		{name: "global", err: newGlobalAnchorError("test")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Unwrap(); got != nil {
+				t.Errorf("Unwrap() = %v, want nil", got)
+			}
+		})
+	}
+}
+
+// Test_isError_distinguishesAnchorTypes guards the internal anchorError enum:
+// each anchor type must remain distinguishable from the other two, including
+// when the error is wrapped.
+func Test_isError_distinguishesAnchorTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		err  validateAnchorError
+		want anchorError
+	}{
+		{name: "conditional", err: newConditionalAnchorError("test"), want: conditionalAnchorErr},
+		{name: "global", err: newGlobalAnchorError("test"), want: globalAnchorErr},
+		{name: "negation", err: newNegationAnchorError("test"), want: negationAnchorErr},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapped := []error{tt.err, fmt.Errorf("ctx: %w", tt.err), maskedError{inner: tt.err}}
+			codes := []anchorError{conditionalAnchorErr, globalAnchorErr, negationAnchorErr}
+			for _, e := range wrapped {
+				for _, code := range codes {
+					want := code == tt.want
+					if got := isError(e, code); got != want {
+						t.Errorf("isError(%v, %v) = %v, want %v", e, code, got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// Test_isError_outermostAnchorErrorWins documents the classification semantics
+// when anchor errors are nested: the outermost anchor error decides. This is
+// what conditionAnchorHandler relies on when it re-classifies a nested failure
+// as a conditional anchor mismatch.
+func Test_isError_outermostAnchorErrorWins(t *testing.T) {
+	err := wrapConditionalAnchorError(newGlobalAnchorError("inner"))
+
+	if !IsConditionalAnchorError(err) {
+		t.Errorf("IsConditionalAnchorError() = false, want true")
+	}
+	if IsGlobalAnchorError(err) {
+		t.Errorf("IsGlobalAnchorError() = true, want false (outermost anchor error wins)")
+	}
+}
+
+// Test_isError_classifiesMultiplyWrappedAnchorErrors covers anchor errors buried
+// several layers deep behind a mix of wrapping mechanisms: fmt.Errorf("%w"),
+// errors.Join and a wrapper that replaces the message entirely. None of these
+// could be recognised while classification was based on message text.
+func Test_isError_classifiesMultiplyWrappedAnchorErrors(t *testing.T) {
+	// bury wraps err behind three layers, the middle one hiding the message.
+	bury := func(err error) error {
+		return fmt.Errorf("outer: %w", maskedError{
+			inner: errors.Join(errors.New("unrelated sibling"), fmt.Errorf("inner: %w", err)),
+		})
+	}
+
+	tests := []struct {
+		name          string
+		err           error
+		wantCondition bool
+		wantGlobal    bool
+		wantNegation  bool
+	}{{
+		name:          "conditional, multiply wrapped",
+		err:           bury(newConditionalAnchorError("test")),
+		wantCondition: true,
+	}, {
+		name:       "global, multiply wrapped",
+		err:        bury(newGlobalAnchorError("test")),
+		wantGlobal: true,
+	}, {
+		name:         "negation, multiply wrapped",
+		err:          bury(newNegationAnchorError("test")),
+		wantNegation: true,
+	}, {
+		name: "unrelated error, multiply wrapped",
+		err:  bury(errors.New("conditional anchor mismatch: unrelated error")),
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsConditionalAnchorError(tt.err); got != tt.wantCondition {
+				t.Errorf("IsConditionalAnchorError() = %v, want %v", got, tt.wantCondition)
+			}
+			if got := IsGlobalAnchorError(tt.err); got != tt.wantGlobal {
+				t.Errorf("IsGlobalAnchorError() = %v, want %v", got, tt.wantGlobal)
+			}
+			if got := IsNegationAnchorError(tt.err); got != tt.wantNegation {
+				t.Errorf("IsNegationAnchorError() = %v, want %v", got, tt.wantNegation)
 			}
 		})
 	}

--- a/pkg/engine/anchor/handlers.go
+++ b/pkg/engine/anchor/handlers.go
@@ -165,7 +165,7 @@ func (ch conditionAnchorHandler) Handle(handler resourceElementHandler, resource
 		// validate the values of the pattern
 		returnPath, err := handler(logging.GlobalLogger(), value, ch.pattern, originPattern, currentPath, ac)
 		if err != nil {
-			ac.AnchorError = newConditionalAnchorError(err.Error())
+			ac.AnchorError = wrapConditionalAnchorError(err)
 			return returnPath, ac.AnchorError
 		}
 		return "", nil
@@ -200,7 +200,7 @@ func (gh globalAnchorHandler) Handle(handler resourceElementHandler, resourceMap
 		// validate the values of the pattern
 		returnPath, err := handler(logging.GlobalLogger(), value, gh.pattern, originPattern, currentPath, ac)
 		if err != nil {
-			ac.AnchorError = newGlobalAnchorError(err.Error())
+			ac.AnchorError = wrapGlobalAnchorError(err)
 			return returnPath, ac.AnchorError
 		}
 		return "", nil

--- a/pkg/engine/validate/validate.go
+++ b/pkg/engine/validate/validate.go
@@ -26,6 +26,14 @@ func (e *PatternError) Error() string {
 	return e.Err.Error()
 }
 
+// Unwrap exposes the underlying error so that errors.Is and errors.As can
+// traverse a PatternError. Anchor errors are frequently aggregated here (see
+// validateMap, validateArray and validateArrayOfMaps) before being handed back
+// to skip() and fail(), and they must remain classifiable through this layer.
+func (e *PatternError) Unwrap() error {
+	return e.Err
+}
+
 // MatchPattern is a start of element-by-element pattern validation process.
 // It assumes that validation is started from root, so "/" is passed
 func MatchPattern(logger logr.Logger, resource, pattern interface{}) error {

--- a/pkg/engine/validate/validate_test.go
+++ b/pkg/engine/validate/validate_test.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -1759,5 +1760,176 @@ func testMatchPattern(t *testing.T, testCase struct {
 		assert.Assert(t, pe.Skip, fmt.Sprintf("\nexpected skip == true - test: %s\npattern: %s\nresource: %s\n", testCase.name, pattern, resource))
 	} else if testCase.status == engineapi.RuleStatusError {
 		assert.Assert(t, err == nil, fmt.Sprintf("\nexpected error - test: %s\npattern: %s\nresource: %s\n", testCase.name, pattern, resource))
+	}
+}
+
+// TestPatternError_Unwrap guards the error chain that anchor classification
+// depends on. Anchor errors are aggregated into a *PatternError by validateMap,
+// validateArray and validateArrayOfMaps before being handed back to skip() and
+// fail(), so a *PatternError must stay transparent to errors.Is/errors.As.
+func TestPatternError_Unwrap(t *testing.T) {
+	inner := fmt.Errorf("inner")
+	pe := &PatternError{Err: inner, Path: "/spec/", Skip: true}
+
+	assert.Assert(t, errors.Is(pe, inner), "PatternError must unwrap to its cause")
+}
+
+// TestMatchPattern_AnchorClassificationThroughPatternError verifies end to end
+// that a conditional anchor mismatch nested in an array of maps is still
+// classified as a skip after travelling through the *PatternError aggregation
+// layer. This is the common case of selecting a container by name.
+func TestMatchPattern_AnchorClassificationThroughPatternError(t *testing.T) {
+	var pattern, resource interface{}
+	err := json.Unmarshal([]byte(`{"spec":{"containers":[{"(name)":"nginx","image":"nginx:latest"}]}}`), &pattern)
+	assert.NilError(t, err)
+	err = json.Unmarshal([]byte(`{"spec":{"containers":[{"name":"redis","image":"redis:7"}]}}`), &resource)
+	assert.NilError(t, err)
+
+	err = MatchPattern(logr.Discard(), resource, pattern)
+	assert.Assert(t, err != nil)
+
+	pe, ok := err.(*PatternError)
+	assert.Assert(t, ok, "expected a *PatternError, got %T", err)
+	assert.Assert(t, pe.Skip, "conditional anchor mismatch must be reported as a skip")
+	assert.Assert(t, anchor.IsConditionalAnchorError(pe), "anchor type must survive PatternError aggregation")
+}
+
+// TestMatchPattern_ResourceValueMimickingAnchorMessage is the end to end
+// regression test for the removed strings.Contains classification. A resource
+// value that happens to contain an anchor error message must not change the
+// outcome of the rule: it is a plain mismatch, not a skip.
+func TestMatchPattern_ResourceValueMimickingAnchorMessage(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "control", value: "intruder"},
+		{name: "conditional anchor message", value: "conditional anchor mismatch"},
+		{name: "global anchor message", value: "global anchor mismatch"},
+		{name: "negation anchor message", value: "negation anchor matched in resource"},
+		{name: "anchor message as substring", value: "x-conditional anchor mismatch-y"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var pattern, resource interface{}
+			err := json.Unmarshal([]byte(`{"metadata":{"annotations":{"owner":"platform-team"}}}`), &pattern)
+			assert.NilError(t, err)
+			raw := fmt.Sprintf(`{"metadata":{"annotations":{"owner":%q}}}`, tt.value)
+			err = json.Unmarshal([]byte(raw), &resource)
+			assert.NilError(t, err)
+
+			err = MatchPattern(logr.Discard(), resource, pattern)
+			assert.Assert(t, err != nil, "expected a validation error")
+
+			pe, ok := err.(*PatternError)
+			assert.Assert(t, ok, "expected a *PatternError, got %T", err)
+			assert.Assert(t, !pe.Skip, "a plain value mismatch must not be reported as a skip")
+			assert.Equal(t, pe.Path, "/metadata/annotations/owner/")
+		})
+	}
+}
+
+// Test_negation_anchor covers end to end evaluation of the negation anchor.
+// fail() is the only consumer of anchor.IsNegationAnchorError, so this is the
+// path most affected by moving classification from message text to error type.
+// Assertions are explicit rather than routed through testMatchPattern, which
+// has no RuleStatusFail branch.
+func Test_negation_anchor(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		resource string
+		wantPass bool
+	}{{
+		name:     "negated key absent, rule passes",
+		pattern:  `{"spec":{"X(hostNetwork)":"*"}}`,
+		resource: `{"spec":{"containers":[{"name":"a"}]}}`,
+		wantPass: true,
+	}, {
+		name:     "negated key present, rule fails",
+		pattern:  `{"spec":{"X(hostNetwork)":"*"}}`,
+		resource: `{"spec":{"hostNetwork":true}}`,
+		wantPass: false,
+	}, {
+		name:     "negated key absent in array of maps, rule passes",
+		pattern:  `{"spec":{"containers":[{"X(securityContext)":"*"}]}}`,
+		resource: `{"spec":{"containers":[{"name":"a"}]}}`,
+		wantPass: true,
+	}, {
+		name:     "negated key present in array of maps, rule fails",
+		pattern:  `{"spec":{"containers":[{"X(securityContext)":"*"}]}}`,
+		resource: `{"spec":{"containers":[{"name":"a","securityContext":{"privileged":true}}]}}`,
+		wantPass: false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var pattern, resource interface{}
+			err := json.Unmarshal([]byte(tt.pattern), &pattern)
+			assert.NilError(t, err)
+			err = json.Unmarshal([]byte(tt.resource), &resource)
+			assert.NilError(t, err)
+
+			err = MatchPattern(logr.Discard(), resource, pattern)
+			if tt.wantPass {
+				assert.NilError(t, err)
+				return
+			}
+
+			assert.Assert(t, err != nil, "expected the rule to fail")
+			pe, ok := err.(*PatternError)
+			assert.Assert(t, ok, "expected a *PatternError, got %T", err)
+			// a negation match is a rule failure, never a skip
+			assert.Assert(t, !pe.Skip, "negation anchor match must not be reported as a skip")
+			// and it must still be recognised as a negation anchor error
+			assert.Assert(t, anchor.IsNegationAnchorError(pe), "negation anchor error must survive propagation")
+			assert.Assert(t, !anchor.IsConditionalAnchorError(pe))
+			assert.Assert(t, !anchor.IsGlobalAnchorError(pe))
+		})
+	}
+}
+
+// Test_existence_anchor_nestedConditional guards the boundary in
+// validateExistenceListResource, which deliberately does not propagate the
+// per element errors it collected. If that aggregation ever became transparent
+// to errors.As, a nested conditional mismatch would leak out and turn an
+// existence anchor failure into a skip, silently disabling the rule.
+func Test_existence_anchor_nestedConditional(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		wantPass bool
+	}{{
+		name:     "an element satisfies the existence anchor",
+		resource: `{"spec":{"containers":[{"name":"nginx","image":"nginx:latest"}]}}`,
+		wantPass: true,
+	}, {
+		name:     "no element satisfies the conditional anchor nested in the existence anchor",
+		resource: `{"spec":{"containers":[{"name":"redis","image":"redis:7"}]}}`,
+		wantPass: false,
+	}, {
+		name:     "conditional anchor matches but the nested value does not",
+		resource: `{"spec":{"containers":[{"name":"nginx","image":"nginx:v1"}]}}`,
+		wantPass: false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var pattern, resource interface{}
+			err := json.Unmarshal([]byte(`{"spec":{"^(containers)":[{"(name)":"nginx","image":"nginx:latest"}]}}`), &pattern)
+			assert.NilError(t, err)
+			err = json.Unmarshal([]byte(tt.resource), &resource)
+			assert.NilError(t, err)
+
+			err = MatchPattern(logr.Discard(), resource, pattern)
+			if tt.wantPass {
+				assert.NilError(t, err)
+				return
+			}
+
+			assert.Assert(t, err != nil, "expected the rule to fail")
+			pe, ok := err.(*PatternError)
+			assert.Assert(t, ok, "expected a *PatternError, got %T", err)
+			assert.Assert(t, !pe.Skip, "an existence anchor failure must not be reported as a skip")
+			assert.Assert(t, !anchor.IsConditionalAnchorError(pe), "the nested conditional error must not leak out of the existence anchor")
+		})
 	}
 }


### PR DESCRIPTION
## Explanation

Anchor errors were being identified partly by matching text in the error message. This could cause wrapped anchor errors to be missed, while unrelated errors containing the same message could be treated as anchor errors.

This PR fixes the error classification to rely on the actual error type and adds regression tests for the affected cases.


## Related issue
Closes #17345

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
 /kind bug


## Proposed Changes

- Update anchor error classification to correctly handle wrapped errors.
- Remove the fallback based on matching error message text.
- Add tests for direct, wrapped, and multiply wrapped anchor errors.
- Add coverage for unrelated errors containing anchor error messages.
- Add validation tests covering conditional, global, and negation anchor paths.

### Proof Manifests
Not applicable. This change affects internal error handling and does not introduce new user-facing behavior.

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The main goal of this change is to keep anchor error handling based on error types rather than error message contents. This avoids treating unrelated errors as anchor errors while preserving the existing anchor evaluation behavior.