### PR TITLE
fix(test): disable IVPol digest defaults in leftover report fixtures

### DIFF
--- a/test/conformance/chainsaw/namespaced-image-validating-policies/report/background/policy.yaml
+++ b/test/conformance/chainsaw/namespaced-image-validating-policies/report/background/policy.yaml
@@ -33,6 +33,10 @@ spec:
   failurePolicy: Ignore
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:

--- a/test/conformance/chainsaw/validating-admission-policy-reports/background/policies-with-the-same-name/imagevalidatingpolicy.yaml
+++ b/test/conformance/chainsaw/validating-admission-policy-reports/background/policies-with-the-same-name/imagevalidatingpolicy.yaml
@@ -33,6 +33,10 @@ spec:
   failurePolicy: Ignore
   matchImageReferences:
     - glob: ghcr.io/*
+  validationConfigurations:
+    mutateDigest: false
+    verifyDigest: false
+    required: false
   attestors:
     - name: notary
       notary:


### PR DESCRIPTION
## Explanation

This is PR will fix two conformance report tests to address verification failure, but ImageValidatingPolicy now requires an image digest by default. This is mirroring the same fix as main branch

## Related issue

Related to #17365

## Milestone of this PR

/milestone 1.19.0

## What type of PR is this

/kind failing-test

## Proposed Changes

Same leftover as #17375, on `release-1.19`. Add `validationConfigurations` (`mutateDigest` / `verifyDigest` / `required`: false) on:

- `test/conformance/chainsaw/namespaced-image-validating-policies/report/background/policy.yaml`
- `test/conformance/chainsaw/validating-admission-policy-reports/background/policies-with-the-same-name/imagevalidatingpolicy.yaml`



### Proof Manifests

```yaml
validationConfigurations:
  mutateDigest: false
  verifyDigest: false
  required: false
```