### PR TITLE
fix(test): disable IVPol digest defaults in leftover report fixtures

### DIFF
--- a/test/conformance/chainsaw/namespaced-image-validating-policies/report/background/policy.yaml
+++ b/test/conformance/chainsaw/namespaced-image-validating-policies/report/background/policy.yaml
@@ -33,6 +33,10 @@ spec:
   failurePolicy: Ignore
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/validating-admission-policy-reports/background/policies-with-the-same-name/imagevalidatingpolicy.yaml
+++ b/test/conformance/chainsaw/validating-admission-policy-reports/background/policies-with-the-same-name/imagevalidatingpolicy.yaml
@@ -33,6 +33,10 @@ spec:
   failurePolicy: Ignore
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:


### PR DESCRIPTION
## Explanation

This is PR will fix two conformance report tests to address verification failure, but ImageValidatingPolicy now requires an image digest by default

## Related issue

Related to #17364

## Milestone of this PR

/milestone 1.20.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind failing-test

## Proposed Changes

Following the pattern from #16815 / #17357. Add `validationConfigurations` (`mutateDigest` / `verifyDigest` / `required`: false) on the two report fixtures that still failed on `main` in [run 32979057458](https://github.com/kyverno/kyverno/actions/runs/32979057458):

- `test/conformance/chainsaw/namespaced-image-validating-policies/report/background/policy.yaml`
- `test/conformance/chainsaw/validating-admission-policy-reports/background/policies-with-the-same-name/imagevalidatingpolicy.yaml`

I'm making these changes one by one to ensure the correct changes are applied. If it is working, will apply the same fix to other release branches

### Proof Manifests

```yaml
validationConfigurations:
  mutateDigest: false
  verifyDigest: false
  required: false
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
