### PR TITLE
fix: use errors.Is for anchor error type classification instead of string matching

### DIFF
--- a/pkg/engine/anchor/error.go
+++ b/pkg/engine/anchor/error.go
@@ -1,8 +1,8 @@
 package anchor
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 )
 
 // anchorError is the const specification of anchor errors
@@ -37,6 +37,18 @@ func (e validateAnchorError) Error() string {
 	return e.message
 }
 
+// Is implements the errors.Is interface so that anchor errors are identified by
+// their type rather than by matching error message text. This allows wrapped
+// anchor errors (via %w) to be correctly recognized, and prevents unrelated
+// errors with the same message text from being misclassified as anchor errors.
+func (e validateAnchorError) Is(target error) bool {
+	t, ok := target.(validateAnchorError)
+	if !ok {
+		return false
+	}
+	return e.err == t.err
+}
+
 // newNegationAnchorError returns a new instance of validateAnchorError
 func newValidateAnchorError(err anchorError, prefix, msg string) validateAnchorError {
 	return validateAnchorError{
@@ -60,30 +72,27 @@ func newGlobalAnchorError(msg string) validateAnchorError {
 	return newValidateAnchorError(globalAnchorErr, globalAnchorErrMsg, msg)
 }
 
-// isError checks if error matches the given error type
-func isError(err error, code anchorError, msg string) bool {
+// isError checks if error matches the given error type, including when
+// the error is wrapped (via %w). Uses errors.Is for type-based matching
+// instead of error message string matching.
+func isError(err error, code anchorError) bool {
 	if err != nil {
-		if t, ok := err.(validateAnchorError); ok {
-			return t.err == code
-		} else {
-			// TODO: we shouldn't need this, error is not properly propagated
-			return strings.Contains(err.Error(), msg)
-		}
+		return errors.Is(err, validateAnchorError{err: code})
 	}
 	return false
 }
 
 // IsNegationAnchorError checks if error is a negation anchor error
 func IsNegationAnchorError(err error) bool {
-	return isError(err, negationAnchorErr, negationAnchorErrMsg)
+	return isError(err, negationAnchorErr)
 }
 
 // IsConditionalAnchorError checks if error is a conditional anchor error
 func IsConditionalAnchorError(err error) bool {
-	return isError(err, conditionalAnchorErr, conditionalAnchorErrMsg)
+	return isError(err, conditionalAnchorErr)
 }
 
 // IsGlobalAnchorError checks if error is a global anchor error
 func IsGlobalAnchorError(err error) bool {
-	return isError(err, globalAnchorErr, globalAnchorErrMsg)
+	return isError(err, globalAnchorErr)
 }

--- a/pkg/engine/anchor/error_test.go
+++ b/pkg/engine/anchor/error_test.go
@@ -2,7 +2,7 @@ package anchor
 
 import (
 	"errors"
-	"reflect"
+	"fmt"
 	"testing"
 )
 
@@ -77,7 +77,7 @@ func Test_newNegationAnchorError(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := newNegationAnchorError(tt.args.msg); !reflect.DeepEqual(got, tt.want) {
+			if got := newNegationAnchorError(tt.args.msg); got != tt.want {
 				t.Errorf("newNegationAnchorError() = %v, want %v", got, tt.want)
 			}
 		})
@@ -108,7 +108,7 @@ func Test_newConditionalAnchorError(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := newConditionalAnchorError(tt.args.msg); !reflect.DeepEqual(got, tt.want) {
+			if got := newConditionalAnchorError(tt.args.msg); got != tt.want {
 				t.Errorf("newConditionalAnchorError() = %v, want %v", got, tt.want)
 			}
 		})
@@ -139,7 +139,7 @@ func Test_newGlobalAnchorError(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := newGlobalAnchorError(tt.args.msg); !reflect.DeepEqual(got, tt.want) {
+			if got := newGlobalAnchorError(tt.args.msg); got != tt.want {
 				t.Errorf("newGlobalAnchorError() = %v, want %v", got, tt.want)
 			}
 		})
@@ -147,42 +147,42 @@ func Test_newGlobalAnchorError(t *testing.T) {
 }
 
 func TestIsNegationAnchorError(t *testing.T) {
-	type args struct {
-		err error
-	}
 	tests := []struct {
 		name string
-		args args
+		err  error
 		want bool
 	}{{
-		args: args{
-			err: nil,
-		},
+		name: "nil error",
+		err:  nil,
 		want: false,
 	}, {
-		args: args{
-			err: errors.New("negation anchor matched in resource: test"),
-		},
+		name: "plain error with matching message should NOT be classified as anchor error",
+		err:  errors.New("negation anchor matched in resource: test"),
+		want: false,
+	}, {
+		name: "conditional anchor error is not negation",
+		err:  newConditionalAnchorError("test"),
+		want: false,
+	}, {
+		name: "global anchor error is not negation",
+		err:  newGlobalAnchorError("test"),
+		want: false,
+	}, {
+		name: "direct negation anchor error",
+		err:  newNegationAnchorError("test"),
 		want: true,
 	}, {
-		args: args{
-			err: newConditionalAnchorError("test"),
-		},
-		want: false,
+		name: "wrapped negation anchor error should be recognized",
+		err:  fmt.Errorf("wrapper: %w", newNegationAnchorError("test")),
+		want: true,
 	}, {
-		args: args{
-			err: newGlobalAnchorError("test"),
-		},
-		want: false,
-	}, {
-		args: args{
-			err: newNegationAnchorError("test"),
-		},
+		name: "doubly wrapped negation anchor error should be recognized",
+		err:  fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", newNegationAnchorError("test"))),
 		want: true,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsNegationAnchorError(tt.args.err); got != tt.want {
+			if got := IsNegationAnchorError(tt.err); got != tt.want {
 				t.Errorf("IsNegationAnchorError() = %v, want %v", got, tt.want)
 			}
 		})
@@ -190,42 +190,42 @@ func TestIsNegationAnchorError(t *testing.T) {
 }
 
 func TestIsConditionalAnchorError(t *testing.T) {
-	type args struct {
-		err error
-	}
 	tests := []struct {
 		name string
-		args args
+		err  error
 		want bool
 	}{{
-		args: args{
-			err: nil,
-		},
+		name: "nil error",
+		err:  nil,
 		want: false,
 	}, {
-		args: args{
-			err: errors.New("conditional anchor mismatch: test"),
-		},
-		want: true,
-	}, {
-		args: args{
-			err: newConditionalAnchorError("test"),
-		},
-		want: true,
-	}, {
-		args: args{
-			err: newGlobalAnchorError("test"),
-		},
+		name: "plain error with matching message should NOT be classified as anchor error",
+		err:  errors.New("conditional anchor mismatch: test"),
 		want: false,
 	}, {
-		args: args{
-			err: newNegationAnchorError("test"),
-		},
+		name: "direct conditional anchor error",
+		err:  newConditionalAnchorError("test"),
+		want: true,
+	}, {
+		name: "global anchor error is not conditional",
+		err:  newGlobalAnchorError("test"),
+		want: false,
+	}, {
+		name: "negation anchor error is not conditional",
+		err:  newNegationAnchorError("test"),
+		want: false,
+	}, {
+		name: "wrapped conditional anchor error should be recognized",
+		err:  fmt.Errorf("wrapper: %w", newConditionalAnchorError("test")),
+		want: true,
+	}, {
+		name: "unrelated error with same text should NOT be classified as anchor error",
+		err:  fmt.Errorf("wrapper: %w", errors.New("conditional anchor mismatch: something")),
 		want: false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsConditionalAnchorError(tt.args.err); got != tt.want {
+			if got := IsConditionalAnchorError(tt.err); got != tt.want {
 				t.Errorf("IsConditionalAnchorError() = %v, want %v", got, tt.want)
 			}
 		})
@@ -233,42 +233,38 @@ func TestIsConditionalAnchorError(t *testing.T) {
 }
 
 func TestIsGlobalAnchorError(t *testing.T) {
-	type args struct {
-		err error
-	}
 	tests := []struct {
 		name string
-		args args
+		err  error
 		want bool
 	}{{
-		args: args{
-			err: nil,
-		},
+		name: "nil error",
+		err:  nil,
 		want: false,
 	}, {
-		args: args{
-			err: errors.New("global anchor mismatch: test"),
-		},
+		name: "plain error with matching message should NOT be classified as anchor error",
+		err:  errors.New("global anchor mismatch: test"),
+		want: false,
+	}, {
+		name: "conditional anchor error is not global",
+		err:  newConditionalAnchorError("test"),
+		want: false,
+	}, {
+		name: "direct global anchor error",
+		err:  newGlobalAnchorError("test"),
 		want: true,
 	}, {
-		args: args{
-			err: newConditionalAnchorError("test"),
-		},
+		name: "negation anchor error is not global",
+		err:  newNegationAnchorError("test"),
 		want: false,
 	}, {
-		args: args{
-			err: newGlobalAnchorError("test"),
-		},
+		name: "wrapped global anchor error should be recognized",
+		err:  fmt.Errorf("wrapper: %w", newGlobalAnchorError("test")),
 		want: true,
-	}, {
-		args: args{
-			err: newNegationAnchorError("test"),
-		},
-		want: false,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsGlobalAnchorError(tt.args.err); got != tt.want {
+			if got := IsGlobalAnchorError(tt.err); got != tt.want {
 				t.Errorf("IsGlobalAnchorError() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Fix anchor error type classification using `errors.Is` instead of string matching

### Problem
Anchor errors are identified partly by checking the error message text (`strings.Contains(err.Error(), msg)`). This causes two problems:

1. **Wrapped anchor errors (via `%w`) are not recognized** — the type assertion `err.(validateAnchorError)` fails on the wrapper, and the fallback substring match only works for direct `errors.New` with the same prefix.

2. **Unrelated errors can be misclassified** — any error whose message contains the phrase "conditional anchor mismatch" (or similar) is incorrectly treated as an anchor error, even if it is a completely different type.

### Root Cause
In `isError()`, the `else` branch falls back to string matching when the type assertion fails:
```go
return strings.Contains(err.Error(), msg)
```
This was a workaround noted with a `TODO: we shouldn't need this, error is not properly propagated` comment.

### Fix
- Implement `Is(target error) bool` on `validateAnchorError` so it participates in Go's `errors.Is` chain
- Replace string matching in `isError()` with `errors.Is(err, validateAnchorError{err: code})`
- This correctly identifies both direct and wrapped anchor errors by type, and rejects unrelated errors regardless of their message text

### Changes
- `pkg/engine/anchor/error.go`: replace `strings` import with `errors`, add `Is` method, rewrite `isError`
- `pkg/engine/anchor/error_test.go`: remove string-matching test cases (they were testing the buggy behavior), add wrapped/doubly-wrapped/unrelated error test cases

### Testing
- Direct anchor errors: still correctly identified
- Wrapped anchor errors (via `%w`): now correctly identified (was broken)
- Doubly wrapped anchor errors: now correctly identified
- Plain `errors.New` with matching text: no longer misclassified (was the bug)
- Unrelated errors with same text: no longer misclassified
- All existing type-based classification tests pass