### PR TITLE
fix(cel): set rule name for validate.cel results

### DIFF
--- a/pkg/cel/policies/vpol/engine/engine.go
+++ b/pkg/cel/policies/vpol/engine/engine.go
@@ -192,8 +192,7 @@ func (e *engineImpl) handlePolicy(ctx context.Context, policy Policy, jsonPayloa
 			)
 		}
 	} else {
-		// TODO: do we want to set a rule name?
-		ruleName := ""
+		ruleName := "validation"
 		if result.Error != nil {
 			response.Rules = append(response.Rules, *engineapi.RuleError(ruleName, engineapi.Validation, "error", result.Error, withValidationIndex(nil, result.Index)))
 		} else if result.Result {


### PR DESCRIPTION
### Explanation

The rule name for `validate.cel` results was left blank due to an open TODO. This fix sets it to "`validation`" so results show a meaningful rule name in reports and CLI output, consistent with the other named stages (match, evaluation, exception) already used in the same function.

### What type of PR is this

/kind cleanup

### Proposed Changes

Sets `ruleName := "validation"` instead of an empty string in `handlePolicy` when producing pass/fail/error rule results for `validate.cel` policies. No behavior change to policy evaluation, only the reported rule name.