### PR TITLE
Bump kyverno sdk to 68d74afcb07a

### DIFF
--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -129,7 +129,7 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 	}
 	rclient := p.Store.GetRegistryClient()
 	if rclient == nil {
-		rclient = registryclient.New(nil, "", "", "", false)
+		rclient = registryclient.New()
 	}
 	isCluster := false
 	if len(p.CrdPaths) > 0 {

--- a/cmd/cli/kubectl-kyverno/store/store.go
+++ b/cmd/cli/kubectl-kyverno/store/store.go
@@ -53,7 +53,7 @@ func (s *Store) GetForeachElement() int {
 
 func (s *Store) SetRegistryAccess(access bool) {
 	if access {
-		s.registryClient = registryclient.New(nil, "", "", "", false)
+		s.registryClient = registryclient.New()
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/kyverno/go-jmespath v0.4.1-0.20231124160150-95e59c162877
 	github.com/kyverno/kyverno-authz v0.4.1-0.20260701230957-9101a3ffd44f
 	github.com/kyverno/playground/backend v0.0.0-20251124111549-b7997c02bca2
-	github.com/kyverno/sdk v0.0.0-20260703121625-e0dc6fb8661a
+	github.com/kyverno/sdk v0.0.0-20260825082632-68d74afcb07a
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7
 	github.com/notaryproject/notation-core-go v1.3.0
 	github.com/notaryproject/notation-go v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -646,8 +646,8 @@ github.com/kyverno/playground/backend v0.0.0-20251124111549-b7997c02bca2 h1:uLTs
 github.com/kyverno/playground/backend v0.0.0-20251124111549-b7997c02bca2/go.mod h1:EumSDUMvIitgwlZBvVYnlgC285mZ0yCjAfoiu8s3o/g=
 github.com/kyverno/pod-security-admission v0.0.0-20251031094455-46f20778634f h1:9u+4QYMLdZPC8qeUB1TnfiUYRrFGYHxjYQsPiHKgJjI=
 github.com/kyverno/pod-security-admission v0.0.0-20251031094455-46f20778634f/go.mod h1:2oJ/wAoh8hld09eMTT1KzlN3dHjKEQn1xJdu1WAZMa0=
-github.com/kyverno/sdk v0.0.0-20260703121625-e0dc6fb8661a h1:MN7azUnUBwx4zXz0PsYVKcoXTf9RK+barMKffst6YNg=
-github.com/kyverno/sdk v0.0.0-20260703121625-e0dc6fb8661a/go.mod h1:LBPB/TdWmJ8VWZvRbc27SVHMutYX/lJIZnlFMm2xWes=
+github.com/kyverno/sdk v0.0.0-20260825082632-68d74afcb07a h1:Oh5sST+MT/r4FcTGdTKQhr1kuB4IzoO8wxA8vAP4GTE=
+github.com/kyverno/sdk v0.0.0-20260825082632-68d74afcb07a/go.mod h1:LBPB/TdWmJ8VWZvRbc27SVHMutYX/lJIZnlFMm2xWes=
 github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7 h1:k/1ku0yehLCPqERCHkIHMDqDg1R02AcCScRuHbamU3s=
 github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7/go.mod h1:YR/zYthNdWfO8+0IOyHDcIDBBBS2JMnYUIwSsnwmRqU=
 github.com/lestrrat-go/blackmagic v1.0.4 h1:IwQibdnf8l2KoO+qC3uT4OaTWsW7tuRQXy9TRN9QanA=

--- a/pkg/engine/adapters/rclient_test.go
+++ b/pkg/engine/adapters/rclient_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRclientAdapter_ForRef_Integration(t *testing.T) {
-	client := registryclient.New(nil, "", "", "", false)
+	client := registryclient.New()
 
 	adapter := RegistryClient(client)
 	require.NotNil(t, adapter)
@@ -38,7 +38,7 @@ func TestRclientAdapter_ForRef_Integration(t *testing.T) {
 }
 
 func TestRclientAdapter_ForRef_InvalidImage(t *testing.T) {
-	client := registryclient.New(nil, "", "", "", false)
+	client := registryclient.New()
 
 	adapter := RegistryClient(client)
 	require.NotNil(t, adapter)
@@ -52,7 +52,7 @@ func TestRclientAdapter_ForRef_InvalidImage(t *testing.T) {
 }
 
 func TestRclientAdapter_ForRef_NonExistentImage(t *testing.T) {
-	client := registryclient.New(nil, "", "", "", false)
+	client := registryclient.New()
 
 	adapter := RegistryClient(client)
 	require.NotNil(t, adapter)
@@ -66,7 +66,7 @@ func TestRclientAdapter_ForRef_NonExistentImage(t *testing.T) {
 }
 
 func TestRclientAdapter_ForRef_WithDigest(t *testing.T) {
-	client := registryclient.New(nil, "", "", "", false)
+	client := registryclient.New()
 
 	adapter := RegistryClient(client)
 	require.NotNil(t, adapter)
@@ -90,7 +90,7 @@ func TestRclientAdapter_ForRef_WithDigest(t *testing.T) {
 }
 
 func TestRclientAdapter_ForRef_WithTagAndDigest(t *testing.T) {
-	client := registryclient.New(nil, "", "", "", false)
+	client := registryclient.New()
 
 	adapter := RegistryClient(client)
 	require.NotNil(t, adapter)
@@ -114,7 +114,7 @@ func TestRclientAdapter_ForRef_WithTagAndDigest(t *testing.T) {
 }
 
 func TestRclientAdapter_ForRef_IdentifierParsingEdgeCases(t *testing.T) {
-	client := registryclient.New(nil, "", "", "", false)
+	client := registryclient.New()
 
 	adapter := RegistryClient(client)
 	require.NotNil(t, adapter)

--- a/pkg/engine/factories/registryclientfactory.go
+++ b/pkg/engine/factories/registryclientfactory.go
@@ -35,12 +35,11 @@ func (f *registryClientFactory) GetClient(ctx context.Context, creds *kyvernov1.
 
 	// the policy contains extra credentials apart from whats passed in imagePullSecrets
 	if creds != nil {
-		// turn the array of providers to a single comma separated string
-		strs := make([]string, len(creds.Providers))
+		// turn the array of providers into a slice of credential helper names
+		providers := make([]string, len(creds.Providers))
 		for i, p := range creds.Providers {
-			strs[i] = string(p)
+			providers[i] = string(p)
 		}
-		providers := strings.Join(strs, ",")
 
 		// create an array of secret names where we will accumulate whats in creds and imagePullSecrets
 		// creds.Secrets default to the Kyverno namespace, imagePullSecrets default to the resource namespace,
@@ -53,14 +52,21 @@ func (f *registryClientFactory) GetClient(ctx context.Context, creds *kyvernov1.
 			secrets = append(secrets, prefixSecretNamespaces(imagePullSecrets, resourceNamespace)...)
 		}
 
-		secretsJoined := strings.Join(secrets, ",")
-		client := registryclient.New(f.secretsLister, resourceNamespace, secretsJoined, providers, creds.AllowInsecureRegistry)
+		client := registryclient.New(
+			registryclient.WithSecretLister(f.secretsLister, resourceNamespace),
+			registryclient.WithImagePullSecrets(secrets...),
+			registryclient.WithCredentialHelpers(providers...),
+			registryclient.WithAllowInsecureRegistry(creds.AllowInsecureRegistry),
+		)
 		return adapters.RegistryClient(client), nil
 	}
 
 	// creds is nil. create a registry client with only the imagePullSecrets and no providers
-	secretsJoined := strings.Join(prefixSecretNamespaces(imagePullSecrets, resourceNamespace), ",")
-	client := registryclient.New(f.secretsLister, resourceNamespace, secretsJoined, "", false)
+	secrets := prefixSecretNamespaces(imagePullSecrets, resourceNamespace)
+	client := registryclient.New(
+		registryclient.WithSecretLister(f.secretsLister, resourceNamespace),
+		registryclient.WithImagePullSecrets(secrets...),
+	)
 	return adapters.RegistryClient(client), nil
 }
 

--- a/pkg/engine/factories/registryclientfactory_test.go
+++ b/pkg/engine/factories/registryclientfactory_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestGetClient_NilSecretsLister(t *testing.T) {
 	// Create a factory with nil secretsLister (simulating CLI usage)
-	rclient := registryclient.New(nil, "", "", "", false)
+	rclient := registryclient.New()
 	factory := DefaultRegistryClientFactory(adapters.RegistryClient(rclient), nil)
 
 	tests := []struct {

--- a/pkg/engine/fuzz_test.go
+++ b/pkg/engine/fuzz_test.go
@@ -30,7 +30,7 @@ var (
 	fuzzJp         = jmespath.New(fuzzCfg)
 
 	validateContext = context.Background()
-	regClient       = registryclient.New(nil, "", "", "", false)
+	regClient       = registryclient.New()
 	validateEngine  = NewEngine(
 		fuzzCfg,
 		fuzzJp,
@@ -118,7 +118,7 @@ func FuzzVerifyImageAndPatchTest(f *testing.F) {
 			fuzzCfg,
 			fuzzJp,
 			nil,
-			factories.DefaultRegistryClientFactory(adapters.RegistryClient(registryclient.New(nil, "", "", "", false)), nil),
+			factories.DefaultRegistryClientFactory(adapters.RegistryClient(registryclient.New()), nil),
 			imageverifycache.DisabledImageVerifyCache(),
 			factories.DefaultContextLoaderFactory(nil),
 			nil,

--- a/pkg/engine/image_verify_test.go
+++ b/pkg/engine/image_verify_test.go
@@ -337,7 +337,7 @@ func Test_CosignMockAttest(t *testing.T) {
 	defer cosign.ClearMock()
 	assert.NilError(t, err)
 
-	er, ivm := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(er.PolicyResponse.Rules), 1)
 	assert.Equal(t, er.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass,
 		fmt.Sprintf("expected: %v, got: %v, failure: %v",
@@ -352,7 +352,7 @@ func Test_CosignMockAttest_fail(t *testing.T) {
 	defer cosign.ClearMock()
 	assert.NilError(t, err)
 
-	er, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(er.PolicyResponse.Rules), 1)
 	assert.Equal(t, er.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusFail)
 }
@@ -632,7 +632,7 @@ var (
 
 func Test_NoMatch(t *testing.T) {
 	policyContext := buildContext(t, testConfigMapMissing, testConfigMapMissingResource, "")
-	err, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	err, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(err.PolicyResponse.Rules), 0)
 }
 
@@ -641,7 +641,7 @@ func Test_ConfigMapMissingFailure(t *testing.T) {
 	policyContext := buildContext(t, testConfigMapMissing, ghcrImage, "")
 	resolver, err := resolvers.NewClientBasedResolver(kubefake.NewSimpleClientset())
 	assert.NilError(t, err)
-	resp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), resolver, policyContext, cfg)
+	resp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), resolver, policyContext, cfg)
 	assert.Equal(t, len(resp.PolicyResponse.Rules), 1)
 	assert.Equal(t, resp.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusError, resp.PolicyResponse.Rules[0].Message())
 }
@@ -649,7 +649,7 @@ func Test_ConfigMapMissingFailure(t *testing.T) {
 func Test_SignatureGoodSigned(t *testing.T) {
 	policyContext := buildContext(t, testSampleSingleKeyPolicy, testSampleResource, "")
 	policyContext.Policy().GetSpec().Rules[0].VerifyImages[0].MutateDigest = true
-	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(engineResp.PolicyResponse.Rules), 1)
 	assert.Equal(t, engineResp.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass, engineResp.PolicyResponse.Rules[0].Message())
 	constainers, found, err := unstructured.NestedSlice(engineResp.PatchedResource.UnstructuredContent(), "spec", "containers")
@@ -664,7 +664,7 @@ func Test_SignatureGoodSigned(t *testing.T) {
 func Test_SignatureUnsigned(t *testing.T) {
 	unsigned := strings.Replace(testSampleResource, ":signed", ":unsigned", -1)
 	policyContext := buildContext(t, testSampleSingleKeyPolicy, unsigned, "")
-	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(engineResp.PolicyResponse.Rules), 1)
 	assert.Equal(t, engineResp.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusFail, engineResp.PolicyResponse.Rules[0].Message())
 }
@@ -672,7 +672,7 @@ func Test_SignatureUnsigned(t *testing.T) {
 func Test_SignatureWrongKey(t *testing.T) {
 	otherKey := strings.Replace(testSampleResource, ":signed", ":signed-by-someone-else", -1)
 	policyContext := buildContext(t, testSampleSingleKeyPolicy, otherKey, "")
-	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(engineResp.PolicyResponse.Rules), 1)
 	assert.Equal(t, engineResp.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusFail, engineResp.PolicyResponse.Rules[0].Message())
 }
@@ -682,7 +682,7 @@ func Test_SignaturesMultiKey(t *testing.T) {
 	policy = strings.Replace(policy, "KEY2", testVerifyImageKey, -1)
 	policy = strings.Replace(policy, "COUNT", "0", -1)
 	policyContext := buildContext(t, policy, testSampleResource, "")
-	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(engineResp.PolicyResponse.Rules), 1)
 	assert.Equal(t, engineResp.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass, engineResp.PolicyResponse.Rules[0].Message())
 }
@@ -691,7 +691,7 @@ func Test_SignaturesMultiKeyFail(t *testing.T) {
 	policy := strings.Replace(testSampleMultipleKeyPolicy, "KEY1", testVerifyImageKey, -1)
 	policy = strings.Replace(policy, "COUNT", "0", -1)
 	policyContext := buildContext(t, policy, testSampleResource, "")
-	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(engineResp.PolicyResponse.Rules), 1)
 	assert.Equal(t, engineResp.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusFail, engineResp.PolicyResponse.Rules[0].Message())
 }
@@ -701,7 +701,7 @@ func Test_SignaturesMultiKeyOneGoodKey(t *testing.T) {
 	policy = strings.Replace(policy, "KEY2", testOtherKey, -1)
 	policy = strings.Replace(policy, "COUNT", "1", -1)
 	policyContext := buildContext(t, policy, testSampleResource, "")
-	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	engineResp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(engineResp.PolicyResponse.Rules), 1)
 	assert.Equal(t, engineResp.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass, engineResp.PolicyResponse.Rules[0].Message())
 }
@@ -711,7 +711,7 @@ func Test_SignaturesMultiKeyZeroGoodKey(t *testing.T) {
 	policy = strings.Replace(policy, "KEY2", testOtherKey, -1)
 	policy = strings.Replace(policy, "COUNT", "1", -1)
 	policyContext := buildContext(t, policy, testSampleResource, "")
-	resp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	resp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(resp.PolicyResponse.Rules), 1)
 	assert.Equal(t, resp.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusFail, resp.PolicyResponse.Rules[0].Message())
 }
@@ -725,14 +725,14 @@ func Test_RuleSelectorImageVerify(t *testing.T) {
 	applyAll := kyvernov1.ApplyAll
 	spec.ApplyRules = &applyAll
 
-	resp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	resp, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(resp.PolicyResponse.Rules), 2)
 	assert.Equal(t, resp.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass, resp.PolicyResponse.Rules[0].Message())
 	assert.Equal(t, resp.PolicyResponse.Rules[1].Status(), engineapi.RuleStatusFail, resp.PolicyResponse.Rules[1].Message())
 
 	applyOne := kyvernov1.ApplyOne
 	spec.ApplyRules = &applyOne
-	resp, _ = testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	resp, _ = testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(resp.PolicyResponse.Rules), 1)
 	assert.Equal(t, resp.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass, resp.PolicyResponse.Rules[0].Message())
 }
@@ -848,7 +848,7 @@ func Test_NestedAttestors(t *testing.T) {
 	policy = strings.Replace(policy, "KEY2", testVerifyImageKey, -1)
 	policy = strings.Replace(policy, "COUNT", "0", -1)
 	policyContext := buildContext(t, policy, testSampleResource, "")
-	err, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	err, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(err.PolicyResponse.Rules), 1)
 	assert.Equal(t, err.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass)
 
@@ -856,7 +856,7 @@ func Test_NestedAttestors(t *testing.T) {
 	policy = strings.Replace(policy, "KEY2", testOtherKey, -1)
 	policy = strings.Replace(policy, "COUNT", "0", -1)
 	policyContext = buildContext(t, policy, testSampleResource, "")
-	err, _ = testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	err, _ = testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(err.PolicyResponse.Rules), 1)
 	assert.Equal(t, err.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusFail)
 
@@ -864,7 +864,7 @@ func Test_NestedAttestors(t *testing.T) {
 	policy = strings.Replace(policy, "KEY2", testOtherKey, -1)
 	policy = strings.Replace(policy, "COUNT", "1", -1)
 	policyContext = buildContext(t, policy, testSampleResource, "")
-	err, _ = testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	err, _ = testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(err.PolicyResponse.Rules), 1)
 	assert.Equal(t, err.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass)
 }
@@ -934,7 +934,7 @@ func Test_MarkImageVerified(t *testing.T) {
 	defer cosign.ClearMock()
 	assert.NilError(t, err)
 
-	engineResponse, verifiedImages := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	engineResponse, verifiedImages := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(engineResponse.PolicyResponse.Rules), 1)
 	assert.Equal(t, engineResponse.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass)
 
@@ -1037,7 +1037,7 @@ func Test_ParsePEMDelimited(t *testing.T) {
 	defer cosign.ClearMock()
 	assert.NilError(t, err)
 
-	engineResponse, verifiedImages := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	engineResponse, verifiedImages := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	assert.Equal(t, len(engineResponse.PolicyResponse.Rules), 1)
 	assert.Equal(t, engineResponse.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass)
 
@@ -1090,12 +1090,12 @@ func Test_ImageVerifyCacheCosign(t *testing.T) {
 	policyContext := buildContext(t, cosignTestPolicy, cosignTestResource, "")
 
 	start := time.Now()
-	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	firstOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 
 	start = time.Now()
-	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	secondOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 	assert.Check(t, secondOperationTime < firstOperationTime/10, "cache entry is valid, so image verification should be from cache.", firstOperationTime, secondOperationTime)
@@ -1114,12 +1114,12 @@ func Test_ImageVerifyCacheDisabled(t *testing.T) {
 	policyContext := buildContext(t, cosignTestPolicy, cosignTestResource, "")
 
 	start := time.Now()
-	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	firstOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 
 	start = time.Now()
-	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	secondOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 	assert.Check(t, secondOperationTime > firstOperationTime/10 && secondOperationTime < firstOperationTime*10, "cache is disabled, so image verification should not be from cache.", firstOperationTime, secondOperationTime)
@@ -1138,14 +1138,14 @@ func Test_ImageVerifyCacheExpiredCosign(t *testing.T) {
 	policyContext := buildContext(t, cosignTestPolicy, cosignTestResource, "")
 
 	start := time.Now()
-	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	firstOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 
 	time.Sleep(5 * time.Second)
 
 	start = time.Now()
-	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	secondOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 	assert.Check(t, secondOperationTime > firstOperationTime/10 && secondOperationTime < firstOperationTime*10, "cache entry is expired, so image verification should not be from cache.", firstOperationTime, secondOperationTime)
@@ -1164,13 +1164,13 @@ func Test_changePolicyCacheVerificationCosign(t *testing.T) {
 	policyContext := buildContext(t, cosignTestPolicy, cosignTestResource, "")
 
 	start := time.Now()
-	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	firstOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 	policyContext = buildContext(t, cosignTestPolicyUpdated, cosignTestResource, "")
 
 	start = time.Now()
-	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	secondOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 	assert.Check(t, secondOperationTime > firstOperationTime/10 && secondOperationTime < firstOperationTime*10, "cache entry not found, so image verification should not be from cache.", firstOperationTime, secondOperationTime)
@@ -1313,12 +1313,12 @@ func Test_ImageVerifyCacheNotary(t *testing.T) {
 	policyContext := buildContext(t, verifyImageNotaryPolicy, verifyImageNotaryResource, "")
 
 	start := time.Now()
-	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	firstOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 
 	start = time.Now()
-	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	secondOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 	assert.Check(t, secondOperationTime < firstOperationTime/10, "cache entry is valid, so image verification should be from cache.", firstOperationTime, secondOperationTime)
@@ -1337,14 +1337,14 @@ func Test_ImageVerifyCacheExpiredNotary(t *testing.T) {
 	policyContext := buildContext(t, verifyImageNotaryPolicy, verifyImageNotaryResource, "")
 
 	start := time.Now()
-	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	firstOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 
 	time.Sleep(5 * time.Second)
 
 	start = time.Now()
-	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	secondOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 	assert.Check(t, secondOperationTime > firstOperationTime/10 && secondOperationTime < firstOperationTime*10, "cache entry is expired, so image verification should not be from cache.", firstOperationTime, secondOperationTime)
@@ -1362,13 +1362,13 @@ func Test_changePolicyCacheVerificationNotary(t *testing.T) {
 
 	policyContext := buildContext(t, verifyImageNotaryPolicy, verifyImageNotaryResource, "")
 	start := time.Now()
-	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm := testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	firstOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 	policyContext = buildContext(t, verifyImageNotaryUpdatedPolicy, verifyImageNotaryResource, "")
 
 	start = time.Now()
-	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContext, cfg)
+	er, ivm = testImageVerifyCache(imageVerifyCache, context.TODO(), registryclient.New(), nil, policyContext, cfg)
 	secondOperationTime := time.Since(start)
 	errorAssertionUtil(t, image, ivm, er)
 	assert.Check(t, secondOperationTime > firstOperationTime/10 && secondOperationTime < firstOperationTime*10, "cache entry not found, so image verification should not be from cache.", firstOperationTime, secondOperationTime)
@@ -1480,7 +1480,7 @@ func Test_SkipImageReferences(t *testing.T) {
 	policyContextPass := buildContext(t, excludeVerifyImageNotaryPolicy, excludeVerifyImageNotaryResourcePass, "")
 
 	// Passes as image is included and not excluded
-	erPass, ivm := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContextPass, cfg)
+	erPass, ivm := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContextPass, cfg)
 	assert.Equal(t, len(erPass.PolicyResponse.Rules), 1)
 	assert.Equal(t, erPass.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass,
 		fmt.Sprintf("expected: %v, got: %v, failure: %v",
@@ -1490,7 +1490,7 @@ func Test_SkipImageReferences(t *testing.T) {
 	policyContextSkip := buildContext(t, excludeVerifyImageNotaryPolicy, excludeVerifyImageNotaryResourceSkip, "")
 
 	// Skipped as image is excluded
-	erSkip, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContextSkip, cfg)
+	erSkip, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContextSkip, cfg)
 	assert.Equal(t, len(erSkip.PolicyResponse.Rules), 1)
 	assert.Equal(t, erSkip.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusSkip,
 		fmt.Sprintf("expected: %v, got: %v, failure: %v",
@@ -1685,7 +1685,7 @@ func Test_MultipleImageVerificationAttestationPass(t *testing.T) {
 	policyContextPass := buildContext(t, multipleImageVerificationAttestationPolicyPass, excludeVerifyImageNotaryResourcePass, "")
 
 	// Passes as image is included and not excluded
-	erPass, ivm := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContextPass, cfg)
+	erPass, ivm := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContextPass, cfg)
 	assert.Equal(t, len(erPass.PolicyResponse.Rules), 1)
 	assert.Equal(t, erPass.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass,
 		fmt.Sprintf("expected: %v, got: %v, failure: %v",
@@ -1695,7 +1695,7 @@ func Test_MultipleImageVerificationAttestationPass(t *testing.T) {
 	policyContextSkip := buildContext(t, excludeVerifyImageNotaryPolicy, excludeVerifyImageNotaryResourceSkip, "")
 
 	// Skipped as image is excluded
-	erSkip, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContextSkip, cfg)
+	erSkip, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContextSkip, cfg)
 	assert.Equal(t, len(erSkip.PolicyResponse.Rules), 1)
 	assert.Equal(t, erSkip.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusSkip,
 		fmt.Sprintf("expected: %v, got: %v, failure: %v",
@@ -1706,7 +1706,7 @@ func Test_MultipleImageVerificationAttestationFail(t *testing.T) {
 	policyContextPass := buildContext(t, multipleImageVerificationAttestationPolicyFail, excludeVerifyImageNotaryResourcePass, "")
 
 	// Passes as image is included and not excluded
-	erPass, ivm := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContextPass, cfg)
+	erPass, ivm := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContextPass, cfg)
 	assert.Equal(t, len(erPass.PolicyResponse.Rules), 1)
 	assert.Equal(t, erPass.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusPass,
 		fmt.Sprintf("expected: %v, got: %v, failure: %v",
@@ -1716,7 +1716,7 @@ func Test_MultipleImageVerificationAttestationFail(t *testing.T) {
 	policyContextSkip := buildContext(t, excludeVerifyImageNotaryPolicy, excludeVerifyImageNotaryResourceSkip, "")
 
 	// Skipped as image is excluded
-	erSkip, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(nil, "", "", "", false), nil, policyContextSkip, cfg)
+	erSkip, _ := testVerifyAndPatchImages(context.TODO(), registryclient.New(), nil, policyContextSkip, cfg)
 	assert.Equal(t, len(erSkip.PolicyResponse.Rules), 1)
 	assert.Equal(t, erSkip.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusSkip,
 		fmt.Sprintf("expected: %v, got: %v, failure: %v",

--- a/pkg/engine/mixed_failureaction_test.go
+++ b/pkg/engine/mixed_failureaction_test.go
@@ -49,7 +49,7 @@ func runMixed(t *testing.T, rulesJSON string, podJSON []byte) bool {
 	resource, err := kubeutils.BytesToUnstructured(podJSON)
 	assert.NilError(t, err)
 	pc := newPolicyContext(t, *resource, kyvernov1.Create, nil).WithPolicy(&policy)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), pc, cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), pc, cfg, nil)
 	return webhookutils.BlockRequest(er, kyvernov1.Fail)
 }
 

--- a/pkg/engine/mutation_test.go
+++ b/pkg/engine/mutation_test.go
@@ -2165,7 +2165,7 @@ func Test_mutate_existing_resources(t *testing.T) {
 		require.NoError(t, err)
 		dclient.SetDiscovery(client.NewFakeDiscoveryClient(nil))
 
-		er := testMutate(context.TODO(), dclient, registryclient.New(nil, "", "", "", false), policyContext, nil)
+		er := testMutate(context.TODO(), dclient, registryclient.New(), policyContext, nil)
 
 		var actualPatchedTargets []unstructured.Unstructured
 		for i := range er.PolicyResponse.Rules {

--- a/pkg/engine/validation_test.go
+++ b/pkg/engine/validation_test.go
@@ -153,7 +153,7 @@ func TestValidate_image_tag_fail(t *testing.T) {
 		"validation error: imagePullPolicy 'Always' required with tag 'latest'. rule validate-latest failed at path /spec/containers/0/imagePullPolicy/",
 	}
 
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	for index, r := range er.PolicyResponse.Rules {
 		assert.Equal(t, r.Message(), msgs[index])
 	}
@@ -253,7 +253,7 @@ func TestValidate_image_tag_pass(t *testing.T) {
 		"validation rule 'validate-tag' passed.",
 		"validation rule 'validate-latest' passed.",
 	}
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	for index, r := range er.PolicyResponse.Rules {
 		assert.Equal(t, r.Message(), msgs[index])
 	}
@@ -327,7 +327,7 @@ func TestValidate_Fail_anyPattern(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	assert.Assert(t, !er.IsSuccessful())
 
 	msgs := []string{"validation error: A namespace is required. rule check-default-namespace[0] failed at path /metadata/namespace/ rule check-default-namespace[1] failed at path /metadata/namespace/"}
@@ -410,7 +410,7 @@ func TestValidate_host_network_port(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation error: Host network and port are not allowed. rule validate-host-network-port failed at path /spec/containers/0/ports/0/hostPort/"}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -500,7 +500,7 @@ func TestValidate_anchor_arraymap_pass(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation rule 'validate-host-path' passed."}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -588,7 +588,7 @@ func TestValidate_anchor_arraymap_fail(t *testing.T) {
 	assert.NilError(t, err)
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation error: Host path '/var/lib/' is not allowed. rule validate-host-path failed at path /spec/volumes/0/hostPath/path/"}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -658,7 +658,7 @@ func TestValidate_anchor_map_notfound(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation rule 'pod rule 2' passed."}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -745,7 +745,7 @@ func TestValidate_foreach_zero_reported_asskip(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation rule 'check-token-exp' passed."}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -818,7 +818,7 @@ func TestValidate_anchor_map_found_valid(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation rule 'pod rule 2' passed."}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -892,7 +892,7 @@ func TestValidate_inequality_List_Processing(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation rule 'pod rule 2' passed."}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -972,7 +972,7 @@ func TestValidate_inequality_List_ProcessingBrackets(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation rule 'pod rule 2' passed."}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -1046,7 +1046,7 @@ func TestValidate_anchor_map_found_invalid(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation error: pod: validate run as non root user. rule pod rule 2 failed at path /spec/securityContext/runAsNonRoot/"}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -1121,7 +1121,7 @@ func TestValidate_AnchorList_pass(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation rule 'pod image rule' passed."}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -1196,7 +1196,7 @@ func TestValidate_AnchorList_fail(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	assert.Assert(t, !er.IsSuccessful())
 }
 
@@ -1266,7 +1266,7 @@ func TestValidate_existenceAnchor_fail(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	assert.Assert(t, !er.IsSuccessful())
 }
 
@@ -1336,7 +1336,7 @@ func TestValidate_existenceAnchor_pass(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation rule 'pod image rule' passed."}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -1424,7 +1424,7 @@ func TestValidate_negationAnchor_deny(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation error: Host path is not allowed. rule validate-host-path failed at path /spec/volumes/0/hostPath/"}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -1511,7 +1511,7 @@ func TestValidate_negationAnchor_pass(t *testing.T) {
 
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(rawResource)
 	assert.NilError(t, err)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 	msgs := []string{"validation rule 'validate-host-path' passed."}
 
 	for index, r := range er.PolicyResponse.Rules {
@@ -1580,7 +1580,7 @@ func Test_VariableSubstitutionPathNotExistInPattern(t *testing.T) {
 	assert.NilError(t, err)
 
 	policyContext := newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), policyContext, cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), policyContext, cfg, nil)
 
 	assert.Equal(t, len(er.PolicyResponse.Rules), 1)
 	assert.Equal(t, er.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusError)
@@ -1666,7 +1666,7 @@ func Test_VariableSubstitutionPathNotExistInAnyPattern_OnePatternStatisfiesButSu
 	assert.NilError(t, err)
 
 	policyContext := newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), policyContext, cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), policyContext, cfg, nil)
 
 	assert.Equal(t, len(er.PolicyResponse.Rules), 1)
 	assert.Equal(t, er.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusError)
@@ -1720,7 +1720,7 @@ func Test_VariableSubstitution_NotOperatorWithStringVariable(t *testing.T) {
 	assert.NilError(t, err)
 
 	policyContext := newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), policyContext, cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), policyContext, cfg, nil)
 	assert.Equal(t, er.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusFail)
 	assert.Equal(t, er.PolicyResponse.Rules[0].Message(), "validation error: rule not-operator-with-variable-should-alway-fail-validation failed at path /spec/content/")
 }
@@ -1804,7 +1804,7 @@ func Test_VariableSubstitutionPathNotExistInAnyPattern_AllPathNotPresent(t *test
 	assert.NilError(t, err)
 
 	policyContext := newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), policyContext, cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), policyContext, cfg, nil)
 
 	assert.Equal(t, len(er.PolicyResponse.Rules), 1)
 	assert.Equal(t, er.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusError)
@@ -1890,7 +1890,7 @@ func Test_VariableSubstitutionPathNotExistInAnyPattern_AllPathPresent_NonePatter
 	assert.NilError(t, err)
 
 	policyContext := newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), policyContext, cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), policyContext, cfg, nil)
 
 	assert.Equal(t, er.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusFail)
 	assert.Equal(t, er.PolicyResponse.Rules[0].Message(),
@@ -1988,7 +1988,7 @@ func Test_VariableSubstitutionValidate_VariablesInMessageAreResolved(t *testing.
 	assert.NilError(t, err)
 
 	policyContext := newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy)
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), policyContext, cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), policyContext, cfg, nil)
 	assert.Equal(t, er.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusFail)
 	assert.Equal(t, er.PolicyResponse.Rules[0].Message(), "The animal cow is not in the allowed list of animals.")
 }
@@ -2034,7 +2034,7 @@ func Test_Flux_Kustomization_PathNotPresent(t *testing.T) {
 		assert.NilError(t, err)
 
 		policyContext := newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy)
-		er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), policyContext, cfg, nil)
+		er := testValidate(context.TODO(), registryclient.New(), policyContext, cfg, nil)
 
 		for i, rule := range er.PolicyResponse.Rules {
 			assert.Equal(t, er.PolicyResponse.Rules[i].Status(), test.expectedResults[i], "\ntest %s failed\nexpected: %s\nactual: %s", test.name, test.expectedResults[i], er.PolicyResponse.Rules[i].Status())
@@ -2234,7 +2234,7 @@ func executeTest(t *testing.T, test testCase) {
 		WithPolicy(&policy).
 		WithOldResource(oldR)
 
-	resp := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), pc, cfg, nil)
+	resp := testValidate(context.TODO(), registryclient.New(), pc, cfg, nil)
 	if resp.IsSuccessful() && test.requestDenied {
 		t.Errorf("Testcase has failed, policy: %v", policy.Name)
 	}
@@ -2326,7 +2326,7 @@ func TestValidate_context_variable_substitution_CLI(t *testing.T) {
 	)
 	er := testValidate(
 		context.TODO(),
-		registryclient.New(nil, "", "", "", false),
+		registryclient.New(),
 		newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy),
 		cfg,
 		ctxLoaderFactory,
@@ -2415,7 +2415,7 @@ func Test_EmptyStringInDenyCondition(t *testing.T) {
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false),
+	er := testValidate(context.TODO(), registryclient.New(),
 		newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).
 			WithPolicy(&policy),
 		cfg, nil)
@@ -2503,7 +2503,7 @@ func Test_StringInDenyCondition(t *testing.T) {
 	resourceUnstructured, err := kubeutils.BytesToUnstructured(resourceRaw)
 	assert.NilError(t, err)
 
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false),
+	er := testValidate(context.TODO(), registryclient.New(),
 		newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).
 			WithPolicy(&policy),
 		cfg, nil)
@@ -3175,7 +3175,7 @@ func testForEach(t *testing.T, policyraw []byte, resourceRaw []byte, msg string,
 	policyContext := newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).
 		WithPolicy(&policy)
 
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), policyContext, cfg, contextLoader)
+	er := testValidate(context.TODO(), registryclient.New(), policyContext, cfg, contextLoader)
 
 	assert.Equal(t, er.PolicyResponse.Rules[0].Status(), status)
 	if msg != "" {
@@ -3233,14 +3233,14 @@ func Test_delete_ignore_pattern(t *testing.T) {
 	policyContextCreate := newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).
 		WithPolicy(&policy)
 
-	engineResponseCreate := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), policyContextCreate, cfg, nil)
+	engineResponseCreate := testValidate(context.TODO(), registryclient.New(), policyContextCreate, cfg, nil)
 	assert.Equal(t, len(engineResponseCreate.PolicyResponse.Rules), 1)
 	assert.Equal(t, engineResponseCreate.PolicyResponse.Rules[0].Status(), engineapi.RuleStatusFail)
 
 	policyContextDelete := newPolicyContext(t, *resourceUnstructured, kyvernov1.Delete, nil).
 		WithPolicy(&policy)
 
-	engineResponseDelete := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), policyContextDelete, cfg, nil)
+	engineResponseDelete := testValidate(context.TODO(), registryclient.New(), policyContextDelete, cfg, nil)
 	assert.Equal(t, len(engineResponseDelete.PolicyResponse.Rules), 0)
 }
 
@@ -3299,7 +3299,7 @@ func Test_ValidatePattern_anyPattern(t *testing.T) {
 			resourceUnstructured, err := kubeutils.BytesToUnstructured(tc.rawResource)
 			assert.NilError(t, err)
 
-			er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
+			er := testValidate(context.TODO(), registryclient.New(), newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy), cfg, nil)
 			if tc.expectedFailed {
 				assert.Assert(t, er.IsFailed())
 			} else if tc.expectedSkipped {
@@ -3406,7 +3406,7 @@ func TestValidate_DenyOverridesValidate(t *testing.T) {
 
 	policyContext := newPolicyContext(t, *resourceUnstructured, kyvernov1.Create, nil).WithPolicy(&policy)
 
-	er := testValidate(context.TODO(), registryclient.New(nil, "", "", "", false), policyContext, cfg, nil)
+	er := testValidate(context.TODO(), registryclient.New(), policyContext, cfg, nil)
 
 	assert.Assert(t, !er.IsSuccessful(), "Expected the request to be denied")
 

--- a/pkg/image/verifiers/cpol/cosign/cert_limit_test.go
+++ b/pkg/image/verifiers/cpol/cosign/cert_limit_test.go
@@ -110,7 +110,7 @@ func buildTSAChainPEM(t *testing.T, numIntermediates int) string {
 // TestBuildCosignOptions_TSACertChainTooManyIntermediates verifies that a TSA certificate
 // chain with more than maxIntermediateCerts intermediate CAs is rejected.
 func TestBuildCosignOptions_TSACertChainTooManyIntermediates(t *testing.T) {
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 
 	tsaChain := buildTSAChainPEM(t, maxIntermediateCerts+1)
 
@@ -131,7 +131,7 @@ func TestBuildCosignOptions_TSACertChainTooManyIntermediates(t *testing.T) {
 // TestBuildCosignOptions_TSACertChainAtLimit verifies that a TSA chain with exactly
 // maxIntermediateCerts intermediates is not rejected by the length check.
 func TestBuildCosignOptions_TSACertChainAtLimit(t *testing.T) {
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 
 	tsaChain := buildTSAChainPEM(t, maxIntermediateCerts)
 
@@ -163,7 +163,7 @@ func buildCertChainPEM(t *testing.T, n int) string {
 // TestBuildCosignOptions_CertChainTooLong verifies that a certificate chain longer than
 // maxIntermediateCerts+1 is rejected when opts.Cert and opts.CertChain are set.
 func TestBuildCosignOptions_CertChainTooLong(t *testing.T) {
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 
 	leafCert, _ := generateTestRootCA(t)
 	certPEM := string(certsToPEM([]*x509.Certificate{leafCert}))
@@ -183,7 +183,7 @@ func TestBuildCosignOptions_CertChainTooLong(t *testing.T) {
 // TestBuildCosignOptions_CertChainAtLimit verifies that a certificate chain of exactly
 // maxIntermediateCerts+1 entries is not rejected by the length check.
 func TestBuildCosignOptions_CertChainAtLimit(t *testing.T) {
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 
 	leafCert, _ := generateTestRootCA(t)
 	certPEM := string(certsToPEM([]*x509.Certificate{leafCert}))

--- a/pkg/image/verifiers/cpol/cosign/sigstore_test.go
+++ b/pkg/image/verifiers/cpol/cosign/sigstore_test.go
@@ -25,7 +25,7 @@ func TestSigstoreBundleSignatureVerification(t *testing.T) {
 		Subject:        "https://github.com/vishal-chdhry/artifact-attestation-example/.github/workflows/build-attested-image.yaml@refs/heads/main",
 	}
 
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 	opts.Client = rc
 
 	verifier := &verifier{}
@@ -45,7 +45,7 @@ func TestSigstoreBundleSignatureResponse(t *testing.T) {
 		Subject:        "https://github.com/vishal-chdhry/artifact-attestation-example/.github/workflows/build-attested-image.yaml@refs/heads/main",
 	}
 
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 	opts.Client = rc
 
 	verifier := &verifier{}
@@ -71,7 +71,7 @@ func TestSigstoreBundleAttestation(t *testing.T) {
 		Type:           "https://slsa.dev/provenance/v1",
 	}
 
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 	opts.Client = rc
 
 	verifier := &verifier{}

--- a/pkg/image/verifiers/cpol/cosign/verifier_test.go
+++ b/pkg/image/verifiers/cpol/cosign/verifier_test.go
@@ -153,7 +153,7 @@ func TestCosignInvalidSignatureAlgorithm(t *testing.T) {
 		SignatureAlgorithm: "sha1",
 	}
 
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 	opts.Client = rc
 
 	verifier := &verifier{}
@@ -170,7 +170,7 @@ func TestCosignKeyless(t *testing.T) {
 		IgnoreSCT: true,
 	}
 
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 	opts.Client = rc
 
 	verifier := &verifier{}
@@ -196,7 +196,7 @@ func TestRekorPubkeys(t *testing.T) {
 		IgnoreSCT:   true,
 	}
 
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 	opts.Client = rc
 
 	verifier := &verifier{}
@@ -217,7 +217,7 @@ func TestIgnoreTlogsandIgnoreSCT(t *testing.T) {
 		ImageRef: "ghcr.io/kyverno/test-verify-image",
 	}
 
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 	opts.Client = rc
 
 	verifier := &verifier{}
@@ -252,7 +252,7 @@ func TestCTLogsPubkeys(t *testing.T) {
 		CTLogsPubKey: wrongPubKey,
 	}
 
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 	opts.Client = rc
 
 	verifier := &verifier{}
@@ -331,7 +331,7 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEstG5Xl7UxkQsmLUxdmS85HLgYBFyc/P/oQ22iazkKm8P
 		TSACertChain: freeTSACertChain,
 	}
 
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 	opts.Client = rc
 
 	verifier := &verifier{}
@@ -349,7 +349,7 @@ IoL3R/9n1SJ7s00Nfkk3z4/Ar6q8el/guUmXi8akEJMxvHnvphorVUz8vQ==
 `,
 	}
 
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 	opts.Client = rc
 
 	verifier := &verifier{}
@@ -362,7 +362,7 @@ IoL3R/9n1SJ7s00Nfkk3z4/Ar6q8el/guUmXi8akEJMxvHnvphorVUz8vQ==
 }
 
 func TestBuildCosignOptionsUsesSignedTimestamps(t *testing.T) {
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 
 	tests := []struct {
 		name             string

--- a/pkg/image/verifiers/cpol/notary/notary_test.go
+++ b/pkg/image/verifiers/cpol/notary/notary_test.go
@@ -60,7 +60,7 @@ func TestNotaryImageVerification(t *testing.T) {
 		Cert:     cert,
 	}
 
-	rc := registryclient.New(nil, "", "", "", false)
+	rc := registryclient.New()
 	opts.Client = rc
 
 	verifier := &notaryVerifier{}

--- a/pkg/webhooks/resource/fake.go
+++ b/pkg/webhooks/resource/fake.go
@@ -43,7 +43,7 @@ func NewFakeHandlers(ctx context.Context, policyCache policycache.Cache) *resour
 	urLister := kyvernoInformers.Kyverno().V2().UpdateRequests().Lister().UpdateRequests(config.KyvernoNamespace())
 	peLister := kyvernoInformers.Kyverno().V2().PolicyExceptions().Lister()
 	jp := jmespath.New(configuration)
-	rclient := registryclient.New(nil, "", "", "", false)
+	rclient := registryclient.New()
 	_ = reportutils.NewReportingConfig([]string{"pass", "fail", "warn", "error", "skip"}, "validate", "mutate", "mutateExisiting", "generate", "imageVerify")
 
 	return &resourceHandlers{

--- a/pkg/webhooks/resource/imageverification/handler_test.go
+++ b/pkg/webhooks/resource/imageverification/handler_test.go
@@ -49,7 +49,7 @@ func newFakeImageVerificationHandler(t *testing.T, ctx context.Context) (ImageVe
 	dclientInstance := dclient.NewEmptyFakeClient()
 	configuration := config.NewDefaultConfiguration(false)
 	jp := jmespath.New(configuration)
-	rclient := registryclient.New(nil, "", "", "", false)
+	rclient := registryclient.New()
 	configMapResolver, _ := resolvers.NewClientBasedResolver(client)
 	peLister := kyvernoInformers.Kyverno().V2().PolicyExceptions().Lister()
 

--- a/pkg/webhooks/resource/validation_test.go
+++ b/pkg/webhooks/resource/validation_test.go
@@ -2078,7 +2078,7 @@ func TestValidate_failure_action_overrides(t *testing.T) {
 	}
 	cfg := config.NewDefaultConfiguration(false)
 	jp := jmespath.New(cfg)
-	rclient := registryclient.New(nil, "", "", "", false)
+	rclient := registryclient.New()
 	eng := engine.NewEngine(
 		cfg,
 		jp,
@@ -2180,7 +2180,7 @@ func Test_RuleSelector(t *testing.T) {
 	assert.NilError(t, err)
 
 	ctx = ctx.WithPolicy(&policy)
-	rclient := registryclient.New(nil, "", "", "", false)
+	rclient := registryclient.New()
 	eng := engine.NewEngine(
 		cfg,
 		jp,


### PR DESCRIPTION
## Explanation

Bump kyverno-sdk to commit  68d74afcb07a, it crosses `registryclient.New()` switch from positional args to variable args.


THIS IS MANDATORY.
-->

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
