### PR TITLE
fix(cli): preserve GeneratingPolicy skips in test results

### DIFF
--- a/cmd/cli/kubectl-kyverno/processor/policy_processor.go
+++ b/cmd/cli/kubectl-kyverno/processor/policy_processor.go
@@ -715,7 +715,14 @@ func (p *PolicyProcessor) ApplyPoliciesOnResource() ([]engineapi.EngineResponse,
 					return nil, err
 				}
 				for _, res := range engineResponse.Policies {
+
 					if res.Result == nil {
+						generateResponse := engineapi.EngineResponse{
+							Resource: *engineResponse.Trigger,
+						}
+						generateResponse = generateResponse.WithPolicy(engineapi.NewGeneratingPolicyFromLike(res.Policy))
+						p.Rc.addGenerateResponse(generateResponse)
+						responses = append(responses, generateResponse)
 						continue
 					}
 					generateResponse := engineapi.EngineResponse{

--- a/test/cli/test-generating-policy/matchconditions-skip/configmap.yaml
+++ b/test/cli/test-generating-policy/matchconditions-skip/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: generated-config
+  namespace: workload-namespace
+data:
+  foo: bar

--- a/test/cli/test-generating-policy/matchconditions-skip/kyverno-test.yaml
+++ b/test/cli/test-generating-policy/matchconditions-skip/kyverno-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: generating-policy-match-condition-skip
+policies:
+  - policy.yaml
+resources:
+  - resources.yaml
+results:
+  - isGeneratingPolicy: true
+    policy: generate-configmap-for-workloads
+    resources:
+      - workload-namespace
+    kind: Namespace
+    generatedResource: configmap.yaml
+    result: pass
+  - isGeneratingPolicy: true
+    policy: generate-configmap-for-workloads
+    resources:
+      - excluded-namespace
+    kind: Namespace
+    result: skip

--- a/test/cli/test-generating-policy/matchconditions-skip/policy.yaml
+++ b/test/cli/test-generating-policy/matchconditions-skip/policy.yaml
@@ -1,0 +1,32 @@
+apiVersion: policies.kyverno.io/v1
+kind: GeneratingPolicy
+metadata:
+  name: generate-configmap-for-workloads
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["namespaces"]
+  matchConditions:
+    - name: workload-namespaces-only
+      expression: 'object.metadata.?labels["example.com/type"].orValue("") == "workload"'
+  variables:
+    - name: downstream
+      expression: >-
+        [
+          {
+            "apiVersion": dyn("v1"),
+            "kind": dyn("ConfigMap"),
+            "metadata": dyn({
+              "name": dyn("generated-config"),
+              "namespace": dyn(string(object.metadata.name))
+            }),
+            "data": dyn({
+              "foo": dyn("bar")
+            })
+          }
+        ]
+  generate:
+    - expression: generator.Apply(object.metadata.name, variables.downstream)

--- a/test/cli/test-generating-policy/matchconditions-skip/resources.yaml
+++ b/test/cli/test-generating-policy/matchconditions-skip/resources.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workload-namespace
+  labels:
+    example.com/type: workload
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: excluded-namespace
+  labels:
+    example.com/type: platform


### PR DESCRIPTION
Fixes #17382

## Problem

`kyverno test` reported `Not found` when a CEL-based `GeneratingPolicy`
was excluded by `matchConditions`.

When the generating policy does not match the trigger resource, the
generating policy engine returns a policy entry with a nil rule response.
The CLI processor previously discarded that response entirely, leaving
the test runner with no response for the excluded resource.

## Fix

Preserve an `EngineResponse` for non-matching `GeneratingPolicy`
resources instead of dropping the nil result.

This allows the existing CLI test result handling to recognize the
resource as excluded and report `Pass / Excluded`.

## Regression test

Added a CLI regression fixture covering:

- matching namespace → generated ConfigMap → `pass`
- excluded namespace → `skip` → `Pass / Excluded`

## Validation

- `kyverno test test/cli/test-generating-policy/matchconditions-skip`
- `go test ./cmd/cli/kubectl-kyverno/commands/test -count=1`
- `go test ./cmd/cli/kubectl-kyverno/processor -count=1`

All passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of generating policies when no rules are produced, ensuring an appropriate response is recorded instead of silently skipping the result.
  - Generating policies now correctly handle resources excluded by match conditions while continuing to generate resources for matching namespaces.

- **Tests**
  - Added coverage for generating ConfigMaps in workload namespaces and skipping excluded namespaces based on labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->