### PR TITLE
fix(anchor): classify wrapped anchor errors by type

### DIFF
--- a/pkg/engine/anchor/error.go
+++ b/pkg/engine/anchor/error.go
@@ -1,8 +1,8 @@
 package anchor
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 )
 
 // anchorError is the const specification of anchor errors
@@ -61,29 +61,22 @@ func newGlobalAnchorError(msg string) validateAnchorError {
 }
 
 // isError checks if error matches the given error type
-func isError(err error, code anchorError, msg string) bool {
-	if err != nil {
-		if t, ok := err.(validateAnchorError); ok {
-			return t.err == code
-		} else {
-			// TODO: we shouldn't need this, error is not properly propagated
-			return strings.Contains(err.Error(), msg)
-		}
-	}
-	return false
+func isError(err error, code anchorError) bool {
+	var anchorErr validateAnchorError
+	return errors.As(err, &anchorErr) && anchorErr.err == code
 }
 
 // IsNegationAnchorError checks if error is a negation anchor error
 func IsNegationAnchorError(err error) bool {
-	return isError(err, negationAnchorErr, negationAnchorErrMsg)
+	return isError(err, negationAnchorErr)
 }
 
 // IsConditionalAnchorError checks if error is a conditional anchor error
 func IsConditionalAnchorError(err error) bool {
-	return isError(err, conditionalAnchorErr, conditionalAnchorErrMsg)
+	return isError(err, conditionalAnchorErr)
 }
 
 // IsGlobalAnchorError checks if error is a global anchor error
 func IsGlobalAnchorError(err error) bool {
-	return isError(err, globalAnchorErr, globalAnchorErrMsg)
+	return isError(err, globalAnchorErr)
 }

--- a/pkg/engine/anchor/error_test.go
+++ b/pkg/engine/anchor/error_test.go
@@ -2,9 +2,23 @@ package anchor
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
+
+// maskedError hides the wrapped error message while preserving its error chain.
+type maskedError struct {
+	err error
+}
+
+func (e maskedError) Error() string {
+	return "masked error"
+}
+
+func (e maskedError) Unwrap() error {
+	return e.err
+}
 
 func Test_validateAnchorError_Error(t *testing.T) {
 	type fields struct {
@@ -163,7 +177,7 @@ func TestIsNegationAnchorError(t *testing.T) {
 		args: args{
 			err: errors.New("negation anchor matched in resource: test"),
 		},
-		want: true,
+		want: false,
 	}, {
 		args: args{
 			err: newConditionalAnchorError("test"),
@@ -206,7 +220,7 @@ func TestIsConditionalAnchorError(t *testing.T) {
 		args: args{
 			err: errors.New("conditional anchor mismatch: test"),
 		},
-		want: true,
+		want: false,
 	}, {
 		args: args{
 			err: newConditionalAnchorError("test"),
@@ -249,7 +263,7 @@ func TestIsGlobalAnchorError(t *testing.T) {
 		args: args{
 			err: errors.New("global anchor mismatch: test"),
 		},
-		want: true,
+		want: false,
 	}, {
 		args: args{
 			err: newConditionalAnchorError("test"),
@@ -270,6 +284,48 @@ func TestIsGlobalAnchorError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsGlobalAnchorError(tt.args.err); got != tt.want {
 				t.Errorf("IsGlobalAnchorError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAnchorErrorWrapped(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		isTarget func(error) bool
+	}{
+		{
+			name:     "negation",
+			err:      newNegationAnchorError("test"),
+			isTarget: IsNegationAnchorError,
+		},
+		{
+			name:     "conditional",
+			err:      newConditionalAnchorError("test"),
+			isTarget: IsConditionalAnchorError,
+		},
+		{
+			name:     "global",
+			err:      newGlobalAnchorError("test"),
+			isTarget: IsGlobalAnchorError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapped := fmt.Errorf("wrapped: %w", tt.err)
+			if !tt.isTarget(wrapped) {
+				t.Errorf("wrapped error was not classified as a %s anchor error", tt.name)
+			}
+
+			masked := maskedError{err: tt.err}
+			if !tt.isTarget(masked) {
+				t.Errorf("masked error was not classified as a %s anchor error", tt.name)
+			}
+
+			multiplyWrapped := fmt.Errorf("wrapped again: %w", masked)
+			if !tt.isTarget(multiplyWrapped) {
+				t.Errorf("multiply wrapped error was not classified as a %s anchor error", tt.name)
 			}
 		})
 	}

--- a/pkg/engine/validate/validate.go
+++ b/pkg/engine/validate/validate.go
@@ -26,6 +26,10 @@ func (e *PatternError) Error() string {
 	return e.Err.Error()
 }
 
+func (e *PatternError) Unwrap() error {
+	return e.Err
+}
+
 // MatchPattern is a start of element-by-element pattern validation process.
 // It assumes that validation is started from root, so "/" is passed
 func MatchPattern(logger logr.Logger, resource, pattern interface{}) error {

--- a/pkg/engine/validate/validate_test.go
+++ b/pkg/engine/validate/validate_test.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -11,6 +12,61 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine/variables"
 	"gotest.tools/v3/assert"
 )
+
+func TestPatternErrorUnwrap(t *testing.T) {
+	target := errors.New("test")
+	err := &PatternError{Err: target}
+	assert.Assert(t, errors.Is(err, target))
+}
+
+func TestMatchPatternPreservesAnchorErrorClassification(t *testing.T) {
+	tests := []struct {
+		name          string
+		pattern       string
+		resource      string
+		wantSkip      bool
+		isAnchorError func(error) bool
+	}{
+		{
+			name:          "conditional anchor skip",
+			pattern:       `{"spec":{"containers":[{"(name)":"nginx","image":"nginx:latest"}]}}`,
+			resource:      `{"spec":{"containers":[{"name":"redis","image":"redis:7"}]}}`,
+			wantSkip:      true,
+			isAnchorError: anchor.IsConditionalAnchorError,
+		},
+		{
+			name:          "global anchor skip",
+			pattern:       `{"spec":{"containers":[{"<(image)":"nginx:latest","name":"nginx"}]}}`,
+			resource:      `{"spec":{"containers":[{"name":"redis","image":"redis:7"}]}}`,
+			wantSkip:      true,
+			isAnchorError: anchor.IsGlobalAnchorError,
+		},
+		{
+			name:          "negation anchor failure",
+			pattern:       `{"spec":{"X(hostNetwork)":"*"}}`,
+			resource:      `{"spec":{"hostNetwork":true}}`,
+			wantSkip:      false,
+			isAnchorError: anchor.IsNegationAnchorError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var pattern, resource interface{}
+			err := json.Unmarshal([]byte(tt.pattern), &pattern)
+			assert.NilError(t, err)
+			err = json.Unmarshal([]byte(tt.resource), &resource)
+			assert.NilError(t, err)
+
+			err = MatchPattern(logr.Discard(), resource, pattern)
+			patternErr, ok := err.(*PatternError)
+			if !ok {
+				t.Fatalf("expected a *PatternError, got %T", err)
+			}
+			assert.Equal(t, patternErr.Skip, tt.wantSkip)
+			assert.Assert(t, tt.isAnchorError(patternErr))
+		})
+	}
+}
 
 func TestValidateMap(t *testing.T) {
 	rawPattern := []byte(`{


### PR DESCRIPTION
## Explanation
This PR fixes existing behavior by classifying anchor errors by their type, including when they are wrapped, instead of relying on error message text.

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behaviour. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
Closes #17345 
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## Documentation (required for features)
This is an internal bug fix and does not introduce new user-facing functionality.

<!--
My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is: -->
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this
/kind bug

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
- Use `errors.As` to identify wrapped anchor errors.
- Add `PatternError.Unwrap()` so anchor errors can be identified through validation.
- Prevent unrelated errors with the same message from being treated as anchor errors.
- Add regression tests for wrapped and unrelated errors, including anchor classification through `MatchPattern`.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

### Proof Manifests
This internal error fix is covered by unit and validation-path tests.

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
