### PR TITLE
test: fix 'occured' typo in response_test.go

### DIFF
--- a/pkg/utils/admission/response_test.go
+++ b/pkg/utils/admission/response_test.go
@@ -40,27 +40,27 @@ func TestResponse(t *testing.T) {
 	}, {
 		name: "error, no warnings",
 		args: args{
-			err:      errors.New("an error has occured"),
+			err:      errors.New("an error has occurred"),
 			warnings: nil,
 		},
 		want: admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status:  metav1.StatusFailure,
-				Message: "an error has occured",
+				Message: "an error has occurred",
 			},
 		},
 	}, {
 		name: "error, warnings",
 		args: args{
-			err:      errors.New("an error has occured"),
+			err:      errors.New("an error has occurred"),
 			warnings: []string{"foo", "bar"},
 		},
 		want: admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status:  metav1.StatusFailure,
-				Message: "an error has occured",
+				Message: "an error has occurred",
 			},
 			Warnings: []string{"foo", "bar"},
 		},


### PR DESCRIPTION
`pkg/utils/admission/response_test.go` had "an error has occured" in both the input error and the expected status message, in two test cases. Fixed to "occurred" in all four spots so input and expected stay in sync; test behavior is unchanged.