### PR TITLE
fix(test): disable IVPol digest defaults in leftover fixtures in v1.19

### DIFF
--- a/test/conformance/chainsaw/cli/apply/apply-ivps-in-cluster-mode-with-polex/policy.yaml
+++ b/test/conformance/chainsaw/cli/apply/apply-ivps-in-cluster-mode-with-polex/policy.yaml
@@ -18,6 +18,10 @@ spec:
         has(object.metadata.labels) && has(object.metadata.labels.prod) && object.metadata.labels.prod == 'true'
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/image-validating-policies/context/configmap/policy.yaml
+++ b/test/conformance/chainsaw/image-validating-policies/context/configmap/policy.yaml
@@ -15,6 +15,10 @@ spec:
         apiVersions: [v1]
         operations: [CREATE]
         resources: [deployments]
+  validationConfigurations:
+    mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:


### PR DESCRIPTION
## Explanation

Fix for existing conformance tests. This PR turns the defaults off for two ImageValidatingPolicy fixtures that still uses the default digest settings.

I'm bring up the fixes in smaller PRs

## Related issue
https://github.com/kyverno/kyverno/issues/17352

## Milestone of this PR

/milestone 1.19.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind failing-test

## Proposed Changes

Set `validationConfigurations` (`mutateDigest`, `verifyDigest`, and `required` to `false`) on:

- `image-validating-policies/context/configmap`
- `cli/apply/apply-ivps-in-cluster-mode-with-polex`

Same as the other fixtures updated in #16815 and #17336.

### Proof Manifests

N/A

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
