### PR TITLE
fix: apply allowedResults filter to generate rules without generated results

### DIFF
--- a/pkg/utils/report/results.go
+++ b/pkg/utils/report/results.go
@@ -325,11 +325,11 @@ func MutationEngineResponseToReportResults(response engineapi.EngineResponse) []
 func GenerationEngineResponseToReportResults(response engineapi.EngineResponse) []openreportsv1alpha1.ReportResult {
 	results := make([]openreportsv1alpha1.ReportResult, 0, len(response.PolicyResponse.Rules))
 	for _, ruleResult := range response.PolicyResponse.Rules {
+		if !ReportingCfg.IsStatusAllowed(ruleResult.Status()) {
+			continue
+		}
 		result := ToPolicyReportResult(response.Policy(), ruleResult, nil)
 		if generatedResources := ruleResult.GeneratedResources(); len(generatedResources) != 0 {
-			if !ReportingCfg.IsStatusAllowed(ruleResult.Status()) {
-				continue
-			}
 			property := make([]string, 0, len(generatedResources))
 			for _, r := range generatedResources {
 				property = append(property, getResourceInfo(r.GroupVersionKind(), r.GetName(), r.GetNamespace()))

--- a/pkg/utils/report/results_test.go
+++ b/pkg/utils/report/results_test.go
@@ -11,6 +11,7 @@ import (
 	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -313,4 +314,50 @@ func TestToPolicyReportResult_ConcurrentAccess(t *testing.T) {
 		assert.Equal(t, openreportsv1alpha1.Result(openreports.StatusPass), r.Result, "goroutine %d", i)
 		assert.Equal(t, "resource is compliant", r.Description, "goroutine %d", i)
 	}
+}
+
+func Test_GenerationEngineResponseToReportResults_filters_disallowed_status_without_generated_resources(t *testing.T) {
+	oldCfg := ReportingCfg
+	ReportingCfg = NewReportingConfig([]string{"pass"})
+	defer func() { ReportingCfg = oldCfg }()
+
+	pol := engineapi.NewKyvernoPolicy(&kyvernov1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "gen-policy"},
+	})
+	ruleResp := engineapi.NewRuleResponse(
+		"gen-rule",
+		engineapi.Generation,
+		"no resources generated",
+		engineapi.RuleStatusSkip,
+		nil,
+	)
+	resp := engineapi.NewEngineResponse(unstructured.Unstructured{}, pol, nil).
+		WithPolicyResponse(engineapi.PolicyResponse{Rules: []engineapi.RuleResponse{*ruleResp}})
+
+	results := GenerationEngineResponseToReportResults(resp)
+	assert.Empty(t, results)
+}
+
+func Test_GenerationEngineResponseToReportResults_keeps_allowed_status_without_generated_resources(t *testing.T) {
+	oldCfg := ReportingCfg
+	ReportingCfg = NewReportingConfig([]string{"skip"})
+	defer func() { ReportingCfg = oldCfg }()
+
+	pol := engineapi.NewKyvernoPolicy(&kyvernov1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "gen-policy"},
+	})
+	ruleResp := engineapi.NewRuleResponse(
+		"gen-rule",
+		engineapi.Generation,
+		"no resources generated",
+		engineapi.RuleStatusSkip,
+		nil,
+	)
+	resp := engineapi.NewEngineResponse(unstructured.Unstructured{}, pol, nil).
+		WithPolicyResponse(engineapi.PolicyResponse{Rules: []engineapi.RuleResponse{*ruleResp}})
+
+	results := GenerationEngineResponseToReportResults(resp)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "gen-rule", results[0].Rule)
+	assert.Equal(t, openreportsv1alpha1.Result(openreports.StatusSkip), results[0].Result)
 }


### PR DESCRIPTION
## What

`GenerationEngineResponseToReportResults()` only checked `ReportingCfg.IsStatusAllowed()` inside the `len(GeneratedResources()) != 0` branch, so generate rule results with **no** generated resources bypassed the `--allowedResults` status filter and were always included in reports.

This contradicts the validate (`EngineResponseToReportResults`) and mutate (`MutationEngineResponseToReportResults`) paths, which check the configured status filter before appending any result.

## Fix

Move the `IsStatusAllowed` check to the top of the loop so it applies to every generate rule result, regardless of whether generated resources exist.

## Tests

- `Test_GenerationEngineResponseToReportResults_filters_disallowed_status_without_generated_resources` — a `skip` generate result with no generated resources is filtered out when only `pass` is allowed.
- `Test_GenerationEngineResponseToReportResults_keeps_allowed_status_without_generated_resources` — the same result is kept when `skip` is allowed.

Fixes #17321