### PR TITLE
fix(cli): restore checks assertions in test API

### DIFF
--- a/cmd/cli/kubectl-kyverno/apis/v1alpha1/test.go
+++ b/cmd/cli/kubectl-kyverno/apis/v1alpha1/test.go
@@ -2,7 +2,9 @@ package v1alpha1
 
 import (
 	"encoding/json"
+
 	"fmt"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -57,6 +59,9 @@ type Test struct {
 
 	// Results are the results to be checked in the test
 	Results []TestResult `json:"results,omitempty"`
+
+	// Checks are the verifications to be checked in the test.
+	Checks []CheckResult `json:"checks,omitempty"`
 
 	// Values are the values to be used in the test
 	Values *ValuesSpec `json:"values,omitempty"`
@@ -322,6 +327,28 @@ func RawExtensionToObject(raw runtime.RawExtension) (interface{}, error) {
 		return nil, err
 	}
 	return v, nil
+}
+
+type CheckResult struct {
+	// Match tells how to match relevant rule responses.
+	Match CheckMatch `json:"match,omitempty"`
+
+	// Assert contains assertion to be performed on the relevant rule responses.
+	Assert kyvernov1.Any `json:"assert"`
+
+	// Error contains negative assertion to be performed on the relevant rule responses.
+	Error kyvernov1.Any `json:"error"`
+}
+
+type CheckMatch struct {
+	// Resource filters engine responses.
+	Resource *kyvernov1.Any `json:"resource,omitempty"`
+
+	// Policy filters engine responses.
+	Policy *kyvernov1.Any `json:"policy,omitempty"`
+
+	// Rule filters rule responses.
+	Rule *kyvernov1.Any `json:"rule,omitempty"`
 }
 
 type TestResourceSpec struct {

--- a/cmd/cli/kubectl-kyverno/commands/test/checks.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/checks.go
@@ -1,0 +1,263 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/apis/v1alpha1"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/output/color"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/output/table"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func printCheckResult(
+	checks []v1alpha1.CheckResult,
+	responses TestResponse,
+	rc *resultCounts,
+	resultsTable *table.Table,
+) error {
+	var engineResponses []engineapi.EngineResponse
+	for _, responseList := range responses.Trigger {
+		engineResponses = append(engineResponses, responseList...)
+	}
+
+	testCount := 1
+
+	for _, check := range checks {
+		matches := engineResponses
+
+		if check.Match.Resource != nil {
+			filtered := make([]engineapi.EngineResponse, 0, len(matches))
+			for _, response := range matches {
+				actual := response.Resource.UnstructuredContent()
+				if checkMatches(check.Match.Resource.Value, addMetadataAliases(actual)) {
+					filtered = append(filtered, response)
+				}
+			}
+			matches = filtered
+		}
+
+		if check.Match.Policy != nil {
+			filtered := make([]engineapi.EngineResponse, 0, len(matches))
+			for _, response := range matches {
+				actual, err := runtime.DefaultUnstructuredConverter.ToUnstructured(response.Policy().AsObject())
+				if err != nil {
+					return fmt.Errorf("convert policy response: %w", err)
+				}
+				if checkMatches(check.Match.Policy.Value, addMetadataAliases(actual)) {
+					filtered = append(filtered, response)
+				}
+			}
+			matches = filtered
+		}
+
+		for _, response := range matches {
+			rules := response.PolicyResponse.Rules
+
+			if check.Match.Rule != nil {
+				filtered := make([]engineapi.RuleResponse, 0, len(rules))
+				for _, rule := range rules {
+					actual := map[string]any{"name": rule.Name()}
+					if checkMatches(check.Match.Rule.Value, actual) {
+						filtered = append(filtered, rule)
+					}
+				}
+				rules = filtered
+			}
+
+			for _, rule := range rules {
+				actual := map[string]any{
+					"name":              rule.Name(),
+					"ruleType":          rule.RuleType(),
+					"message":           rule.Message(),
+					"status":            string(rule.Status()),
+					"podSecurityChecks": rule.PodSecurityChecks(),
+					"exceptions":        rule.Exceptions(),
+				}
+
+				if check.Assert.Value != nil {
+					ok, err := evaluateCheck(context.Background(), check.Assert.Value, actual)
+					if err != nil {
+						return fmt.Errorf("evaluate check assertion: %w", err)
+					}
+					addCheckResultRow(resultsTable, rc, testCount, response, rule, ok, "Assertion failed")
+					testCount++
+				}
+
+				if check.Error.Value != nil {
+					ok, err := evaluateCheck(context.Background(), check.Error.Value, actual)
+					if err != nil {
+						return fmt.Errorf("evaluate check error assertion: %w", err)
+					}
+					addCheckResultRow(resultsTable, rc, testCount, response, rule, !ok, "The assertion succeeded but was expected to fail")
+					testCount++
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func addCheckResultRow(
+	resultsTable *table.Table,
+	rc *resultCounts,
+	id int,
+	response engineapi.EngineResponse,
+	rule engineapi.RuleResponse,
+	pass bool,
+	failureReason string,
+) {
+	row := table.Row{
+		RowCompact: table.RowCompact{
+			ID:        id,
+			Policy:    color.Policy("", response.Policy().GetName()),
+			Rule:      color.Rule(rule.Name()),
+			Resource:  color.Resource(response.Resource.GetKind(), response.Resource.GetNamespace(), response.Resource.GetName()),
+			IsFailure: !pass,
+		},
+		Message: rule.Message(),
+	}
+
+	if pass {
+		row.Result = color.ResultPass()
+		row.Reason = "Ok"
+		if rule.Status() == engineapi.RuleStatusSkip {
+			rc.Skip++
+		} else {
+			rc.Pass++
+		}
+	} else {
+		row.Result = color.ResultFail()
+		row.Reason = failureReason
+		rc.Fail++
+	}
+
+	resultsTable.Add(row)
+}
+
+func evaluateCheck(ctx context.Context, value any, actual map[string]any) (bool, error) {
+	expected, ok := value.(map[string]any)
+	if !ok {
+		return false, fmt.Errorf("assertion must be an object")
+	}
+
+	for key, expectedValue := range expected {
+		if strings.HasPrefix(key, "(") && strings.HasSuffix(key, ")") {
+			expression := strings.TrimSpace(key[1 : len(key)-1])
+
+			result, err := evaluateCEL(ctx, expression, actual)
+			if err != nil {
+				return false, err
+			}
+
+			want, ok := expectedValue.(bool)
+			if !ok {
+				return false, fmt.Errorf("assertion expression %q must have a boolean expected value", expression)
+			}
+
+			if result != want {
+				return false, nil
+			}
+			continue
+		}
+
+		actualValue, exists := actual[key]
+		if !exists || !checkMatches(expectedValue, actualValue) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func evaluateCEL(_ context.Context, expression string, activation map[string]any) (bool, error) {
+	options := make([]cel.EnvOption, 0, len(activation))
+	for name := range activation {
+		options = append(options, cel.Variable(name, cel.DynType))
+	}
+
+	env, err := cel.NewEnv(options...)
+	if err != nil {
+		return false, err
+	}
+
+	ast, issues := env.Compile(expression)
+	if issues.Err() != nil {
+		return false, issues.Err()
+	}
+
+	program, err := env.Program(ast)
+	if err != nil {
+		return false, err
+	}
+
+	value, _, err := program.Eval(activation)
+	if err != nil {
+		return false, err
+	}
+
+	result, ok := value.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("assertion expression %q did not return bool", expression)
+	}
+
+	return result, nil
+}
+
+func checkMatches(expected, actual any) bool {
+	switch expectedValue := expected.(type) {
+	case map[string]any:
+		actualValue, ok := actual.(map[string]any)
+		if !ok {
+			return false
+		}
+
+		for key, value := range expectedValue {
+			actualField, exists := actualValue[key]
+			if !exists || !checkMatches(value, actualField) {
+				return false
+			}
+		}
+		return true
+
+	case []any:
+		actualValue, ok := actual.([]any)
+		if !ok || len(expectedValue) != len(actualValue) {
+			return false
+		}
+
+		for i := range expectedValue {
+			if !checkMatches(expectedValue[i], actualValue[i]) {
+				return false
+			}
+		}
+		return true
+
+	default:
+		return reflect.DeepEqual(expected, actual)
+	}
+}
+
+func addMetadataAliases(data map[string]any) map[string]any {
+	result := make(map[string]any, len(data)+2)
+
+	for key, value := range data {
+		result[key] = value
+	}
+
+	if metadata, ok := data["metadata"].(map[string]any); ok {
+		if name, ok := metadata["name"]; ok {
+			result["name"] = name
+		}
+		if namespace, ok := metadata["namespace"]; ok {
+			result["namespace"] = namespace
+		}
+	}
+
+	return result
+}

--- a/cmd/cli/kubectl-kyverno/commands/test/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/command.go
@@ -165,6 +165,9 @@ func testCommandExecute(
 			if err := printTestResult(filteredResults, responses, rc, &resultsTable, test.Fs, resourcePath, removeColor); err != nil {
 				return fmt.Errorf("failed to print test result (%w)", err)
 			}
+			if err := printCheckResult(test.Test.Checks, *responses, rc, &resultsTable); err != nil {
+				return fmt.Errorf("failed to check assertions (%w)", err)
+			}
 			fullTable.AddFailed(resultsTable.RawRows...)
 			if !failOnly {
 				if len(outputFormat) > 0 {

--- a/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/config/crds/cli.kyverno.io_tests.yaml
@@ -1,4 +1,4 @@
----
+﻿---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -69,6 +69,41 @@ spec:
               may reject unrecognized values.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
+          checks:
+            description: Checks are the verifications to be checked in the test
+            items:
+              properties:
+                assert:
+                  description: Assert contains assertion to be performed on the relevant
+                    rule responses
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                error:
+                  description: Error contains negative assertion to be performed on
+                    the relevant rule responses
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                match:
+                  description: Match tells how to match relevant rule responses
+                  properties:
+                    policy:
+                      description: Policy filters engine responses
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    resource:
+                      description: Resource filters engine responses
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    rule:
+                      description: Rule filters rule responses
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+              required:
+              - assert
+              - error
+              type: object
+            type: array
           clusterResources:
             description: ClusterResources are the cluster resources to be used in
               the test

--- a/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/cli.kyverno.io_tests.yaml
@@ -1,4 +1,4 @@
----
+﻿---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -69,6 +69,41 @@ spec:
               may reject unrecognized values.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
+          checks:
+            description: Checks are the verifications to be checked in the test
+            items:
+              properties:
+                assert:
+                  description: Assert contains assertion to be performed on the relevant
+                    rule responses
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                error:
+                  description: Error contains negative assertion to be performed on
+                    the relevant rule responses
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                match:
+                  description: Match tells how to match relevant rule responses
+                  properties:
+                    policy:
+                      description: Policy filters engine responses
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    resource:
+                      description: Resource filters engine responses
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    rule:
+                      description: Rule filters rule responses
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+              required:
+              - assert
+              - error
+              type: object
+            type: array
           clusterResources:
             description: ClusterResources are the cluster resources to be used in
               the test


### PR DESCRIPTION
Closes #17372

Restores the documented `checks:` assertion block removed from the CLI test API.

Changes:
- restore `checks`, `CheckResult`, and `CheckMatch`
- restore checks assertion execution
- restore `checks:` in both CLI Test CRD schemas
- avoid restoring the removed kyverno-json dependency

Verified with the issue reproduction:
Test Summary: 2 tests passed and 0 tests failed

Also verified:
go build ./cmd/cli/kubectl-kyverno
git diff --check