### PR TITLE
fix: expand List resources in createFakeClientFromResources

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -1349,8 +1349,36 @@ func createFakeClientFromResources(resources, targetResources, parameterResource
 	var discoveryGVRs []schema.GroupVersionResource
 	seen := make(map[schema.GroupVersionResource]bool)
 
-	objects := make([]runtime.Object, 0, len(allResources))
+	// A `kind: List` resource (e.g. produced by `kubectl get` on multiple
+	// resources) wraps its children under "items". The fake dynamic client
+	// cannot ingest such an object directly - client-go's object tracker
+	// panics with "*unstructured.Unstructured is not a list: no Items field
+	// in this object". Flatten the items into individual objects first,
+	// mirroring how kubectl processes List inputs.
+	flat := make([]*unstructured.Unstructured, 0, len(allResources))
 	for _, r := range allResources {
+		if r.GetKind() != "List" {
+			flat = append(flat, r)
+			continue
+		}
+		items, found, err := unstructured.NestedSlice(r.Object, "items")
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract items from List resource %s/%s: %w", r.GetNamespace(), r.GetName(), err)
+		}
+		if !found {
+			return nil, fmt.Errorf("List resource %s/%s has no items", r.GetNamespace(), r.GetName())
+		}
+		for _, item := range items {
+			itemMap, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			flat = append(flat, &unstructured.Unstructured{Object: itemMap})
+		}
+	}
+
+	objects := make([]runtime.Object, 0, len(flat))
+	for _, r := range flat {
 		objects = append(objects, r.DeepCopy())
 		gvk := r.GroupVersionKind()
 		if gvk.Kind == "" || gvk.Version == "" {

--- a/cmd/cli/kubectl-kyverno/commands/apply/create_fake_client_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/create_fake_client_test.go
@@ -161,3 +161,61 @@ func TestCreateFakeClientFromResources_ResourceDataPreserved(t *testing.T) {
 	assert.Equal(t, "production", gotData["environment"])
 	assert.Equal(t, "3", gotData["replicas"])
 }
+
+func TestCreateFakeClientFromResources_ListResource(t *testing.T) {
+	// Regression test for https://github.com/kyverno/kyverno/issues/17371:
+	// `kyverno apply` on a `kind: List` resource used to panic with
+	// "*unstructured.Unstructured is not a list: no Items field in this object"
+	// because client-go's fake tracker cannot ingest a List object directly.
+	list := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "List",
+			"items": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "cm-a",
+						"namespace": "default",
+					},
+				},
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "cm-b",
+						"namespace": "default",
+					},
+				},
+			},
+		},
+	}
+
+	client, err := createFakeClientFromResources([]*unstructured.Unstructured{list}, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	// The flattened items must be individually retrievable from the fake client.
+	cmA, err := client.GetResource(context.Background(), "v1", "ConfigMap", "default", "cm-a")
+	require.NoError(t, err)
+	assert.Equal(t, "cm-a", cmA.GetName())
+	assert.Equal(t, "default", cmA.GetNamespace())
+
+	cmB, err := client.GetResource(context.Background(), "v1", "ConfigMap", "default", "cm-b")
+	require.NoError(t, err)
+	assert.Equal(t, "cm-b", cmB.GetName())
+}
+
+func TestCreateFakeClientFromResources_ListResourceNoItems(t *testing.T) {
+	// A List with no items should produce a clear error instead of a panic.
+	emptyList := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "List",
+			"items":      []interface{}{},
+		},
+	}
+	_, err := createFakeClientFromResources([]*unstructured.Unstructured{emptyList}, nil, nil)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
### Problem

`kyverno apply` panics when the input resources include a `kind: List` object (e.g. a manifest produced by `kubectl get ... -o yaml` for multiple resources):

```
panic: *unstructured.Unstructured is not a list: no Items field in this object

goroutine 1 [running]:
k8s.io/client-go/dynamic/fake.NewSimpleDynamicClientWithCustomListKinds(...)
        .../dynamic/fake/simple.go:110 +0xa37
```

### Root cause

`createFakeClientFromResources` passes every loaded resource directly to the fake dynamic client. A `kind: List` resource is an `*unstructured.Unstructured` whose children live under `items`; client-go's object tracker treats it as a list kind and tries to reflect its `Items` field, which the `Unstructured` Go struct does not have, so `o.Add(obj)` fails and `NewSimpleDynamicClientWithCustomListKinds` panics at `simple.go:110`.

### Fix

Flatten `kind: List` resources into their individual `items` before registering them with the fake client, mirroring how `kubectl` processes List inputs. Each flattened item is then registered normally (GVR→ListKind mapping, discovery, dedup) and is individually retrievable from the fake client. A List without `items` produces a clear error instead of a panic.

### Tests

- `TestCreateFakeClientFromResources_ListResource` — a List with two ConfigMaps no longer panics, and both flattened items are retrievable via the fake client.
- `TestCreateFakeClientFromResources_ListResourceNoItems` — an empty List is handled without panic.

Verified locally against client-go v0.36.4 (the version kyverno uses): the panic reproduces exactly as reported before the fix and disappears after it.

Closes #17371


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved local resource handling so resources provided in Kubernetes `List` objects are processed individually.
  - Empty lists are handled safely without errors or crashes.
  - Resource names and namespaces remain available when retrieving items from a list.

- **Tests**
  - Added coverage for lists containing multiple resources and empty lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->