### PR TITLE
fix: preserve sigstore trust material for bundles

### DIFF
--- a/pkg/image/verifiers/ivpol/cosign/cert_limit_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/cert_limit_test.go
@@ -68,7 +68,7 @@ func TestCheckOptions_TSACertChainTooManyIntermediates(t *testing.T) {
 		},
 	}
 
-	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "TSA certificate chain contains too many")
 }
@@ -93,7 +93,7 @@ func TestCheckOptions_TSACertChainAtLimit(t *testing.T) {
 		},
 	}
 
-	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	if err != nil {
 		assert.False(t, strings.Contains(err.Error(), "TSA certificate chain contains too many"),
 			"boundary value (%d intermediates) must not be rejected by the count check; got: %v", maxIntermediateCerts, err)
@@ -124,7 +124,7 @@ func TestCheckOptions_CertChainTooLong(t *testing.T) {
 		},
 	}
 
-	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "certificate chain too long")
 }
@@ -152,7 +152,7 @@ func TestCheckOptions_CertChainAtLimit(t *testing.T) {
 		},
 	}
 
-	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	// May fail for chain-validation reasons but must not fail on the length check.
 	if err != nil {
 		assert.False(t, strings.Contains(err.Error(), "certificate chain too long"),

--- a/pkg/image/verifiers/ivpol/cosign/opts.go
+++ b/pkg/image/verifiers/ivpol/cosign/opts.go
@@ -79,12 +79,12 @@ func countPEMCertBlocks(pem []byte) int {
 	return bytes.Count(pem, pemCertBlockHeader)
 }
 
-func checkOptions(ctx context.Context, att *v1beta1.Cosign, baseROpts []remote.Option, baseNOpts []name.Option, secretLister corev1listers.SecretLister) (*cosign.CheckOpts, error) {
-	// Key/certificate verification with the transparency log ignored needs no
-	// Sigstore infrastructure (TUF, Rekor, CTLog), mirroring cosign.
-	ignoreTlog := att.CTLog != nil && att.CTLog.InsecureIgnoreTlog
-	keyOrCert := att.Keyless == nil && (att.Key != nil || att.Certificate != nil)
-	skipSigstoreInfra := keyOrCert && ignoreTlog
+func buildCosignRemoteOpts(
+	att *v1beta1.Cosign,
+	baseROpts []remote.Option,
+	baseNOpts []name.Option,
+	secretLister corev1listers.SecretLister,
+) ([]ociremote.Option, error) {
 	cosignRemoteOpts := []ociremote.Option{}
 
 	if att.Source != nil {
@@ -93,6 +93,7 @@ func checkOptions(ctx context.Context, att *v1beta1.Cosign, baseROpts []remote.O
 			return nil, err
 		}
 		baseROpts = append(baseROpts, remoteOpts...)
+
 		if len(att.Source.Repository) > 0 {
 			signatureRepo, err := name.NewRepository(att.Source.Repository)
 			if err != nil {
@@ -101,13 +102,28 @@ func checkOptions(ctx context.Context, att *v1beta1.Cosign, baseROpts []remote.O
 
 			cosignRemoteOpts = append(cosignRemoteOpts, ociremote.WithTargetRepository(signatureRepo))
 		}
+
 		if len(att.Source.TagPrefix) != 0 {
 			cosignRemoteOpts = append(cosignRemoteOpts, ociremote.WithPrefix(att.Source.TagPrefix))
 		}
 	}
+
 	cosignRemoteOpts = append(cosignRemoteOpts, ociremote.WithRemoteOptions(baseROpts...), ociremote.WithNameOptions(baseNOpts...))
 
-	var err error
+	return cosignRemoteOpts, nil
+}
+
+func checkOptions(ctx context.Context, att *v1beta1.Cosign, baseROpts []remote.Option, baseNOpts []name.Option, secretLister corev1listers.SecretLister, hasBundle bool) (*cosign.CheckOpts, error) {
+	// Key/certificate verification with the transparency log ignored needs no
+	// Sigstore infrastructure (TUF, Rekor, CTLog), mirroring cosign.
+	ignoreTlog := att.CTLog != nil && att.CTLog.InsecureIgnoreTlog
+	keyOrCert := att.Keyless == nil && (att.Key != nil || att.Certificate != nil)
+	skipSigstoreInfra := keyOrCert && ignoreTlog && !hasBundle
+
+	cosignRemoteOpts, err := buildCosignRemoteOpts(att, baseROpts, baseNOpts, secretLister)
+	if err != nil {
+		return nil, err
+	}
 	var trust *sigstoreTrustMaterial
 	opts := &cosign.CheckOpts{
 		RegistryClientOpts: cosignRemoteOpts,

--- a/pkg/image/verifiers/ivpol/cosign/opts_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/opts_test.go
@@ -184,7 +184,7 @@ func TestCheckOptions_KeyBased(t *testing.T) {
 		},
 	}
 
-	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	require.NoError(t, err)
 	assert.NotNil(t, opts)
 	assert.NotNil(t, opts.SigVerifier)
@@ -214,7 +214,7 @@ func TestCheckOptions_Keyless(t *testing.T) {
 		},
 	}
 
-	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	require.NoError(t, err)
 	assert.NotNil(t, opts)
 	assert.Len(t, opts.Identities, 1)
@@ -246,7 +246,7 @@ func TestCheckOptions_KeylessWithRegex(t *testing.T) {
 		},
 	}
 
-	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	require.NoError(t, err)
 	assert.NotNil(t, opts)
 	assert.Equal(t, ".*token.actions.githubusercontent.com", opts.Identities[0].IssuerRegExp)
@@ -277,7 +277,7 @@ func TestCheckOptions_MultipleIdentities(t *testing.T) {
 		},
 	}
 
-	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	require.NoError(t, err)
 	assert.Len(t, opts.Identities, 2)
 }
@@ -299,7 +299,7 @@ func TestCheckOptions_WithSource(t *testing.T) {
 		},
 	}
 
-	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	require.NoError(t, err)
 	assert.NotNil(t, opts)
 	assert.NotEmpty(t, opts.RegistryClientOpts)
@@ -318,7 +318,7 @@ func TestCheckOptions_InvalidPublicKey(t *testing.T) {
 		},
 	}
 
-	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load public key")
 }
@@ -340,7 +340,7 @@ func TestCheckOptions_InvalidSourceRepository(t *testing.T) {
 		},
 	}
 
-	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	_, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse signature repository")
 }
@@ -359,7 +359,7 @@ func TestCheckOptions_RekorOfflineMode(t *testing.T) {
 		},
 	}
 
-	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	require.NoError(t, err)
 	assert.False(t, opts.Offline)
 }
@@ -776,7 +776,7 @@ func TestCheckOptions_CTLogConfiguration(t *testing.T) {
 				CTLog: tt.ctlog,
 			}
 
-			opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+			opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantSCT, opts.IgnoreSCT)
 			assert.Equal(t, tt.wantTlog, opts.IgnoreTlog)
@@ -841,7 +841,7 @@ func TestCheckOptions_VerifierTypes(t *testing.T) {
 			ctx := context.TODO()
 			baseROpts, baseNOpts := baseOpts()
 
-			opts, err := checkOptions(ctx, tt.cosignCfg, baseROpts, baseNOpts, nil)
+			opts, err := checkOptions(ctx, tt.cosignCfg, baseROpts, baseNOpts, nil, false)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -892,7 +892,7 @@ func TestCheckOptions_TSACertChain_UseSignedTimestamps(t *testing.T) {
 				},
 			}
 
-			opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+			opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantUseSignedTS, opts.UseSignedTimestamps)
 			if tt.wantTSARootCerts {
@@ -922,7 +922,7 @@ func TestCheckOptions_Keyless_TSACertChainTrustedMaterial(t *testing.T) {
 		},
 	}
 
-	opts, err := checkOptions(context.Background(), cosignCfg, baseROpts, baseNOpts, nil)
+	opts, err := checkOptions(context.Background(), cosignCfg, baseROpts, baseNOpts, nil, false)
 	require.NoError(t, err)
 	require.NotNil(t, opts.TrustedMaterial)
 
@@ -948,7 +948,7 @@ func TestCheckOptions_KeyBased_AirGapped(t *testing.T) {
 		},
 	}
 
-	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	require.NoError(t, err)
 	assert.NotNil(t, opts)
 	assert.NotNil(t, opts.SigVerifier)
@@ -958,6 +958,35 @@ func TestCheckOptions_KeyBased_AirGapped(t *testing.T) {
 	assert.Nil(t, opts.RekorPubKeys)
 	assert.Nil(t, opts.CTLogPubKeys)
 	assert.Nil(t, opts.TrustedMaterial)
+}
+
+func TestCheckOptions_KeyBased_WithBundle(t *testing.T) {
+	stubTufWithFixture(t)
+
+	ctx := context.TODO()
+	baseROpts, baseNOpts := baseOpts()
+
+	cosignCfg := &v1beta1.Cosign{
+		Key: &v1beta1.Key{
+			Data: testPublicKey,
+		},
+		CTLog: &v1beta1.CTLog{
+			InsecureIgnoreTlog: true,
+			InsecureIgnoreSCT:  true,
+		},
+	}
+
+	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, true)
+	require.NoError(t, err)
+	require.NotNil(t, opts)
+
+	assert.NotNil(t, opts.SigVerifier)
+	assert.True(t, opts.IgnoreTlog)
+	assert.True(t, opts.IgnoreSCT)
+
+	// Sigstore trust material is required to verify v0.3 bundles,
+	// even when transparency-log verification is disabled.
+	assert.NotNil(t, opts.TrustedMaterial)
 }
 
 // TestCheckOptions_Keyless_InsecureIgnoreTlog_NoURL reproduces the reported
@@ -985,7 +1014,7 @@ func TestCheckOptions_Keyless_InsecureIgnoreTlog_NoURL(t *testing.T) {
 		},
 	}
 
-	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	require.NoError(t, err)
 	assert.NotNil(t, opts)
 	assert.True(t, opts.IgnoreTlog)
@@ -1018,7 +1047,7 @@ func TestCheckOptions_FallbackViaInitTUFAndFetch(t *testing.T) {
 		},
 	}
 
-	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil)
+	opts, err := checkOptions(ctx, cosignCfg, baseROpts, baseNOpts, nil, false)
 	require.NoError(t, err)
 	assert.NotNil(t, opts)
 	assert.NotNil(t, opts.RootCerts)

--- a/pkg/image/verifiers/ivpol/cosign/verifier.go
+++ b/pkg/image/verifiers/ivpol/cosign/verifier.go
@@ -30,14 +30,20 @@ func NewVerifier(secretLister corev1listers.SecretLister, logger logr.Logger) *V
 
 // buildCheckOptsWithBundleDetection builds CheckOpts and auto-detects cosign v3 bundle format
 func (v *Verifier) buildCheckOptsWithBundleDetection(ctx context.Context, attestor *policiesv1beta1.Cosign, image *imagedataloader.ImageData) (*cosign.CheckOpts, error) {
-	cOpts, err := checkOptions(ctx, attestor, image.RemoteOpts(), image.NameOpts(), v.secretLister)
+	cosignRemoteOpts, err := buildCosignRemoteOpts(attestor, image.RemoteOpts(), image.NameOpts(), v.secretLister)
 	if err != nil {
 		return nil, err
 	}
 
-	// Auto-detect if new bundle format (cosign v3) is actually present
-	newBundles, _, err := cosign.GetBundles(ctx, image.NameRef(), cOpts.RegistryClientOpts)
+	// Auto-detect if new bundle format (cosign v3) is actually present.
+	newBundles, _, err := cosign.GetBundles(ctx, image.NameRef(), cosignRemoteOpts)
 	bundleDetected := len(newBundles) > 0 && err == nil
+
+	cOpts, err := checkOptions(ctx, attestor, image.RemoteOpts(), image.NameOpts(), v.secretLister, bundleDetected)
+	if err != nil {
+		return nil, err
+	}
+
 	cOpts.NewBundleFormat = bundleDetected
 	if bundleDetected && shouldUseSignedTimestamps(cOpts.IgnoreTlog, cOpts.UseSignedTimestamps, cOpts.TrustedMaterial) {
 		cOpts.UseSignedTimestamps = true


### PR DESCRIPTION
## Explanation

Key-based image signature verification with `insecureIgnoreTlog: true` can skip initialization of Sigstore trust material as an optimization. However, Sigstore v0.3 bundle verification still requires this trust material, causing verification of images whose signatures are stored as v0.3 bundle referrers to fail.

This PR fixes the existing behavior by making the optimization bundle-aware: trust material continues to be skipped for regular key/certificate signatures, while it is initialized when a Sigstore v0.3 bundle is detected.

## Related issue

Closes #17363

## Milestone of this PR

<!-- /milestone 1.19.1 -->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

The bundle detection currently occurs after `checkOptions()` is constructed. This meant the key-based `insecureIgnoreTlog` optimization could prevent Sigstore trust material from being initialized before bundle verification.

This change:

- Reuses the existing Cosign registry option construction for bundle detection.
- Detects the presence of a Sigstore v0.3 bundle before constructing verification options.
- Preserves the existing optimization for key/certificate verification when no bundle is present.
- Ensures Sigstore trust material is initialized when a bundle is detected.
- Adds regression coverage for both the bundle and non-bundle paths.

### Proof Manifests

Not applicable. This is an internal verification-path fix and does not introduce a new user-facing policy syntax or resource.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The existing key-based `insecureIgnoreTlog` fast path is retained for images without Sigstore bundles. For bundle-backed signatures, trust material is initialized before verification so that the Sigstore v0.3 bundle can be validated correctly.

Tests:
- `go test ./pkg/image/verifiers/ivpol/cosign -run 'TestCheckOptions_KeyBased_(AirGapped|WithBundle)$' -count=1 -v`
- `go test ./pkg/image/verifiers/ivpol/cosign/... -count=1 -v`