### PR TITLE
fix: validate PolicyException CEL match conditions

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -236,7 +236,7 @@ func createrLeaderControllers(
 		[]admissionregistrationv1.RuleWithOperations{{
 			Rule: admissionregistrationv1.Rule{
 				APIGroups:   []string{"policies.kyverno.io"},
-				APIVersions: []string{"v1alpha1"},
+				APIVersions: []string{"v1alpha1", "v1beta1", "v1"},
 				Resources:   []string{"policyexceptions"},
 			},
 			Operations: []admissionregistrationv1.OperationType{

--- a/pkg/cel/compiler/policy_exception.go
+++ b/pkg/cel/compiler/policy_exception.go
@@ -1,0 +1,105 @@
+package compiler
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/google/cel-go/cel"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/util/version"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+	"k8s.io/apiserver/pkg/cel/environment"
+)
+
+var (
+	policyExceptionEnvSetInit sync.Once
+	policyExceptionEnvSet     *environment.EnvSet
+	errPolicyExceptionEnvSet  error
+)
+
+// CompilePolicyExceptionMatchConditions validates PolicyException match conditions against
+// the admission variables shared by Kyverno CEL policy evaluators.
+func CompilePolicyExceptionMatchConditions(conditions []admissionregistrationv1.MatchCondition, preexistingExpressions map[string]bool) field.ErrorList {
+	path := field.NewPath("spec").Child("matchConditions")
+	var allErrors field.ErrorList
+	conditionNames := sets.New[string]()
+
+	if len(conditions) > 64 {
+		allErrors = append(allErrors, field.TooMany(path, len(conditions), 64))
+	}
+
+	envSet, err := getPolicyExceptionEnvSet()
+	if err != nil {
+		return append(allErrors, field.InternalError(path, err))
+	}
+
+	for i, condition := range conditions {
+		conditionPath := path.Index(i)
+		trimmedExpression := strings.TrimSpace(condition.Expression)
+		if trimmedExpression == "" {
+			allErrors = append(allErrors, field.Required(conditionPath.Child("expression"), ""))
+		} else {
+			envType := environment.NewExpressions
+			if preexistingExpressions[condition.Expression] {
+				envType = environment.StoredExpressions
+			}
+			env, err := envSet.Env(envType)
+			if err != nil {
+				allErrors = append(allErrors, field.InternalError(conditionPath.Child("expression"), err))
+			} else {
+				condition.Expression = trimmedExpression
+				_, errs := CompileMatchCondition(conditionPath, env, condition)
+				allErrors = append(allErrors, errs...)
+			}
+		}
+
+		if condition.Name == "" {
+			allErrors = append(allErrors, field.Required(conditionPath.Child("name"), ""))
+		} else if errs := validation.IsQualifiedName(condition.Name); len(errs) > 0 {
+			for _, err := range errs {
+				allErrors = append(allErrors, field.Invalid(conditionPath.Child("name"), condition.Name, err))
+			}
+		} else if conditionNames.Has(condition.Name) {
+			allErrors = append(allErrors, field.Duplicate(conditionPath.Child("name"), condition.Name))
+		} else {
+			conditionNames.Insert(condition.Name)
+		}
+	}
+
+	return allErrors
+}
+
+func getPolicyExceptionEnvSet() (*environment.EnvSet, error) {
+	policyExceptionEnvSetInit.Do(func() {
+		base := environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion())
+		storedEnv, err := base.Env(environment.StoredExpressions)
+		if err != nil {
+			errPolicyExceptionEnvSet = err
+			return
+		}
+		declProvider := apiservercel.NewDeclTypeProvider(NamespaceType, RequestType)
+		declOptions, err := declProvider.EnvOptions(storedEnv.CELTypeProvider())
+		if err != nil {
+			errPolicyExceptionEnvSet = err
+			return
+		}
+		envOptions := make([]cel.EnvOption, 0, 6+len(declOptions))
+		envOptions = append(envOptions,
+			cel.Variable(NamespaceObjectKey, NamespaceType.CelType()),
+			cel.Variable(ObjectKey, cel.DynType),
+			cel.Variable(OldObjectKey, cel.DynType),
+			cel.Variable(RequestKey, RequestType.CelType()),
+			cel.Types(NamespaceType.CelType()),
+			cel.Types(RequestType.CelType()),
+		)
+		envOptions = append(envOptions, declOptions...)
+		policyExceptionEnvSet, errPolicyExceptionEnvSet = base.Extend(environment.VersionedOptions{
+			IntroducedVersion: version.MajorMinor(1, 0),
+			EnvOptions:        envOptions,
+		})
+	})
+	return policyExceptionEnvSet, errPolicyExceptionEnvSet
+}

--- a/pkg/cel/compiler/policy_exception_test.go
+++ b/pkg/cel/compiler/policy_exception_test.go
@@ -1,0 +1,109 @@
+package compiler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+)
+
+func TestCompilePolicyExceptionMatchConditions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		expression string
+		wantErrors bool
+	}{
+		{
+			name:       "object",
+			expression: "object.metadata.name == 'pod'",
+		},
+		{
+			name:       "old object",
+			expression: "oldObject.metadata.name == 'old-pod'",
+		},
+		{
+			name:       "request object",
+			expression: "request.object.metadata.name == 'pod'",
+		},
+		{
+			name:       "namespace object",
+			expression: "namespaceObject.metadata.name == 'default'",
+		},
+		{
+			name:       "undeclared function",
+			expression: "object.metadata.name.endsWithTYPO('pod')",
+			wantErrors: true,
+		},
+		{
+			name:       "undeclared variable",
+			expression: "totally.unbound.variable == 'x'",
+			wantErrors: true,
+		},
+		{
+			name:       "non boolean result",
+			expression: "object.metadata.name",
+			wantErrors: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			errs := CompilePolicyExceptionMatchConditions([]admissionregistrationv1.MatchCondition{{
+				Name:       "test-condition",
+				Expression: tt.expression,
+			}}, nil)
+			if tt.wantErrors {
+				assert.NotEmpty(t, errs)
+				assert.Equal(t, "spec.matchConditions[0].expression", errs[0].Field)
+			} else {
+				assert.Empty(t, errs)
+			}
+		})
+	}
+}
+
+func TestCompilePolicyExceptionMatchConditionsStructure(t *testing.T) {
+	t.Parallel()
+	t.Run("duplicate names", func(t *testing.T) {
+		t.Parallel()
+		errs := CompilePolicyExceptionMatchConditions([]admissionregistrationv1.MatchCondition{
+			{Name: "duplicate", Expression: "true"},
+			{Name: "duplicate", Expression: "true"},
+		}, nil)
+		assert.NotEmpty(t, errs)
+		assert.Equal(t, "spec.matchConditions[1].name", errs[0].Field)
+	})
+	t.Run("empty expression", func(t *testing.T) {
+		t.Parallel()
+		errs := CompilePolicyExceptionMatchConditions([]admissionregistrationv1.MatchCondition{{
+			Name: "empty",
+		}}, nil)
+		assert.NotEmpty(t, errs)
+		assert.Equal(t, "spec.matchConditions[0].expression", errs[0].Field)
+	})
+	t.Run("invalid name", func(t *testing.T) {
+		t.Parallel()
+		errs := CompilePolicyExceptionMatchConditions([]admissionregistrationv1.MatchCondition{{
+			Name:       "not a qualified name",
+			Expression: "true",
+		}}, nil)
+		assert.NotEmpty(t, errs)
+		assert.Equal(t, "spec.matchConditions[0].name", errs[0].Field)
+	})
+	t.Run("too many conditions", func(t *testing.T) {
+		t.Parallel()
+		conditions := make([]admissionregistrationv1.MatchCondition, 65)
+		for i := range conditions {
+			conditions[i] = admissionregistrationv1.MatchCondition{
+				Name:       fmt.Sprintf("condition-%d", i),
+				Expression: "true",
+			}
+		}
+		errs := CompilePolicyExceptionMatchConditions(conditions, nil)
+		assert.NotEmpty(t, errs)
+		assert.Equal(t, "spec.matchConditions", errs[0].Field)
+	})
+}

--- a/pkg/webhooks/celexception/validate.go
+++ b/pkg/webhooks/celexception/validate.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/kyverno/kyverno/pkg/cel/compiler"
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	validation "github.com/kyverno/kyverno/pkg/validation/exception"
 	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
@@ -22,7 +23,7 @@ func NewHandlers(validationOptions validation.ValidationOptions) *celExceptionHa
 
 // Validate performs the validation check on CEL PolicyException resources
 func (h *celExceptionHandlers) Validate(ctx context.Context, logger logr.Logger, request handlers.AdmissionRequest, _ string, startTime time.Time) handlers.AdmissionResponse {
-	polex, _, err := admissionutils.GetCELPolicyExceptions(request.AdmissionRequest)
+	polex, oldPolex, err := admissionutils.GetCELPolicyExceptions(request.AdmissionRequest)
 	if err != nil {
 		logger.Error(err, "failed to unmarshal CEL PolicyExceptions from admission request")
 		return admissionutils.Response(request.UID, err)
@@ -32,5 +33,12 @@ func (h *celExceptionHandlers) Validate(ctx context.Context, logger logr.Logger,
 		warning = validation.DisabledPolex
 	}
 	errs := polex.Validate()
+	preexistingExpressions := make(map[string]bool)
+	if oldPolex != nil {
+		for _, condition := range oldPolex.Spec.MatchConditions {
+			preexistingExpressions[condition.Expression] = true
+		}
+	}
+	errs = append(errs, compiler.CompilePolicyExceptionMatchConditions(polex.Spec.MatchConditions, preexistingExpressions)...)
 	return admissionutils.Response(request.UID, errs.ToAggregate(), warning)
 }

--- a/pkg/webhooks/celexception/validate_test.go
+++ b/pkg/webhooks/celexception/validate_test.go
@@ -1,0 +1,184 @@
+package celexception
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	policiesv1alpha1 "github.com/kyverno/api/api/policies.kyverno.io/v1alpha1"
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	validation "github.com/kyverno/kyverno/pkg/validation/exception"
+	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func newAdmissionRequest(t *testing.T, operation admissionv1.Operation, object, oldObject *policiesv1beta1.PolicyException) handlers.AdmissionRequest {
+	t.Helper()
+	raw, err := json.Marshal(object)
+	require.NoError(t, err)
+	request := handlers.AdmissionRequest{AdmissionRequest: admissionv1.AdmissionRequest{
+		UID:       types.UID("test-uid"),
+		Operation: operation,
+		Object:    runtime.RawExtension{Raw: raw},
+	}}
+	if oldObject != nil {
+		oldRaw, err := json.Marshal(oldObject)
+		require.NoError(t, err)
+		request.OldObject = runtime.RawExtension{Raw: oldRaw}
+	}
+	return request
+}
+
+func policyException(expression string) *policiesv1beta1.PolicyException {
+	return &policiesv1beta1.PolicyException{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-exception", Namespace: "default"},
+		Spec: policiesv1beta1.PolicyExceptionSpec{
+			PolicyRefs: []policiesv1alpha1.PolicyRef{{
+				Name: "test-policy",
+				Kind: "ValidatingPolicy",
+			}},
+			MatchConditions: []admissionregistrationv1.MatchCondition{{
+				Name:       "test-condition",
+				Expression: expression,
+			}},
+		},
+	}
+}
+
+func TestValidateMatchConditions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		expression string
+		allowed    bool
+	}{
+		{
+			name:       "object",
+			expression: "object.spec.containers.all(container, container.image.endsWith('@sha256:abc'))",
+			allowed:    true,
+		},
+		{
+			name:       "old object",
+			expression: "oldObject.metadata.name == 'old-pod'",
+			allowed:    true,
+		},
+		{
+			name:       "request object",
+			expression: "request.object.metadata.name == 'pod'",
+			allowed:    true,
+		},
+		{
+			name:       "namespace object",
+			expression: "namespaceObject.metadata.name == 'default'",
+			allowed:    true,
+		},
+		{
+			name:       "undeclared receiver function",
+			expression: "object.spec.containers.all(container, container.image.endsWithTYPO('@sha256:abc'))",
+			allowed:    false,
+		},
+		{
+			name:       "undeclared root variable",
+			expression: "totally.unbound.variable == 'x'",
+			allowed:    false,
+		},
+		{
+			name:       "non boolean result",
+			expression: "'not-a-condition'",
+			allowed:    false,
+		},
+		{
+			name:       "syntax error",
+			expression: "object.metadata.name ==",
+			allowed:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler := NewHandlers(validation.ValidationOptions{Enabled: true})
+			response := handler.Validate(
+				context.Background(),
+				logr.Discard(),
+				newAdmissionRequest(t, admissionv1.Create, policyException(tt.expression), nil),
+				"",
+				time.Now(),
+			)
+
+			assert.Equal(t, tt.allowed, response.Allowed)
+			if !tt.allowed {
+				require.NotNil(t, response.Result)
+				assert.Contains(t, response.Result.Message, "spec.matchConditions[0].expression")
+			}
+		})
+	}
+}
+
+func TestValidateUpdateRejectsNewInvalidExpression(t *testing.T) {
+	t.Parallel()
+	handler := NewHandlers(validation.ValidationOptions{Enabled: true})
+	oldException := policyException("object.metadata.name == 'allowed-pod'")
+	newException := oldException.DeepCopy()
+	newException.Spec.MatchConditions[0].Expression = "object.metadata.name.endsWithTYPO('pod')"
+
+	response := handler.Validate(
+		context.Background(),
+		logr.Discard(),
+		newAdmissionRequest(t, admissionv1.Update, newException, oldException),
+		"",
+		time.Now(),
+	)
+
+	assert.False(t, response.Allowed)
+	require.NotNil(t, response.Result)
+	assert.Contains(t, response.Result.Message, "spec.matchConditions[0].expression")
+}
+
+func TestValidateUpdateAllowsValidExpression(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		oldExpression string
+		newExpression string
+	}{
+		{
+			name:          "valid expression remains valid",
+			oldExpression: "object.metadata.name == 'allowed-pod'",
+			newExpression: "object.metadata.name == 'allowed-pod'",
+		},
+		{
+			name:          "invalid expression is corrected",
+			oldExpression: "object.metadata.name.endsWithTYPO('pod')",
+			newExpression: "object.metadata.name.endsWith('pod')",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler := NewHandlers(validation.ValidationOptions{Enabled: true})
+			oldException := policyException(tt.oldExpression)
+			newException := oldException.DeepCopy()
+			newException.Spec.MatchConditions[0].Expression = tt.newExpression
+
+			response := handler.Validate(
+				context.Background(),
+				logr.Discard(),
+				newAdmissionRequest(t, admissionv1.Update, newException, oldException),
+				"",
+				time.Now(),
+			)
+
+			assert.True(t, response.Allowed)
+		})
+	}
+}

--- a/test/conformance/chainsaw/validating-policies/exceptions/cel-validation/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/validating-policies/exceptions/cel-validation/chainsaw-test.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: policy-exception-cel-validation
+spec:
+  concurrent: false
+  steps:
+  - name: reject-invalid-create-for-every-served-version
+    try:
+    - script:
+        content: kubectl apply -n "$NAMESPACE" -f invalid-v1alpha1.yaml
+        check:
+          ($error != null): true
+          (contains($stderr, 'spec.matchConditions[0].expression')): true
+          (contains($stderr, 'endsWithTYPO')): true
+    - script:
+        content: kubectl apply -n "$NAMESPACE" -f invalid-v1beta1.yaml
+        check:
+          ($error != null): true
+          (contains($stderr, 'spec.matchConditions[0].expression')): true
+          (contains($stderr, 'endsWithTYPO')): true
+    - script:
+        content: kubectl apply -n "$NAMESPACE" -f invalid-v1.yaml
+        check:
+          ($error != null): true
+          (contains($stderr, 'spec.matchConditions[0].expression')): true
+          (contains($stderr, 'endsWithTYPO')): true
+  - name: accept-valid-create
+    try:
+    - apply:
+        file: valid-v1beta1.yaml
+  - name: reject-valid-to-invalid-update
+    try:
+    - script:
+        content: kubectl apply -n "$NAMESPACE" -f invalid-update-v1beta1.yaml
+        check:
+          ($error != null): true
+          (contains($stderr, 'spec.matchConditions[0].expression')): true
+          (contains($stderr, 'totally')): true
+    - script:
+        content: kubectl get -n "$NAMESPACE" policyexceptions.policies.kyverno.io valid-exception -o jsonpath='{.spec.matchConditions[0].expression}'
+        check:
+          ($error == null): true
+          (trim_space($stdout)): object.metadata.name == 'allowed-pod'

--- a/test/conformance/chainsaw/validating-policies/exceptions/cel-validation/invalid-update-v1beta1.yaml
+++ b/test/conformance/chainsaw/validating-policies/exceptions/cel-validation/invalid-update-v1beta1.yaml
@@ -1,0 +1,11 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: PolicyException
+metadata:
+  name: valid-exception
+spec:
+  policyRefs:
+  - name: test-policy
+    kind: ValidatingPolicy
+  matchConditions:
+  - name: valid-condition
+    expression: totally.unbound.variable == 'x'

--- a/test/conformance/chainsaw/validating-policies/exceptions/cel-validation/invalid-v1.yaml
+++ b/test/conformance/chainsaw/validating-policies/exceptions/cel-validation/invalid-v1.yaml
@@ -1,0 +1,11 @@
+apiVersion: policies.kyverno.io/v1
+kind: PolicyException
+metadata:
+  name: invalid-v1
+spec:
+  policyRefs:
+  - name: test-policy
+    kind: ValidatingPolicy
+  matchConditions:
+  - name: invalid-function
+    expression: object.metadata.name.endsWithTYPO('pod')

--- a/test/conformance/chainsaw/validating-policies/exceptions/cel-validation/invalid-v1alpha1.yaml
+++ b/test/conformance/chainsaw/validating-policies/exceptions/cel-validation/invalid-v1alpha1.yaml
@@ -1,0 +1,11 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: PolicyException
+metadata:
+  name: invalid-v1alpha1
+spec:
+  policyRefs:
+  - name: test-policy
+    kind: ValidatingPolicy
+  matchConditions:
+  - name: invalid-function
+    expression: object.metadata.name.endsWithTYPO('pod')

--- a/test/conformance/chainsaw/validating-policies/exceptions/cel-validation/invalid-v1beta1.yaml
+++ b/test/conformance/chainsaw/validating-policies/exceptions/cel-validation/invalid-v1beta1.yaml
@@ -1,0 +1,11 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: PolicyException
+metadata:
+  name: invalid-v1beta1
+spec:
+  policyRefs:
+  - name: test-policy
+    kind: ValidatingPolicy
+  matchConditions:
+  - name: invalid-function
+    expression: object.metadata.name.endsWithTYPO('pod')

--- a/test/conformance/chainsaw/validating-policies/exceptions/cel-validation/valid-v1beta1.yaml
+++ b/test/conformance/chainsaw/validating-policies/exceptions/cel-validation/valid-v1beta1.yaml
@@ -1,0 +1,11 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: PolicyException
+metadata:
+  name: valid-exception
+spec:
+  policyRefs:
+  - name: test-policy
+    kind: ValidatingPolicy
+  matchConditions:
+  - name: valid-condition
+    expression: object.metadata.name == 'allowed-pod'


### PR DESCRIPTION
## Explanation

`PolicyException.spec.matchConditions` expressions were accepted without CEL compilation during create or update. A typo or undeclared variable could therefore be stored successfully and only fail later while a referenced policy was compiled, producing behavior that depended on controller state and restart timing.

This fix validates match conditions at write time against the common PolicyException runtime variables and rejects invalid expressions with a field-specific error. It also registers the validating webhook for all served PolicyException versions instead of only `v1alpha1`.

## Related issue

Closes #17277.

The focused scope was discussed with @realshuting in the issue.

## Milestone of this PR

Target: 1.19.1.

## Documentation (required for features)

This is a bug fix and is exempt from a documentation PR under the PR documentation guide.

## What type of PR is this

/kind bug

## Proposed Changes

1. Before this PR, Kyverno structurally validated CEL PolicyExceptions but did not compile their match conditions on create or update. In addition, `v1beta1` and `v1` requests bypassed this validating handler.
2. This PR adds a dedicated PolicyException compilation environment for `object`, `oldObject`, `request`, and `namespaceObject`, preserves stored-expression compatibility on updates, and validates every served API version.
3. After this PR, valid expressions continue to be accepted while syntax errors, undeclared variables/functions, and non-boolean results are rejected before persistence.

This PR intentionally does not change evaluator lifecycle behavior, status conditions, events, or the separately reported state-dependent no-match/Deny latch. Those require independent reproduction and follow-up work.

### Proof Manifests

The complete automated proof is in `test/conformance/chainsaw/validating-policies/exceptions/cel-validation` and covers `v1alpha1`, `v1beta1`, `v1`, and valid-to-invalid updates.

Invalid create (rejected with `spec.matchConditions[0].expression`):

```yaml
apiVersion: policies.kyverno.io/v1
kind: PolicyException
metadata:
  name: invalid-expression
spec:
  policyRefs:
  - name: test-policy
    kind: ValidatingPolicy
  matchConditions:
  - name: invalid-function
    expression: object.metadata.name.endsWithTYPO('pod')
```

Valid create:

```yaml
apiVersion: policies.kyverno.io/v1beta1
kind: PolicyException
metadata:
  name: valid-expression
spec:
  policyRefs:
  - name: test-policy
    kind: ValidatingPolicy
  matchConditions:
  - name: valid-condition
    expression: object.metadata.name == 'allowed-pod'
```

## Verification

- `go test -race -p 1 ./pkg/cel/compiler ./pkg/webhooks/celexception ./pkg/utils/admission -count=1`
- `go test -p 1 ./cmd/kyverno -run '^$' -count=1`
- `chainsaw test test/conformance/chainsaw/validating-policies/exceptions/cel-validation --config test/conformance/chainsaw/validating-policies/.chainsaw.yaml`
- `make codegen-all`
- `make verify-codegen`
- `make imports-check fmt-check`
- `./.tools/golangci-lint run ./... -c .golangci.yml`

The focused validation tests were first run against the pre-fix handler and failed because invalid create/update requests were allowed.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). AI assistance is disclosed with an `Assisted-by` trailer in the commit.
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and added proof manifests. This bug fix is documentation-exempt under that guide.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to `release-1.19`.
- [ ] My PR contains new functionality that requires separate CLI support.

## Further Comments

Please consider this for the 1.19.1 milestone and a `release-1.19` cherry-pick.
