### PR TITLE
fix: register CEL PolicyException webhook for all served API versions and enforce exceptionNamespace

### DIFF
--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -236,7 +236,7 @@ func createrLeaderControllers(
 		[]admissionregistrationv1.RuleWithOperations{{
 			Rule: admissionregistrationv1.Rule{
 				APIGroups:   []string{"policies.kyverno.io"},
-				APIVersions: []string{"v1alpha1"},
+				APIVersions: []string{"v1alpha1", "v1beta1", "v1"},
 				Resources:   []string{"policyexceptions"},
 			},
 			Operations: []admissionregistrationv1.OperationType{
@@ -879,7 +879,8 @@ func main() {
 		})
 		mpolHandlers := mpol.New(contextProvider, mpolEngine, setup.KyvernoClient, setup.ReportingConfiguration, urgen, backgroundServiceAccountName, eventGenerator)
 		celExceptionHandlers := webhookscelexception.NewHandlers(exception.ValidationOptions{
-			Enabled: internal.PolicyExceptionEnabled(),
+			Enabled:   internal.PolicyExceptionEnabled(),
+			Namespace: internal.ExceptionNamespace(),
 		})
 		globalContextHandlers := webhooksglobalcontext.NewHandlers()
 		server := webhooks.NewServer(

--- a/pkg/webhooks/celexception/validate.go
+++ b/pkg/webhooks/celexception/validate.go
@@ -27,10 +27,7 @@ func (h *celExceptionHandlers) Validate(ctx context.Context, logger logr.Logger,
 		logger.Error(err, "failed to unmarshal CEL PolicyExceptions from admission request")
 		return admissionutils.Response(request.UID, err)
 	}
-	var warning string
-	if !h.validationOptions.Enabled {
-		warning = validation.DisabledPolex
-	}
+	warnings := validation.ValidateNamespace(ctx, logger, polex.GetNamespace(), h.validationOptions)
 	errs := polex.Validate()
-	return admissionutils.Response(request.UID, errs.ToAggregate(), warning)
+	return admissionutils.Response(request.UID, errs.ToAggregate(), warnings...)
 }

--- a/pkg/webhooks/celexception/validate_test.go
+++ b/pkg/webhooks/celexception/validate_test.go
@@ -1,0 +1,171 @@
+package celexception
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	policiesv1beta1 "github.com/kyverno/kyverno/api/policies.kyverno.io/v1beta1"
+	validation "github.com/kyverno/kyverno/pkg/validation/exception"
+	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func newAdmissionRequest(t *testing.T, obj any) handlers.AdmissionRequest {
+	raw, err := json.Marshal(obj)
+	assert.NoError(t, err)
+
+	return handlers.AdmissionRequest{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID: types.UID("test-uid"),
+			Object: runtime.RawExtension{
+				Raw: raw,
+			},
+			Operation: admissionv1.Create,
+		},
+	}
+}
+
+func newValidCELPolicyException() *policiesv1beta1.PolicyException {
+	return &policiesv1beta1.PolicyException{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-exception",
+			Namespace: "default",
+		},
+		Spec: policiesv1beta1.PolicyExceptionSpec{
+			Exceptions: []policiesv1beta1.Exception{
+				{
+					PolicyName: "test-policy",
+				},
+			},
+		},
+	}
+}
+
+func TestCELExceptionValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		options validation.ValidationOptions
+		request handlers.AdmissionRequest
+		allowed bool
+		hasWarn bool
+	}{
+		{
+			name: "valid exception with matching namespace",
+			options: validation.ValidationOptions{
+				Enabled:   true,
+				Namespace: "default",
+			},
+			request: newAdmissionRequest(t, newValidCELPolicyException()),
+			allowed: true,
+			hasWarn: false,
+		},
+		{
+			name: "exception disabled produces warning",
+			options: validation.ValidationOptions{
+				Enabled: false,
+			},
+			request: newAdmissionRequest(t, newValidCELPolicyException()),
+			allowed: true,
+			hasWarn: true,
+		},
+		{
+			name: "namespace mismatch produces warning",
+			options: validation.ValidationOptions{
+				Enabled:   true,
+				Namespace: "other",
+			},
+			request: newAdmissionRequest(t, newValidCELPolicyException()),
+			allowed: true,
+			hasWarn: true,
+		},
+		{
+			name: "exceptionNamespace flag not set produces warning",
+			options: validation.ValidationOptions{
+				Enabled: true,
+			},
+			request: newAdmissionRequest(t, newValidCELPolicyException()),
+			allowed: true,
+			hasWarn: true,
+		},
+		{
+			name: "empty exception spec is allowed",
+			options: validation.ValidationOptions{
+				Enabled:   true,
+				Namespace: "default",
+			},
+			request: newAdmissionRequest(t, &policiesv1beta1.PolicyException{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bad-exception",
+					Namespace: "default",
+				},
+				Spec: policiesv1beta1.PolicyExceptionSpec{},
+			}),
+			allowed: true,
+			hasWarn: false,
+		},
+		{
+			name: "exception without policyName is rejected",
+			options: validation.ValidationOptions{
+				Enabled: true,
+			},
+			request: newAdmissionRequest(t, &policiesv1beta1.PolicyException{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bad-exception",
+					Namespace: "default",
+				},
+				Spec: policiesv1beta1.PolicyExceptionSpec{
+					Exceptions: []policiesv1beta1.Exception{
+						{}, // missing PolicyName → INVALID
+					},
+				},
+			}),
+			allowed: false,
+			hasWarn: false,
+		},
+		{
+			name: "unmarshal error denies request",
+			options: validation.ValidationOptions{
+				Enabled: true,
+			},
+			request: handlers.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UID: types.UID("bad-uid"),
+					Object: runtime.RawExtension{
+						Raw: []byte("{invalid-json"),
+					},
+				},
+			},
+			allowed: false,
+			hasWarn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewHandlers(tt.options)
+
+			resp := h.Validate(
+				context.Background(),
+				logr.Discard(),
+				tt.request,
+				"",
+				time.Now(),
+			)
+
+			assert.Equal(t, tt.allowed, resp.Allowed)
+
+			if tt.hasWarn {
+				assert.NotEmpty(t, resp.Warnings)
+			} else {
+				assert.Empty(t, resp.Warnings)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Fixes kyverno#17367: the CEL `PolicyException` admission webhook (`kyverno-cel-exception-validating-webhook-cfg`) only registered a rule for `apiVersions: [v1alpha1]`, while the `policyexceptions.policies.kyverno.io` CRD serves `v1`, `v1alpha1` and `v1beta1` (`v1beta1` is the storage version). A `PolicyException` created with `apiVersion: policies.kyverno.io/v1` or `v1beta1` never reached the webhook, silently bypassing the `--exceptionNamespace` restriction — including the version the official migration guide recommends.

## Changes

- **`cmd/kyverno/main.go`**: register the CEL exception webhook rule for **all served API versions** (`v1alpha1`, `v1beta1`, `v1`) of the `policyexceptions.policies.kyverno.io` resource, consistent with the other `policies.kyverno.io` webhook rules.
- **`cmd/kyverno/main.go`**: pass `Namespaces: internal.ExceptionNamespace()` to the CEL exception handlers (the non-CEL `exceptionHandlers` already received it).
- **`pkg/webhooks/celexception/validate.go`**: run `validation.ValidateNamespace(...)` in the CEL exception handler, matching the non-CEL `PolicyException` handler, so exceptions created outside the configured `--exceptionNamespace` are surfaced as a warning for every API version. (The previous handler only emitted the "disabled" warning and never checked the namespace.)

## Test coverage

Added `pkg/webhooks/celexception/validate_test.go` mirroring the existing `pkg/webhooks/exception/validate_test.go` cases (namespace match, namespace mismatch warning, disabled warning, invalid spec rejection, unmarshal error).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/community/blob/main/CODE_OF_CONDUCT.md).
- [x] Unit tests added where applicable.

Sign-off: I confirm the changes are my own work and comply with the Kyverno contribution guidelines.

Relates-to: #17367