### PR TITLE
fix(cli): stop collecting results after timeout

### DIFF
--- a/pkg/cli/loader/resource_loader.go
+++ b/pkg/cli/loader/resource_loader.go
@@ -170,18 +170,21 @@ func (cl *ClusterLoader) executeTasks(ctx context.Context, tasks []LoadTask) ([]
 
 	var results []LoadTaskResult
 	expectedResults := len(tasks)
+	timer := time.NewTimer(cl.resourceOptions.Timeout)
+	defer timer.Stop()
 
+CollectResults:
 	for i := 0; i < expectedResults; i++ {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case result := <-cl.workerPool.GetResults():
 			results = append(results, result)
-		case <-time.After(cl.resourceOptions.Timeout):
+		case <-timer.C:
 			if !cl.resourceOptions.ContinueOnError {
 				return nil, fmt.Errorf("timeout waiting for task results")
 			}
-			break
+			break CollectResults
 		}
 	}
 

--- a/pkg/cli/loader/resource_loader_test.go
+++ b/pkg/cli/loader/resource_loader_test.go
@@ -90,6 +90,34 @@ func TestClusterLoader_LoadResources(t *testing.T) {
 	})
 }
 
+func TestClusterLoader_ExecuteTasksStopsAfterTimeoutWhenContinuingOnError(t *testing.T) {
+	timeout := 100 * time.Millisecond
+	workerPool := &WorkerPool{
+		taskQueue:  make(chan LoadTask, 2),
+		resultChan: make(chan LoadTaskResult, 1),
+	}
+	loader := &ClusterLoader{
+		workerPool: workerPool,
+		resourceOptions: ResourceOptions{
+			Timeout:         timeout,
+			ContinueOnError: true,
+		},
+	}
+
+	sent := make(chan struct{})
+	go func() {
+		time.Sleep(timeout + timeout/2)
+		workerPool.resultChan <- LoadTaskResult{TaskID: "late-result"}
+		close(sent)
+	}()
+
+	results, err := loader.executeTasks(context.Background(), []LoadTask{{ID: "task-1"}, {ID: "task-2"}})
+	<-sent
+
+	assert.NoError(t, err)
+	assert.Empty(t, results)
+}
+
 func TestClusterLoader_Options(t *testing.T) {
 	t.Run("invalid options", func(t *testing.T) {
 		loader := &ClusterLoader{}


### PR DESCRIPTION

  ## Description

  - Stop collecting task results after a timeout when `ContinueOnError` is enabled.
  - Replace the per-iteration `time.After` call with one stoppable timer for result
  collection.

  Fixes #17043

  ## Tests

  - `go test ./pkg/cli/loader -run
  TestClusterLoader_ExecuteTasksStopsAfterTimeoutWhenContinuingOnError -count=1`
  - `go test ./pkg/cli/loader -count=1`
  - `go test -race ./pkg/cli/loader -count=1`
  - `make imports fmt`
  - `make imports-check fmt-check`
  - `make codegen-all-code`
  - `make verify-codegen`
  - `make lint`