### PR TITLE
fix(apicall): allow Service APICalls in namespaced policies

### DIFF
--- a/pkg/engine/apicall/apiCall.go
+++ b/pkg/engine/apicall/apiCall.go
@@ -81,7 +81,7 @@ func (a *apiCall) Fetch(ctx context.Context) ([]byte, error) {
 	}
 	cleanPath := path.Clean(unescapedPath)
 
-	if a.policyNamespace != "" {
+	if a.policyNamespace != "" && call.APICall.URLPath != "" {
 		// Namespaced Policy: verify path accesses only the policy's namespace
 		if matches := namespacePathRegex.FindStringSubmatch(cleanPath); len(matches) > 2 {
 			ns := matches[2]


### PR DESCRIPTION
## Explanation

This PR fixes a bug where Namespaced Policies fail to execute Service APICalls due to incorrect namespace path validation.

Service APICalls natively have an empty `URLPath`. In `apiCall.Fetch()`, Kyverno performs path verification for Namespaced Policies. Because `URLPath` is empty, `path.Clean("")` evaluates to `.`. The namespace validation regex fails, and Kyverno blocks the call with:
`path . does not contain a namespace segment, which is required for namespaced policies`

This PR fixes the bug by skipping the namespace check if `URLPath` is empty, allowing Service APICalls to proceed to `executeServiceCall`, which handles egress filtering separately.



## Related issue

Fixes #17393

## Milestone of this PR

/milestone TBD

## What type of PR is this

/kind bug

## Proposed Changes

- Modified `pkg/engine/apicall/apiCall.go` to skip K8s API path namespace validation when `call.APICall.URLPath == ""`.
- Allows `Service` APICalls to function correctly in Namespaced Policies.

### Proof Manifests

Not applicable.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

This bug completely prevented `Service` APICalls from being used in namespaced policies, making it a critical fix for policy authors using webhook-like external data lookups.
