### PR TITLE
fix: handle missing reports CRDs as no-op in kyverno-init

### DIFF
--- a/cmd/kyverno-init/main.go
+++ b/cmd/kyverno-init/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/logging"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
 	coordinationv1 "k8s.io/api/coordination/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -97,14 +96,15 @@ func main() {
 
 	if setup.OpenreportsClient != nil {
 		logger := logging.WithName("kyvernopre/wgpolicyreport-cleanup")
-		err := kubeutils.CRDsInstalled(setup.ApiServerClient, "clusterpolicyreports.wgpolicyk8s.io", "policyreports.wgpolicyk8s.io")
+		// The legacy wgpolicyk8s CRDs are intentionally absent when reports-server
+		// serves that API through its aggregated APIService, so treat "not found"
+		// as nothing to clean up rather than a fatal error.
+		exists, err := kubeutils.CRDsExist(setup.ApiServerClient, "clusterpolicyreports.wgpolicyk8s.io", "policyreports.wgpolicyk8s.io")
 		if err != nil {
-			if !apierrors.IsNotFound(err) {
-				logger.Error(err, "error checking if reports CRDs are installed to clean them up")
-				os.Exit(0)
-			}
-			// error was nil, meaning the cluster has the wg policy api and it should be cleaned
-		} else {
+			logger.Error(err, "error checking if reports CRDs are installed to clean them up")
+			os.Exit(0)
+		}
+		if exists {
 			if err := cleanUpWgPolicyReports(logger, setup.KyvernoClient.Wgpolicyk8sV1alpha2()); err != nil {
 				logger.Error(err, "error cleaning up reports belonging to wgpolicyk8s")
 				os.Exit(0)

--- a/pkg/utils/kube/crd.go
+++ b/pkg/utils/kube/crd.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/multierr"
 	apiserver "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -24,4 +25,20 @@ func CRDsInstalled(apiserverClient apiserver.Interface, names ...string) error {
 func isCRDInstalled(apiserverClient apiserver.Interface, kind string) error {
 	_, err := apiserverClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), kind, metav1.GetOptions{})
 	return err
+}
+
+// CRDsExist reports whether all the named CRDs are installed. A missing CRD
+// (NotFound) is not an error: it returns (false, nil). Any other error while
+// checking, for example the API server being unreachable, is returned so callers
+// can distinguish "absent" from "could not determine".
+func CRDsExist(apiserverClient apiserver.Interface, names ...string) (bool, error) {
+	for _, crd := range names {
+		if err := isCRDInstalled(apiserverClient, crd); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to check CRD %s is installed: %w", crd, err)
+		}
+	}
+	return true, nil
 }

--- a/pkg/utils/kube/crd_notfound_test.go
+++ b/pkg/utils/kube/crd_notfound_test.go
@@ -1,0 +1,21 @@
+package kube
+
+import (
+	"testing"
+
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+)
+
+// TestCRDsExist_AbsentIsNoOp verifies that when the named CRDs are not installed,
+// CRDsExist reports (false, nil) so callers treat a missing CRD as "nothing to
+// clean up" rather than a fatal error.
+func TestCRDsExist_AbsentIsNoOp(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	exists, err := CRDsExist(client, "clusterpolicyreports.wgpolicyk8s.io", "policyreports.wgpolicyk8s.io")
+	if err != nil {
+		t.Fatalf("expected no error for absent CRDs, got: %v", err)
+	}
+	if exists {
+		t.Fatalf("expected exists=false for absent CRDs, got true")
+	}
+}


### PR DESCRIPTION
## Related issue

Fixes #17419

## What type of PR is this?

/kind bug

## What this PR does / why we need it

When reports-server serves the reports API, the legacy `wgpolicyk8s.io` CRDs are intentionally not installed. The `kyverno-init` cleanup step checks whether those CRDs exist and is meant to skip cleanup when they are absent. That "not found" check never matches, so a missing CRD is handled the same as a real error.

Root cause: `kubeutils.CRDsInstalled` builds its message with `fmt.Errorf("...: %s", crd, err)` (`%s`, not `%w`) and combines results with `multierr.Combine`. Both steps discard the typed `*apierrors.StatusError`, so `apierrors.IsNotFound(err)` always returns `false`, even for a genuine NotFound. The intended "no-op on NotFound" branch in `cmd/kyverno-init/main.go` is dead code.

This PR:

- Adds `CRDsExist(...) (bool, error)` to `pkg/utils/kube/crd.go`. It treats NotFound as `(false, nil)` and returns any other error wrapped with `%w`.
- Rewires `cmd/kyverno-init/main.go` to use `CRDsExist`: skip cleanup when the CRDs are absent, run cleanup when they exist. The existing best-effort exit code on the error path is preserved.
- Adds a regression test (`TestCRDsExist_AbsentIsNoOp`).

`CRDsInstalled` is left unchanged. Its other callers treat any non-nil result as fatal, which is correct for them. Note that `CRDsInstalled` still uses `%s`, so anyone who later needs `IsNotFound` on it must switch it to `%w` first.

## Proposed changes

- Fix incorrect not-found handling in the kyverno-init reports cleanup.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and requires documentation updates.
