### PR TITLE
feat: add deprecation warnings to legacy CRD versions and migrate test fixtures off v2beta1

### DIFF
--- a/api/kyverno/v1/clusterpolicy_types.go
+++ b/api/kyverno/v1/clusterpolicy_types.go
@@ -26,6 +26,7 @@ import (
 // +kubebuilder:printcolumn:name="VERIFY IMAGES",type=integer,JSONPath=`.status.rulecount.verifyimages`,priority=1
 // +kubebuilder:printcolumn:name="MESSAGE",type=string,JSONPath=`.status.conditions[?(@.type == "Ready")].message`
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v1 ClusterPolicy is deprecated and will be removed in a future release; migrate to ValidatingPolicy, MutatingPolicy, GeneratingPolicy or ImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
 
 // ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.
 type ClusterPolicy struct {

--- a/api/kyverno/v1/policy_types.go
+++ b/api/kyverno/v1/policy_types.go
@@ -25,7 +25,7 @@ import (
 // +kubebuilder:printcolumn:name="MESSAGE",type=string,JSONPath=`.status.conditions[?(@.type == "Ready")].message`
 // +kubebuilder:resource:shortName=pol,categories=kyverno
 // +kubebuilder:storageversion
-// +kubebuilder:deprecatedversion:warning="kyverno.io/v1 Policy is deprecated and will be removed in a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy, NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v1 Policy is deprecated and will be removed in a future release; migrate to NamespacedValidatingPolicy and the other namespaced policy types (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
 
 // Policy declares validation, mutation, and generation behaviors for matching resources.
 // See: https://kyverno.io/docs/writing-policies/ for more information.

--- a/api/kyverno/v1/policy_types.go
+++ b/api/kyverno/v1/policy_types.go
@@ -25,6 +25,7 @@ import (
 // +kubebuilder:printcolumn:name="MESSAGE",type=string,JSONPath=`.status.conditions[?(@.type == "Ready")].message`
 // +kubebuilder:resource:shortName=pol,categories=kyverno
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v1 Policy is deprecated and will be removed in a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy, NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
 
 // Policy declares validation, mutation, and generation behaviors for matching resources.
 // See: https://kyverno.io/docs/writing-policies/ for more information.

--- a/api/kyverno/v1beta1/updaterequest_types.go
+++ b/api/kyverno/v1beta1/updaterequest_types.go
@@ -55,7 +55,7 @@ type UpdateRequestStatus struct {
 // +kubebuilder:printcolumn:name="status",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:shortName=ur,categories=kyverno
-// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v1beta1 UpdateRequest is deprecated; use kyverno.io/v2 UpdateRequest"
 // +kubebuilder:unservedversion
 
 // UpdateRequest is a request to process mutate and generate rules in background.

--- a/api/kyverno/v2/cleanup_policy_types.go
+++ b/api/kyverno/v2/cleanup_policy_types.go
@@ -36,6 +36,7 @@ import (
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=".spec.schedule"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2 CleanupPolicy is deprecated and will be removed in a future release; migrate to NamespacedDeletingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
 
 // CleanupPolicy defines a rule for resource cleanup.
 type CleanupPolicy struct {
@@ -122,6 +123,7 @@ type CleanupPolicyList struct {
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=".spec.schedule"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2 ClusterCleanupPolicy is deprecated and will be removed in a future release; migrate to DeletingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
 
 // ClusterCleanupPolicy defines rule for resource cleanup.
 type ClusterCleanupPolicy struct {

--- a/api/kyverno/v2/policy_exception_types.go
+++ b/api/kyverno/v2/policy_exception_types.go
@@ -28,6 +28,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=polex,categories=kyverno
 // +kubebuilder:storageversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2 PolicyException is deprecated and will be removed in a future release; migrate to PolicyException (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
 
 // PolicyException declares resources to be excluded from specified policies.
 type PolicyException struct {

--- a/api/kyverno/v2alpha1/global_context_entry_types.go
+++ b/api/kyverno/v2alpha1/global_context_entry_types.go
@@ -33,7 +33,7 @@ import (
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="REFRESH INTERVAL",type="string",JSONPath=".spec.apiCall.refreshInterval"
 // +kubebuilder:printcolumn:name="LAST REFRESH",type="date",JSONPath=".status.lastRefreshTime"
-// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2alpha1 GlobalContextEntry is deprecated; use kyverno.io/v2 GlobalContextEntry"
 
 // GlobalContextEntry declares resources to be cached.
 type GlobalContextEntry struct {

--- a/api/kyverno/v2beta1/cleanup_policy_types.go
+++ b/api/kyverno/v2beta1/cleanup_policy_types.go
@@ -35,7 +35,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=".spec.schedule"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2beta1 CleanupPolicy is deprecated and will be removed in a future release; migrate to NamespacedDeletingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
 
 // CleanupPolicy defines a rule for resource cleanup.
 type CleanupPolicy struct {
@@ -121,7 +121,7 @@ type CleanupPolicyList struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=".spec.schedule"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2beta1 ClusterCleanupPolicy is deprecated and will be removed in a future release; migrate to DeletingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
 
 // ClusterCleanupPolicy defines rule for resource cleanup.
 type ClusterCleanupPolicy struct {

--- a/api/kyverno/v2beta1/clusterpolicy_types.go
+++ b/api/kyverno/v2beta1/clusterpolicy_types.go
@@ -26,6 +26,7 @@ import (
 // +kubebuilder:printcolumn:name="GENERATE",type=integer,JSONPath=`.status.rulecount.generate`,priority=1
 // +kubebuilder:printcolumn:name="VERIFY IMAGES",type=integer,JSONPath=`.status.rulecount.verifyimages`,priority=1
 // +kubebuilder:printcolumn:name="MESSAGE",type=string,JSONPath=`.status.conditions[?(@.type == "Ready")].message`
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2beta1 ClusterPolicy is deprecated and will be removed in a future release; migrate to ValidatingPolicy, MutatingPolicy, GeneratingPolicy or ImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
 
 // ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.
 type ClusterPolicy struct {

--- a/api/kyverno/v2beta1/policy_exception_types.go
+++ b/api/kyverno/v2beta1/policy_exception_types.go
@@ -26,7 +26,7 @@ import (
 // +kubebuilder:object:root=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:shortName=polex,categories=kyverno
-// +kubebuilder:deprecatedversion
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2beta1 PolicyException is deprecated and will be removed in a future release; migrate to PolicyException (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
 
 // PolicyException declares resources to be excluded from specified policies.
 type PolicyException struct {

--- a/api/kyverno/v2beta1/policy_types.go
+++ b/api/kyverno/v2beta1/policy_types.go
@@ -25,6 +25,7 @@ import (
 // +kubebuilder:printcolumn:name="VERIFY IMAGES",type=integer,JSONPath=`.status.rulecount.verifyimages`,priority=1
 // +kubebuilder:printcolumn:name="MESSAGE",type=string,JSONPath=`.status.conditions[?(@.type == "Ready")].message`
 // +kubebuilder:resource:shortName=pol,categories=kyverno
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2beta1 Policy is deprecated and will be removed in a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy, NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
 
 // Policy declares validation, mutation, and generation behaviors for matching resources.
 // See: https://kyverno.io/docs/writing-policies/ for more information.

--- a/api/kyverno/v2beta1/policy_types.go
+++ b/api/kyverno/v2beta1/policy_types.go
@@ -25,7 +25,7 @@ import (
 // +kubebuilder:printcolumn:name="VERIFY IMAGES",type=integer,JSONPath=`.status.rulecount.verifyimages`,priority=1
 // +kubebuilder:printcolumn:name="MESSAGE",type=string,JSONPath=`.status.conditions[?(@.type == "Ready")].message`
 // +kubebuilder:resource:shortName=pol,categories=kyverno
-// +kubebuilder:deprecatedversion:warning="kyverno.io/v2beta1 Policy is deprecated and will be removed in a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy, NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
+// +kubebuilder:deprecatedversion:warning="kyverno.io/v2beta1 Policy is deprecated and will be removed in a future release; migrate to NamespacedValidatingPolicy and the other namespaced policy types (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/"
 
 // Policy declares validation, mutation, and generation behaviors for matching resources.
 // See: https://kyverno.io/docs/writing-policies/ for more information.

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_cleanuppolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_cleanuppolicies.yaml
@@ -1325,6 +1325,9 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 CleanupPolicy is deprecated and will be
+      removed in a future release; migrate to NamespacedDeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_cleanuppolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_cleanuppolicies.yaml
@@ -31,6 +31,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: kyverno.io/v2 CleanupPolicy is deprecated and will be removed
+      in a future release; migrate to NamespacedDeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clustercleanuppolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clustercleanuppolicies.yaml
@@ -31,6 +31,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: kyverno.io/v2 ClusterCleanupPolicy is deprecated and will
+      be removed in a future release; migrate to DeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clustercleanuppolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clustercleanuppolicies.yaml
@@ -1325,6 +1325,9 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterCleanupPolicy is deprecated and
+      will be removed in a future release; migrate to DeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clusterpolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clusterpolicies.yaml
@@ -60,6 +60,10 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v1 ClusterPolicy is deprecated and will be removed
+      in a future release; migrate to ValidatingPolicy, MutatingPolicy, GeneratingPolicy
+      or ImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clusterpolicies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_clusterpolicies.yaml
@@ -10363,6 +10363,10 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterPolicy is deprecated and will be
+      removed in a future release; migrate to ValidatingPolicy, MutatingPolicy, GeneratingPolicy
+      or ImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_globalcontextentries.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_globalcontextentries.yaml
@@ -285,6 +285,8 @@ spec:
       name: LAST REFRESH
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2alpha1 GlobalContextEntry is deprecated; use
+      kyverno.io/v2 GlobalContextEntry
     name: v2alpha1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policies.yaml
@@ -62,9 +62,8 @@ spec:
       type: string
     deprecated: true
     deprecationWarning: kyverno.io/v1 Policy is deprecated and will be removed in
-      a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
-      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
-      see https://kyverno.io/docs/guides/migration-to-cel/
+      a future release; migrate to NamespacedValidatingPolicy and the other namespaced
+      policy types (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v1
     schema:
       openAPIV3Schema:
@@ -10372,9 +10371,8 @@ spec:
       type: string
     deprecated: true
     deprecationWarning: kyverno.io/v2beta1 Policy is deprecated and will be removed
-      in a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
-      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
-      see https://kyverno.io/docs/guides/migration-to-cel/
+      in a future release; migrate to NamespacedValidatingPolicy and the other namespaced
+      policy types (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policies.yaml
@@ -10365,6 +10365,11 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 Policy is deprecated and will be removed
+      in a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
+      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policies.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policies.yaml
@@ -60,6 +60,11 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v1 Policy is deprecated and will be removed in
+      a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
+      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policyexceptions.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policyexceptions.yaml
@@ -24,7 +24,10 @@ spec:
     singular: policyexception
   scope: Namespaced
   versions:
-  - name: v2
+  - deprecated: true
+    deprecationWarning: kyverno.io/v2 PolicyException is deprecated and will be removed
+      in a future release; migrate to PolicyException (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
+    name: v2
     schema:
       openAPIV3Schema:
         description: PolicyException declares resources to be excluded from specified

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policyexceptions.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_policyexceptions.yaml
@@ -665,6 +665,9 @@ spec:
     served: true
     storage: true
   - deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 PolicyException is deprecated and will
+      be removed in a future release; migrate to PolicyException (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_updaterequests.yaml
+++ b/charts/kyverno/charts/crds/templates/kyverno.io/kyverno.io_updaterequests.yaml
@@ -50,6 +50,8 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v1beta1 UpdateRequest is deprecated; use kyverno.io/v2
+      UpdateRequest
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_cleanuppolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_cleanuppolicies.yaml
@@ -1319,6 +1319,9 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 CleanupPolicy is deprecated and will be
+      removed in a future release; migrate to NamespacedDeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_cleanuppolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_cleanuppolicies.yaml
@@ -25,6 +25,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: kyverno.io/v2 CleanupPolicy is deprecated and will be removed
+      in a future release; migrate to NamespacedDeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clustercleanuppolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clustercleanuppolicies.yaml
@@ -25,6 +25,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: kyverno.io/v2 ClusterCleanupPolicy is deprecated and will
+      be removed in a future release; migrate to DeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clustercleanuppolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clustercleanuppolicies.yaml
@@ -1319,6 +1319,9 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterCleanupPolicy is deprecated and
+      will be removed in a future release; migrate to DeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
@@ -10357,6 +10357,10 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterPolicy is deprecated and will be
+      removed in a future release; migrate to ValidatingPolicy, MutatingPolicy, GeneratingPolicy
+      or ImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_clusterpolicies.yaml
@@ -54,6 +54,10 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v1 ClusterPolicy is deprecated and will be removed
+      in a future release; migrate to ValidatingPolicy, MutatingPolicy, GeneratingPolicy
+      or ImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policies.yaml
@@ -10359,6 +10359,11 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 Policy is deprecated and will be removed
+      in a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
+      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policies.yaml
@@ -54,6 +54,11 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v1 Policy is deprecated and will be removed in
+      a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
+      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policies.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policies.yaml
@@ -56,9 +56,8 @@ spec:
       type: string
     deprecated: true
     deprecationWarning: kyverno.io/v1 Policy is deprecated and will be removed in
-      a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
-      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
-      see https://kyverno.io/docs/guides/migration-to-cel/
+      a future release; migrate to NamespacedValidatingPolicy and the other namespaced
+      policy types (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v1
     schema:
       openAPIV3Schema:
@@ -10366,9 +10365,8 @@ spec:
       type: string
     deprecated: true
     deprecationWarning: kyverno.io/v2beta1 Policy is deprecated and will be removed
-      in a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
-      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
-      see https://kyverno.io/docs/guides/migration-to-cel/
+      in a future release; migrate to NamespacedValidatingPolicy and the other namespaced
+      policy types (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policyexceptions.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policyexceptions.yaml
@@ -659,6 +659,9 @@ spec:
     served: true
     storage: true
   - deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 PolicyException is deprecated and will
+      be removed in a future release; migrate to PolicyException (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policyexceptions.yaml
+++ b/cmd/cli/kubectl-kyverno/data/crds/kyverno.io_policyexceptions.yaml
@@ -18,7 +18,10 @@ spec:
     singular: policyexception
   scope: Namespaced
   versions:
-  - name: v2
+  - deprecated: true
+    deprecationWarning: kyverno.io/v2 PolicyException is deprecated and will be removed
+      in a future release; migrate to PolicyException (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
+    name: v2
     schema:
       openAPIV3Schema:
         description: PolicyException declares resources to be excluded from specified

--- a/config/crds/kyverno/kyverno.io_cleanuppolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_cleanuppolicies.yaml
@@ -1319,6 +1319,9 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 CleanupPolicy is deprecated and will be
+      removed in a future release; migrate to NamespacedDeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_cleanuppolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_cleanuppolicies.yaml
@@ -25,6 +25,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: kyverno.io/v2 CleanupPolicy is deprecated and will be removed
+      in a future release; migrate to NamespacedDeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_clustercleanuppolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_clustercleanuppolicies.yaml
@@ -25,6 +25,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: kyverno.io/v2 ClusterCleanupPolicy is deprecated and will
+      be removed in a future release; migrate to DeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_clustercleanuppolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_clustercleanuppolicies.yaml
@@ -1319,6 +1319,9 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterCleanupPolicy is deprecated and
+      will be removed in a future release; migrate to DeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
@@ -10357,6 +10357,10 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterPolicy is deprecated and will be
+      removed in a future release; migrate to ValidatingPolicy, MutatingPolicy, GeneratingPolicy
+      or ImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
+++ b/config/crds/kyverno/kyverno.io_clusterpolicies.yaml
@@ -54,6 +54,10 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v1 ClusterPolicy is deprecated and will be removed
+      in a future release; migrate to ValidatingPolicy, MutatingPolicy, GeneratingPolicy
+      or ImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_globalcontextentries.yaml
+++ b/config/crds/kyverno/kyverno.io_globalcontextentries.yaml
@@ -279,6 +279,8 @@ spec:
       name: LAST REFRESH
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2alpha1 GlobalContextEntry is deprecated; use
+      kyverno.io/v2 GlobalContextEntry
     name: v2alpha1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_policies.yaml
+++ b/config/crds/kyverno/kyverno.io_policies.yaml
@@ -10359,6 +10359,11 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 Policy is deprecated and will be removed
+      in a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
+      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_policies.yaml
+++ b/config/crds/kyverno/kyverno.io_policies.yaml
@@ -54,6 +54,11 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v1 Policy is deprecated and will be removed in
+      a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
+      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_policies.yaml
+++ b/config/crds/kyverno/kyverno.io_policies.yaml
@@ -56,9 +56,8 @@ spec:
       type: string
     deprecated: true
     deprecationWarning: kyverno.io/v1 Policy is deprecated and will be removed in
-      a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
-      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
-      see https://kyverno.io/docs/guides/migration-to-cel/
+      a future release; migrate to NamespacedValidatingPolicy and the other namespaced
+      policy types (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v1
     schema:
       openAPIV3Schema:
@@ -10366,9 +10365,8 @@ spec:
       type: string
     deprecated: true
     deprecationWarning: kyverno.io/v2beta1 Policy is deprecated and will be removed
-      in a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
-      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
-      see https://kyverno.io/docs/guides/migration-to-cel/
+      in a future release; migrate to NamespacedValidatingPolicy and the other namespaced
+      policy types (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_policyexceptions.yaml
+++ b/config/crds/kyverno/kyverno.io_policyexceptions.yaml
@@ -659,6 +659,9 @@ spec:
     served: true
     storage: true
   - deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 PolicyException is deprecated and will
+      be removed in a future release; migrate to PolicyException (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/crds/kyverno/kyverno.io_policyexceptions.yaml
+++ b/config/crds/kyverno/kyverno.io_policyexceptions.yaml
@@ -18,7 +18,10 @@ spec:
     singular: policyexception
   scope: Namespaced
   versions:
-  - name: v2
+  - deprecated: true
+    deprecationWarning: kyverno.io/v2 PolicyException is deprecated and will be removed
+      in a future release; migrate to PolicyException (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
+    name: v2
     schema:
       openAPIV3Schema:
         description: PolicyException declares resources to be excluded from specified

--- a/config/crds/kyverno/kyverno.io_updaterequests.yaml
+++ b/config/crds/kyverno/kyverno.io_updaterequests.yaml
@@ -44,6 +44,8 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v1beta1 UpdateRequest is deprecated; use kyverno.io/v2
+      UpdateRequest
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -232,6 +232,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: kyverno.io/v2 CleanupPolicy is deprecated and will be removed
+      in a future release; migrate to NamespacedDeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2
     schema:
       openAPIV3Schema:
@@ -2847,6 +2851,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: kyverno.io/v2 ClusterCleanupPolicy is deprecated and will
+      be removed in a future release; migrate to DeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2
     schema:
       openAPIV3Schema:
@@ -5491,6 +5499,10 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v1 ClusterPolicy is deprecated and will be removed
+      in a future release; migrate to ValidatingPolicy, MutatingPolicy, GeneratingPolicy
+      or ImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v1
     schema:
       openAPIV3Schema:
@@ -26638,6 +26650,11 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v1 Policy is deprecated and will be removed in
+      a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
+      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v1
     schema:
       openAPIV3Schema:
@@ -46969,7 +46986,10 @@ spec:
     singular: policyexception
   scope: Namespaced
   versions:
-  - name: v2
+  - deprecated: true
+    deprecationWarning: kyverno.io/v2 PolicyException is deprecated and will be removed
+      in a future release; migrate to PolicyException (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
+    name: v2
     schema:
       openAPIV3Schema:
         description: PolicyException declares resources to be excluded from specified

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -26652,9 +26652,8 @@ spec:
       type: string
     deprecated: true
     deprecationWarning: kyverno.io/v1 Policy is deprecated and will be removed in
-      a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
-      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
-      see https://kyverno.io/docs/guides/migration-to-cel/
+      a future release; migrate to NamespacedValidatingPolicy and the other namespaced
+      policy types (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v1
     schema:
       openAPIV3Schema:
@@ -36962,9 +36961,8 @@ spec:
       type: string
     deprecated: true
     deprecationWarning: kyverno.io/v2beta1 Policy is deprecated and will be removed
-      in a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
-      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
-      see https://kyverno.io/docs/guides/migration-to-cel/
+      in a future release; migrate to NamespacedValidatingPolicy and the other namespaced
+      policy types (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -1526,6 +1526,9 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 CleanupPolicy is deprecated and will be
+      removed in a future release; migrate to NamespacedDeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:
@@ -4138,6 +4141,9 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterCleanupPolicy is deprecated and
+      will be removed in a future release; migrate to DeletingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:
@@ -15788,6 +15794,10 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 ClusterPolicy is deprecated and will be
+      removed in a future release; migrate to ValidatingPolicy, MutatingPolicy, GeneratingPolicy
+      or ImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:
@@ -26069,6 +26079,8 @@ spec:
       name: LAST REFRESH
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v2alpha1 GlobalContextEntry is deprecated; use
+      kyverno.io/v2 GlobalContextEntry
     name: v2alpha1
     schema:
       openAPIV3Schema:
@@ -36931,6 +36943,11 @@ spec:
     - jsonPath: .status.conditions[?(@.type == "Ready")].message
       name: MESSAGE
       type: string
+    deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 Policy is deprecated and will be removed
+      in a future release; migrate to NamespacedValidatingPolicy, NamespacedMutatingPolicy,
+      NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:
@@ -47593,6 +47610,9 @@ spec:
     served: true
     storage: true
   - deprecated: true
+    deprecationWarning: kyverno.io/v2beta1 PolicyException is deprecated and will
+      be removed in a future release; migrate to PolicyException (policies.kyverno.io),
+      see https://kyverno.io/docs/guides/migration-to-cel/
     name: v2beta1
     schema:
       openAPIV3Schema:
@@ -48284,6 +48304,8 @@ spec:
       name: Age
       type: date
     deprecated: true
+    deprecationWarning: kyverno.io/v1beta1 UpdateRequest is deprecated; use kyverno.io/v2
+      UpdateRequest
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/pkg/deprecations/deprecations.go
+++ b/pkg/deprecations/deprecations.go
@@ -20,7 +20,7 @@ const MigrationGuideURL = "https://kyverno.io/docs/guides/migration-to-cel/"
 // replacements maps a legacy kyverno.io kind to its policies.kyverno.io replacement(s).
 var replacements = map[string]string{
 	"ClusterPolicy":        "ValidatingPolicy, MutatingPolicy, GeneratingPolicy or ImageValidatingPolicy",
-	"Policy":               "NamespacedValidatingPolicy, NamespacedMutatingPolicy, NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy",
+	"Policy":               "NamespacedValidatingPolicy and the other namespaced policy types",
 	"ClusterCleanupPolicy": "DeletingPolicy",
 	"CleanupPolicy":        "NamespacedDeletingPolicy",
 	"PolicyException":      "PolicyException",

--- a/pkg/deprecations/deprecations_test.go
+++ b/pkg/deprecations/deprecations_test.go
@@ -15,7 +15,7 @@ func TestWarning(t *testing.T) {
 		replacement string
 	}{
 		{"ClusterPolicy", "ValidatingPolicy, MutatingPolicy, GeneratingPolicy or ImageValidatingPolicy"},
-		{"Policy", "NamespacedValidatingPolicy, NamespacedMutatingPolicy, NamespacedGeneratingPolicy or NamespacedImageValidatingPolicy"},
+		{"Policy", "NamespacedValidatingPolicy and the other namespaced policy types"},
 		{"ClusterCleanupPolicy", "DeletingPolicy"},
 		{"CleanupPolicy", "NamespacedDeletingPolicy"},
 		{"PolicyException", "PolicyException (policies.kyverno.io)"},
@@ -70,6 +70,25 @@ func TestPolicyFieldWarnings(t *testing.T) {
 		}
 		if !strings.Contains(warning.Message, "deprecated") {
 			t.Fatalf("expected deprecation message, got %q", warning.Message)
+		}
+	}
+}
+
+// TestWarningLength ensures kind deprecation messages stay within the 256
+// character limit Kubernetes enforces for CRD .spec.versions[].deprecationWarning,
+// so the same wording can be reused in kubebuilder deprecatedversion markers.
+func TestWarningLength(t *testing.T) {
+	t.Parallel()
+	for kind := range replacements {
+		for _, version := range []string{"v1", "v2", "v2beta1"} {
+			warning, ok := BuildKindWarning("kyverno.io", version, kind)
+			if !ok {
+				t.Fatalf("expected warning for kind %q", kind)
+			}
+			if len(warning.Message) > 256 {
+				t.Errorf("warning for %s/%s %s is %d characters, exceeding the 256 character CRD deprecationWarning limit: %q",
+					"kyverno.io", version, kind, len(warning.Message), warning.Message)
+			}
 		}
 	}
 }

--- a/test/cli/test-cleanup-policy/cleanup-pod-by-name/policy.yaml
+++ b/test/cli/test-cleanup-policy/cleanup-pod-by-name/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v2
 kind: CleanupPolicy
 metadata:
   name: cleanup-pod-by-name

--- a/test/cli/test-cleanup-policy/cluster-cleanup-namespace/policy.yaml
+++ b/test/cli/test-cleanup-policy/cluster-cleanup-namespace/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v2
 kind: ClusterCleanupPolicy
 metadata:
   name: cluster-cleanup-namespace

--- a/test/cli/test-exceptions/exceptions-1/policy.yaml
+++ b/test/cli/test-exceptions/exceptions-1/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-host-namespaces

--- a/test/conformance/chainsaw/exceptions/allows-rejects-creation/policy.yaml
+++ b/test/conformance/chainsaw/exceptions/allows-rejects-creation/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-labels

--- a/test/conformance/chainsaw/exceptions/only-for-specific-user/policy.yaml
+++ b/test/conformance/chainsaw/exceptions/only-for-specific-user/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-labels

--- a/test/conformance/chainsaw/exceptions/with-wildcard/policy.yaml
+++ b/test/conformance/chainsaw/exceptions/with-wildcard/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-labels

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/clone-source-name-exceeds-63-characters/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/clone-source-name-exceeds-63-characters/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: generate-secret

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-create-on-trigger-deletion/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-create-on-trigger-deletion/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-create-on-trigger-deletion

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-sync-create-source-after-policy/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/cpol-clone-sync-create-source-after-policy/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-create-source-after-policy

--- a/test/conformance/chainsaw/generate/clusterpolicy/cornercases/generate-event-upon-edit/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/cornercases/generate-event-upon-edit/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: generate-event-upon-edit

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-create/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-create/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-downstream/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-policy/chainsaw-test.yaml
@@ -34,6 +34,6 @@ spec:
         file: check.yaml
     - delete:
         ref:
-          apiVersion: kyverno.io/v2beta1
+          apiVersion: kyverno.io/v1
           kind: ClusterPolicy
           name: cpol-nosync-clone-delete-policy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-policy/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-policy/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone-delete-policy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-rule/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-rule/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-rule/singlerule.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-rule/singlerule.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-source/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-source/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-nosync-delete-source

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-trigger/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-delete-trigger/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-nosync-delete-trigger-policy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-modify-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-modify-downstream/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-nosync-modify-downstream

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-modify-source/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-modify-source/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone-modify-source

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-update-trigger-no-match/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/nosync/cpol-clone-nosync-update-trigger-no-match/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-nosync-update-trigger-no-match-policy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-create/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-create/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-sync-clone

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-downstream/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-sync-clone

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-policy/chainsaw-test.yaml
@@ -42,7 +42,7 @@ spec:
     try:
     - delete:
         ref:
-          apiVersion: kyverno.io/v2beta1
+          apiVersion: kyverno.io/v1
           kind: ClusterPolicy
           name: cpol-clone-sync-delete-policy
   - name: step-05

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-policy/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-policy/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-delete-policy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-rule/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-rule/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-delete-rule

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-rule/singlerule.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-rule/singlerule.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-delete-rule

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-source/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-source/policy.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: cpol-clone-sync-delete-source-ns
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-delete-source

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-trigger/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-delete-trigger/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-delete-trigger-policy

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-modify-downstream-apply/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-modify-downstream-apply/policy.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-modify-downstream-apply

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-modify-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-modify-downstream/policy.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-modify-downstream

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-modify-source/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-modify-source/policy.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: cpol-clone-sync-modify-source-ns
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-modify-source

--- a/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-update-trigger-no-match/policy.yaml
+++ b/test/conformance/chainsaw/generate/clusterpolicy/standard/clone/sync/cpol-clone-sync-update-trigger-no-match/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-clone-sync-update-trigger-no-match-policy

--- a/test/conformance/chainsaw/generate/policy/cornercases/pol-clone-sync-create-source-after-policy/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/cornercases/pol-clone-sync-create-source-after-policy/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-create-source-after-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-create/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-create/manifests.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-create-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-downstream/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-downstream/manifests.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-create-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-policy/chainsaw-test.yaml
@@ -36,7 +36,7 @@ spec:
     try:
     - delete:
         ref:
-          apiVersion: kyverno.io/v2beta1
+          apiVersion: kyverno.io/v1
           kind: Policy
           name: pol-clone-nosync-delete-policy
           namespace: default

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-policy/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-policy/manifests.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-delete-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-rule/chainsaw-step-03-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-rule/chainsaw-step-03-apply-1-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-delete-rule

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-rule/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-rule/manifests.yaml
@@ -24,7 +24,7 @@ spec:
     min:
       cpu: 100m
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-delete-rule

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-source/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-source/manifests.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-delete-source

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-trigger/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-delete-trigger/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-delete-trigger-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-invalid/policy1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-invalid/policy1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-invalid

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-invalid/policy2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-invalid/policy2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-invalid

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-modify-downstream/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-modify-downstream/manifests.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: pol-clone-nosync-modify-downstream-ns
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-modify-downstream

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-modify-source/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-modify-source/manifests.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-modify-source

--- a/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-update-trigger-no-match/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/nosync/pol-clone-nosync-update-trigger-no-match/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-nosync-update-trigger-no-match-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-downstream/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-sync-clone-delete-downstream

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-policy/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-policy/chainsaw-test.yaml
@@ -40,7 +40,7 @@ spec:
     try:
     - delete:
         ref:
-          apiVersion: kyverno.io/v2beta1
+          apiVersion: kyverno.io/v1
           kind: Policy
           name: pol-clone-sync-delete-policy
           namespace: default

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-policy/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-policy/manifests.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-delete-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-rule/chainsaw-step-03-apply-1-1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-rule/chainsaw-step-03-apply-1-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-delete-rule

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-rule/manifests.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-rule/manifests.yaml
@@ -24,7 +24,7 @@ spec:
     min:
       cpu: 100m
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-delete-rule

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-source/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-source/policy.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: pol-clone-sync-delete-source
 type: Opaque
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-delete-source

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-trigger/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-delete-trigger/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-delete-trigger-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-invalid/policy1.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-invalid/policy1.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-invalid

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-invalid/policy2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-invalid/policy2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-invalid

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-modify-downstream/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-modify-downstream/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-modify-downstream-policy

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-modify-source/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-sync-clone

--- a/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-update-trigger-no-match/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/clone/sync/pol-clone-sync-update-trigger-no-match/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-clone-sync-update-trigger-no-match-policy

--- a/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-create-policy-invalid/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/nosync/pol-data-nosync-create-policy-invalid/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-data-nosync-create-policy-invalid-policy

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-create-policy-invalid/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-create-policy-invalid/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-data-sync

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-create-policy-valid/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-create-policy-valid/policy.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: poltest
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: pol-data-sync

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/policy-2.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/policy-2.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: zk-kafka-address

--- a/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/policy.yaml
+++ b/test/conformance/chainsaw/generate/policy/standard/data/sync/pol-data-sync-modify-rule/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: zk-kafka-address

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/target-namespace-scope/policy-pass-3.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/target-namespace-scope/policy-pass-3.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: expiration-for-policyexceptions

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/warn-clone-change/policy.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/warn-clone-change/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: generate-update-clone

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/warn-clone-change/update-name.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/warn-clone-change/update-name.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: generate-update-clone

--- a/test/conformance/chainsaw/generate/validation/clusterpolicy/warn-clone-change/update-namespace.yaml
+++ b/test/conformance/chainsaw/generate/validation/clusterpolicy/warn-clone-change/update-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: generate-update-clone

--- a/test/conformance/chainsaw/generate/validation/policy/warn-clone-change/policy.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/warn-clone-change/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: generate-update-clone

--- a/test/conformance/chainsaw/generate/validation/policy/warn-clone-change/update-name.yaml
+++ b/test/conformance/chainsaw/generate/validation/policy/warn-clone-change/update-name.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: Policy
 metadata:
   name: generate-update-clone

--- a/test/conformance/chainsaw/policy-validation/cluster-policy/admission-disabled/policy-generate.yaml
+++ b/test/conformance/chainsaw/policy-validation/cluster-policy/admission-disabled/policy-generate.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: generate

--- a/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/policy-assert.yaml
+++ b/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/policy-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v2
 kind: ClusterCleanupPolicy
 metadata:
   name: test-secret-removal

--- a/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/policy.yaml
+++ b/test/conformance/chainsaw/rbac/cleanup-policy-with-clusterrole/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v2
 kind: ClusterCleanupPolicy
 metadata:
   name: test-secret-removal

--- a/test/conformance/chainsaw/reports/background/exception/policy.yaml
+++ b/test/conformance/chainsaw/reports/background/exception/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: require-labels

--- a/test/conformance/chainsaw/reports/background/generate/policy.yaml
+++ b/test/conformance/chainsaw/reports/background/generate/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: cpol-nosync-clone

--- a/test/conformance/chainsaw/validate/anchors/conditional/policy.yaml
+++ b/test/conformance/chainsaw/validate/anchors/conditional/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: restrict-scale

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/apicalls/subjectaccessreview/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/apicalls/subjectaccessreview/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: check-subjectaccessreview

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce/csr/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce/csr/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: validate-csr
@@ -25,7 +25,7 @@ spec:
               operator: NotEquals
               value: "angela"
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: mutate-csr

--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce/operator-anyin-boolean/policy.yaml
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce/operator-anyin-boolean/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: operator-anyin-boolean-cpol

--- a/test/conformance/chainsaw/verify-images/clusterpolicy/standard/notary-image-verification-secret-from-policy/policy.yaml
+++ b/test/conformance/chainsaw/verify-images/clusterpolicy/standard/notary-image-verification-secret-from-policy/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: secret-in-policy

--- a/test/conformance/chainsaw/verify-images/clusterpolicy/standard/notary-image-verification/policy.yaml
+++ b/test/conformance/chainsaw/verify-images/clusterpolicy/standard/notary-image-verification/policy.yaml
@@ -31,7 +31,7 @@ data:
     uOKpF5rWAruB5PCIrquamOejpXV9aQA/K2JQDuc0mcKz
     -----END CERTIFICATE-----
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: check-image-notary

--- a/test/conformance/chainsaw/verify-images/clusterpolicy/standard/skip-image-reference/policy.yaml
+++ b/test/conformance/chainsaw/verify-images/clusterpolicy/standard/skip-image-reference/policy.yaml
@@ -31,7 +31,7 @@ data:
     uOKpF5rWAruB5PCIrquamOejpXV9aQA/K2JQDuc0mcKz
     -----END CERTIFICATE-----
 ---
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: verify-exclude-refs

--- a/test/conformance/chainsaw/webhook-configurations/match-conditions-fail/policy.yaml
+++ b/test/conformance/chainsaw/webhook-configurations/match-conditions-fail/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: refresh-env-var-in-pods


### PR DESCRIPTION
## Summary

Completes two remaining Phase 1 items from #17214:

1. **`+kubebuilder:deprecatedversion:warning` markers on deprecated versions**
2. **Migrate in-repo test fixtures off `v2beta1`/legacy types (keep a handful as warning-assertion tests)**

## Changes

### Deprecation markers

Previously only 5 version/kind combos carried a *bare* `+kubebuilder:deprecatedversion` marker (default apiserver warning, no migration hint), and `kyverno.io/v2beta1` `ClusterPolicy`/`Policy` had **no marker at all** (see https://github.com/kyverno/kyverno/issues/17214#issuecomment-5489874103).

This PR:
- Adds `+kubebuilder:deprecatedversion:warning="..."` to `v2beta1` `ClusterPolicy` and `Policy` (previously missing).
- Upgrades the existing bare markers with explicit warning messages: `v2beta1` `CleanupPolicy`/`ClusterCleanupPolicy`/`PolicyException`, `v2alpha1` `GlobalContextEntry`, `v1beta1` `UpdateRequest`.
- Adds markers to the latest served versions of the deprecated kinds as well (`v1` `ClusterPolicy`/`Policy`, `v2` `CleanupPolicy`/`ClusterCleanupPolicy`/`PolicyException`) — the apiserver warns on every version of a deprecated kind, while `GlobalContextEntry`/`UpdateRequest` keep their latest versions non-deprecated since those kinds are retained.
- Messages match the centralized `pkg/deprecations` messages from #17362 (CEL replacement + migration guide link for deprecated kinds; latest `kyverno.io` version for `GlobalContextEntry`/`UpdateRequest`).
- Regenerates CRDs (`config/crds`), helm chart CRDs, CLI data CRDs, and `config/install-latest-testing.yaml` — every deprecated version now serves `deprecated: true` + a tailored `deprecationWarning`.

### Test fixture migration

- 86 fixture files migrated off `kyverno.io/v2beta1` to the latest served versions — pure `apiVersion` swaps, no other changes:
  - `ClusterPolicy`/`Policy` → `kyverno.io/v1`
  - `CleanupPolicy`/`ClusterCleanupPolicy`/`PolicyException` → `kyverno.io/v2`
- Kept on `v2beta1` as warning-assertion / deliberate-deprecation tests:
  - `test/cli/test-exceptions/exceptions-deprecated`
  - `test/conformance/chainsaw/**/\*-deprecated/` dirs (`apicalls-deprecated`, `enforce-deprecated`, `conditional-deprecated`, `pol-data-sync-modify-rule-deprecated`)
  - Go unit tests exercising v2beta1 deserialization are untouched.

## Proof

Regenerated CRD now carries the warning:

```yaml
# config/crds/kyverno/kyverno.io_clusterpolicies.yaml
  - deprecated: true
    deprecationWarning: kyverno.io/v2beta1 ClusterPolicy is deprecated and will be
      removed in a future release; migrate to ValidatingPolicy, MutatingPolicy, GeneratingPolicy
      or ImageValidatingPolicy (policies.kyverno.io), see https://kyverno.io/docs/guides/migration-to-cel/
    name: v2beta1
```

## Validation

- `make codegen-api-all codegen-client-all codegen-crds-all codegen-cli-crds codegen-cli-docs codegen-helm-all codegen-manifest-all codegen-fix-all` — clean (`codegen-cli-api-group-resources` requires a running Docker daemon and is unaffected by this change)
- `make imports-check fmt-check` — pass
- `golangci-lint run ./api/kyverno/...` — 0 issues
- `go build ./api/... && go test ./api/kyverno/...` — pass
- `kubectl-kyverno test test/cli/test-cleanup-policy test/cli/test-exceptions` — 12/12 pass, and the kept `exceptions-deprecated` fixture still emits its deprecation warning
- No `kyverno.io/v2beta1` references remain in `test/` outside the deliberately kept `*deprecated*` fixtures

## Related issue

Part of #17214 (Phase 1). Note: submitted at the maintainer's request despite the discussion banner.