### PR TITLE
fix: use dynamic APIVersion in event ObjectReferences instead of hardcoded values

### DIFF
--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -170,8 +170,7 @@ func NewResourceGenerationEvent(policy, rule string, source Source, resource kyv
 func NewBackgroundFailedEvent(err error, policy engineapi.GenericPolicy, rule string, source Source, resource kyvernov1.ResourceSpec) []Info {
 	events := make([]Info, 0, 1)
 	regarding := corev1.ObjectReference{
-		// TODO: iirc it's not safe to assume api version is set
-		APIVersion: "kyverno.io/v1",
+		APIVersion: policy.GetAPIVersion(),
 		Kind:       policy.GetKind(),
 		Name:       policy.GetName(),
 		Namespace:  policy.GetNamespace(),
@@ -210,8 +209,7 @@ func NewBackgroundSuccessEvent(source Source, policy engineapi.GenericPolicy, re
 		action = ResourceMutated
 	}
 	regarding := corev1.ObjectReference{
-		// TODO: iirc it's not safe to assume api version is set
-		APIVersion: "kyverno.io/v1",
+		APIVersion: policy.GetAPIVersion(),
 		Kind:       policy.GetKind(),
 		Name:       policy.GetName(),
 		Namespace:  policy.GetNamespace(),
@@ -260,8 +258,7 @@ func NewPolicyExceptionEvents(engineResponse engineapi.EngineResponse, ruleResp 
 
 			exceptionEvent := Info{
 				Regarding: corev1.ObjectReference{
-					// TODO: iirc it's not safe to assume api version is set
-					APIVersion: "kyverno.io/v2",
+					APIVersion: exception.GetAPIVersion(),
 					Kind:       "PolicyException",
 					Name:       name,
 					Namespace:  ns,
@@ -285,7 +282,7 @@ func NewPolicyExceptionEvents(engineResponse engineapi.EngineResponse, ruleResp 
 		// build the policy events
 		policyMessage := fmt.Sprintf("resource %s was skipped from rule %s due to policy exceptions %s", resourceKey(engineResponse.PatchedResource), ruleResp.Name(), strings.Join(exceptionNames, ", "))
 		regarding := corev1.ObjectReference{
-			// TODO: iirc it's not safe to assume api version is set
+			// PolicyInterface (Policy/ClusterPolicy) is always kyverno.io/v1
 			APIVersion: "kyverno.io/v1",
 			Kind:       pol.GetKind(),
 			Name:       pol.GetName(),
@@ -313,8 +310,7 @@ func NewPolicyExceptionEvents(engineResponse engineapi.EngineResponse, ruleResp 
 
 func NewCleanupPolicyEvent(policy kyvernov2.CleanupPolicyInterface, resource unstructured.Unstructured, err error) Info {
 	regarding := corev1.ObjectReference{
-		// TODO: iirc it's not safe to assume api version is set
-		APIVersion: "kyverno.io/v2",
+		APIVersion: policy.GetAPIVersion(),
 		Kind:       policy.GetKind(),
 		Name:       policy.GetName(),
 		Namespace:  policy.GetNamespace(),


### PR DESCRIPTION
## Explanation

Several `Info` events created by Kyverno (for background rules, cleanup policies, and policy exceptions) had their `APIVersion` hardcoded as a string literal in the event's `ObjectReference`, even though the underlying policy object already exposed a method to get its real API version. This meant that for any policy type where the actual version could legitimately differ (e.g. `kyverno.io/v2` vs `v2beta1`), the emitted Kubernetes Event could carry an inaccurate `apiVersion` field, which could confuse tooling or users inspecting `kubectl get events` output. This PR makes those fields reflect the real value dynamically instead of assuming it.

## What type of PR is this

/kind cleanup

## Proposed Changes

- In `pkg/event/events.go`, replaced hardcoded `APIVersion: "kyverno.io/v1"` / `"kyverno.io/v2"` string literals with dynamic `policy.GetAPIVersion()` / `exception.GetAPIVersion()` calls in:
  - `NewBackgroundFailedEvent`
  - `NewBackgroundSuccessEvent`
  - `NewPolicyExceptionEvents` (exception event)
  - `NewCleanupPolicyEvent`
- One occurrence in `NewPolicyExceptionEvents` (the policy level event, using `kyvernov1.PolicyInterface`) was left hardcoded, since that interface has no `GetAPIVersion()` method and is only implemented by `Policy`/`ClusterPolicy`, which are always `kyverno.io/v1`. Replaced the stale `TODO` there with a comment explaining why it's intentionally hardcoded.
- Resolves 5 instances of the same `// TODO: iirc it's not safe to assume api version is set` comment in this file.


## Further Comments

This was investigated by reading through the type definitions for `engineapi.GenericPolicy`, `engineapi.GenericException`, `kyvernov2.CleanupPolicyInterface`, and `kyvernov1.PolicyInterface` to confirm which had a working `GetAPIVersion()` method before making changes. One case (`kyvernov1.PolicyInterface`) genuinely can't be fixed the same way, so it was left as is with an explanatory comment rather than force fitting a change.