### PR TITLE
fix: report generating policy match skip instead of "Not found" in CLI test

### DIFF
--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -716,6 +716,21 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 				}
 				for _, res := range engineResponse.Policies {
 					if res.Result == nil {
+						// The generating policy did not match the trigger resource
+						// (match constraints or match conditions excluded it). Record a
+						// skip rule response so `kyverno test` reports the expected
+						// `result: skip` instead of failing with "Not found".
+						generateResponse := engineapi.EngineResponse{
+							Resource: *engineResponse.Trigger,
+							PolicyResponse: engineapi.PolicyResponse{
+								Rules: []engineapi.RuleResponse{
+									*engineapi.RuleSkip(res.Policy.GetName(), engineapi.Generation, "policy did not match", nil),
+								},
+							},
+						}
+						generateResponse = generateResponse.WithPolicy(engineapi.NewGeneratingPolicyFromLike(res.Policy))
+						p.Rc.addGenerateResponse(generateResponse)
+						responses = append(responses, generateResponse)
 						continue
 					}
 					generateResponse := engineapi.EngineResponse{

--- a/test/cli/test-generating-policy/matchconditions-skip/generated-resource.yaml
+++ b/test/cli/test-generating-policy/matchconditions-skip/generated-resource.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: generated-config
+  namespace: workload-namespace
+data:
+  foo: bar

--- a/test/cli/test-generating-policy/matchconditions-skip/kyverno-test.yaml
+++ b/test/cli/test-generating-policy/matchconditions-skip/kyverno-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kyverno-test
+policies:
+- policy.yaml
+resources:
+- resources.yaml
+results:
+- generatedResource: generated-resource.yaml
+  isGeneratingPolicy: true
+  kind: Namespace
+  policy: generate-cm-workload-ns
+  resources:
+  - workload-namespace
+  result: pass
+- isGeneratingPolicy: true
+  kind: Namespace
+  policy: generate-cm-workload-ns
+  resources:
+  - excluded-namespace
+  result: skip

--- a/test/cli/test-generating-policy/matchconditions-skip/policy.yaml
+++ b/test/cli/test-generating-policy/matchconditions-skip/policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: GeneratingPolicy
+metadata:
+  name: generate-cm-workload-ns
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["namespaces"]
+  matchConditions:
+    - name: workload-namespaces-only
+      expression: 'object.metadata.?labels["example.com/type"].orValue("") == "workload"'
+  generate:
+    - template:
+        value: |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: generated-config
+            namespace: workload-namespace
+          data:
+            foo: bar

--- a/test/cli/test-generating-policy/matchconditions-skip/resources.yaml
+++ b/test/cli/test-generating-policy/matchconditions-skip/resources.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workload-namespace
+  labels:
+    example.com/type: workload
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: excluded-namespace
+  labels:
+    example.com/type: platform


### PR DESCRIPTION
Fixes #17382

## Problem

Since 1.19, `kyverno test` reports `Not found` (a failure) when a CEL-based `GeneratingPolicy`'s match conditions exclude a resource, instead of the expected skip/`Excluded` result that 1.18 reported.

Attempting to verify "a GeneratingPolicy must NOT generate a resource when `matchConditions` exclude the trigger" fails on upgrade:

```
│ 2  │ generate-configmap-for-workloads │        │ v1/Namespace/default/excluded-namespace │ Fail │ Not found │   <- 1.19
│ 2  │ generate-configmap-for-workloads │        │ v1/Namespace/default/excluded-namespace │ Pass │ Excluded  │   <- 1.18
```

## Root cause

When the generating policy does not match the resource, the CEL generating policy engine (`pkg/cel/policies/gpol/engine`) returns a policy result with a nil rule response:

- match constraints fail → `engine.go` returns an empty response
- match conditions fail → `Evaluate` returns `(nil, nil)` → empty response

The CLI processor (`cmd/cli/kubectl-kyverno/processor/policy_processor.go`) then did `if res.Result == nil { continue }`, so no response was recorded for that resource, and the test result matcher reported `Not found`.

## Fix

Record a skip rule response for non-matching generating policies so `kyverno test` can match the expected `result: skip` (shown as `Excluded`), restoring the pre-1.19 behavior.

## Test

Added `test/cli/test-generating-policy/matchconditions-skip/` — a `GeneratingPolicy` with `matchConditions` evaluated against two namespaces:
- `workload-namespace` matches → generates a ConfigMap → `result: pass`
- `excluded-namespace` does not match → `result: skip`

Before the fix the second case fails with `Not found`; after the fix it passes.

## Checklist

- [x] `make imports fmt` — `gofmt` clean on the modified file
- [x] DCO sign-off included
