### PR TITLE
[release-1.19] fix: deny globalContext in namespaced policies (#17377)

### DIFF
--- a/pkg/background/mpol/env.go
+++ b/pkg/background/mpol/env.go
@@ -46,7 +46,7 @@ func BuildMpolTargetEvalEnv(libsctx libs.Context, namespace string) (*cel.Env, e
 	libEnvOpts := []cel.EnvOption{
 		cel.Variable(compiler.ExceptionsKey, types.NewObjectType("libs.Exception")),
 		globalcontext.Lib(
-			globalcontext.Context{ContextInterface: libsctx},
+			globalcontext.Context{ContextInterface: compiler.ConfineGlobalContext(libsctx, namespace)},
 			compiler.KyvernoVersion,
 		),
 		image.Lib(

--- a/pkg/cel/compiler/http.go
+++ b/pkg/cel/compiler/http.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/cel-go/cel"
 	celast "github.com/google/cel-go/common/ast"
 	"github.com/kyverno/kyverno/pkg/toggle"
+	"github.com/kyverno/sdk/extensions/cel/libs/globalcontext"
 	"github.com/kyverno/sdk/extensions/cel/libs/http"
 )
 
@@ -68,6 +69,19 @@ func NewLazyCELHTTPContext(namespace string) http.ContextInterface {
 	return &namespacedHTTPContext{inner: sharedHTTPContext}
 }
 
+func ConfineGlobalContext(inner globalcontext.ContextInterface, namespace string) globalcontext.ContextInterface {
+	if namespace == "" {
+		return inner
+	}
+	return namespacedGlobalContext{}
+}
+
+type namespacedGlobalContext struct{}
+
+func (namespacedGlobalContext) GetGlobalReference(_, _ string) (any, error) {
+	return nil, fmt.Errorf("globalContext.* is not allowed in namespaced policies")
+}
+
 // namespacedHTTPContext enforces the AllowHTTPInNamespacedPolicies toggle at call time.
 type namespacedHTTPContext struct {
 	inner http.ContextInterface
@@ -123,6 +137,14 @@ func getParseEnv() *cel.Env {
 // ExpressionsUseHTTP reports whether any expression references the "http" identifier.
 // Expressions are parsed but not type-checked; malformed expressions are skipped.
 func ExpressionsUseHTTP(expressions ...string) bool {
+	return expressionsUseIdent("http", expressions...)
+}
+
+func ExpressionsUseGlobalContext(expressions ...string) bool {
+	return expressionsUseIdent(GlobalContextKey, expressions...)
+}
+
+func expressionsUseIdent(ident string, expressions ...string) bool {
 	env := getParseEnv()
 	if env == nil {
 		return false
@@ -137,7 +159,7 @@ func ExpressionsUseHTTP(expressions ...string) bool {
 		}
 		nav := celast.NavigateAST(ast.NativeRep())
 		matches := celast.MatchDescendants(nav, func(e celast.NavigableExpr) bool {
-			return e.Kind() == celast.IdentKind && e.AsIdent() == "http"
+			return e.Kind() == celast.IdentKind && e.AsIdent() == ident
 		})
 		if len(matches) > 0 {
 			return true

--- a/pkg/cel/compiler/http_test.go
+++ b/pkg/cel/compiler/http_test.go
@@ -217,6 +217,26 @@ func TestExpressionsUseHTTP(t *testing.T) {
 	}
 }
 
+func TestExpressionsUseGlobalContext(t *testing.T) {
+	assert.True(t, ExpressionsUseGlobalContext(`globalContext.get("entry", "")`))
+	assert.False(t, ExpressionsUseGlobalContext("object.metadata.name == 'foo'"))
+}
+
+func TestConfineGlobalContext(t *testing.T) {
+	_, err := ConfineGlobalContext(allowGlobalContext{}, "tenant-ns").GetGlobalReference("entry", "")
+	assert.ErrorContains(t, err, "not allowed in namespaced policies")
+
+	got, err := ConfineGlobalContext(allowGlobalContext{}, "").GetGlobalReference("entry", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "ok", got)
+}
+
+type allowGlobalContext struct{}
+
+func (allowGlobalContext) GetGlobalReference(_, _ string) (any, error) {
+	return "ok", nil
+}
+
 func TestAllowHTTPInNamespacedPoliciesToggledViaParse(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/cel/policies/dpol/compiler/compiler.go
+++ b/pkg/cel/policies/dpol/compiler/compiler.go
@@ -122,7 +122,7 @@ func (c *compilerImpl) createBaseDpolEnv(libsctx libs.Context, namespace string)
 
 	libEnvOpts := []cel.EnvOption{
 		globalcontext.Lib(
-			globalcontext.Context{ContextInterface: libsctx},
+			globalcontext.Context{ContextInterface: compiler.ConfineGlobalContext(libsctx, namespace)},
 			compiler.KyvernoVersion,
 		),
 		image.Lib(

--- a/pkg/cel/policies/dpol/validate.go
+++ b/pkg/cel/policies/dpol/validate.go
@@ -40,8 +40,12 @@ func Validate(dpol v1beta1.DeletingPolicyLike) ([]string, error) {
 		err = append(err, field.Invalid(field.NewPath("spec").Child("schedule"), spec.Schedule, "schedule spec in the deletingPolicy is not in proper cron format: "+parseErr.Error()))
 	}
 
-	if dpol.GetNamespace() != "" && !toggle.AllowHTTPInNamespacedPolicies.Enabled() {
-		if compiler.ExpressionsUseHTTP(dpolExpressions(spec)...) {
+	if dpol.GetNamespace() != "" {
+		exprs := dpolExpressions(spec)
+		if compiler.ExpressionsUseGlobalContext(exprs...) {
+			err = append(err, field.Forbidden(field.NewPath("spec"), "globalContext.* is not allowed in namespaced policies"))
+		}
+		if !toggle.AllowHTTPInNamespacedPolicies.Enabled() && compiler.ExpressionsUseHTTP(exprs...) {
 			err = append(err, field.Forbidden(field.NewPath("spec"), "http.* is not allowed in namespaced policies; set --allowHTTPInNamespacedPolicies to enable"))
 		}
 	}

--- a/pkg/cel/policies/dpol/validate_test.go
+++ b/pkg/cel/policies/dpol/validate_test.go
@@ -208,6 +208,35 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "namespaced policy using globalContext is rejected",
+			dpol: &v1beta1.DeletingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ns-globalcontext-dpol",
+					Namespace: "tenant-ns",
+				},
+				Spec: v1beta1.DeletingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ResourceRules: []v1.NamedRuleWithOperations{
+							{
+								RuleWithOperations: v1.RuleWithOperations{
+									Rule: v1.Rule{
+										APIGroups: []string{""},
+										Resources: []string{"pods"},
+									},
+								},
+							},
+						},
+					},
+					Schedule: "*/5 * * * *",
+					Variables: []v1.Variable{{
+						Name:       "gctx",
+						Expression: `globalContext.get("cluster-entry", "")`,
+					}},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cel/policies/gpol/compiler/compiler.go
+++ b/pkg/cel/policies/gpol/compiler/compiler.go
@@ -91,7 +91,7 @@ func (c *compilerImpl) createBaseGpolEnv(libsctx libs.Context, namespace string)
 					generator.Latest(),
 				),
 				globalcontext.Lib(
-					globalcontext.Context{ContextInterface: libsctx},
+					globalcontext.Context{ContextInterface: compiler.ConfineGlobalContext(libsctx, namespace)},
 					globalcontext.Latest(),
 				),
 				resource.Lib(

--- a/pkg/cel/policies/gpol/validate.go
+++ b/pkg/cel/policies/gpol/validate.go
@@ -32,8 +32,12 @@ func Validate(gpol v1beta1.GeneratingPolicyLike) ([]string, error) {
 		err = append(err, field.Required(field.NewPath("spec").Child("matchConstraints"), "a matchConstraints with at least one resource rule is required"))
 	}
 
-	if gpol.GetNamespace() != "" && !toggle.AllowHTTPInNamespacedPolicies.Enabled() {
-		if compiler.ExpressionsUseHTTP(gpolExpressions(spec)...) {
+	if gpol.GetNamespace() != "" {
+		exprs := gpolExpressions(spec)
+		if compiler.ExpressionsUseGlobalContext(exprs...) {
+			err = append(err, field.Forbidden(field.NewPath("spec"), "globalContext.* is not allowed in namespaced policies"))
+		}
+		if !toggle.AllowHTTPInNamespacedPolicies.Enabled() && compiler.ExpressionsUseHTTP(exprs...) {
 			err = append(err, field.Forbidden(field.NewPath("spec"), "http.* is not allowed in namespaced policies; set --allowHTTPInNamespacedPolicies to enable"))
 		}
 	}

--- a/pkg/cel/policies/gpol/validate_test.go
+++ b/pkg/cel/policies/gpol/validate_test.go
@@ -143,6 +143,34 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "namespaced policy using globalContext is rejected",
+			pol: &v1beta1.GeneratingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ns-globalcontext-gpol",
+					Namespace: "tenant-ns",
+				},
+				Spec: v1beta1.GeneratingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ResourceRules: []v1.NamedRuleWithOperations{
+							{
+								RuleWithOperations: v1.RuleWithOperations{
+									Rule: v1.Rule{
+										APIGroups: []string{""},
+										Resources: []string{"pods"},
+									},
+								},
+							},
+						},
+					},
+					Variables: []v1.Variable{{
+						Name:       "gctx",
+						Expression: `globalContext.get("cluster-entry", "")`,
+					}},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cel/policies/mpol/compiler/compiler.go
+++ b/pkg/cel/policies/mpol/compiler/compiler.go
@@ -201,7 +201,7 @@ func (c *compilerImpl) newExtendedEnv(libCtx libs.Context, namespace string) (*c
 		cel.Variable(compiler.ExceptionsKey, types.NewObjectType("libs.Exception")),
 		environment.UnversionedLib(library.JSONPatch), // the kubernetes jsonpatch library to enable escapeKey
 		globalcontext.Lib(
-			globalcontext.Context{ContextInterface: libCtx},
+			globalcontext.Context{ContextInterface: compiler.ConfineGlobalContext(libCtx, namespace)},
 			globalcontext.Latest(),
 		),
 		resource.Lib(

--- a/pkg/cel/policies/mpol/validate.go
+++ b/pkg/cel/policies/mpol/validate.go
@@ -37,8 +37,12 @@ func Validate(mpol v1beta1.MutatingPolicyLike) ([]string, error) {
 		err = append(err, field.Forbidden(field.NewPath("spec").Child("evaluation"), "disabling both admission and mutateExisting evaluation modes is not allowed"))
 	}
 
-	if mpol.GetNamespace() != "" && !toggle.AllowHTTPInNamespacedPolicies.Enabled() {
-		if compiler.ExpressionsUseHTTP(mpolExpressions(spec)...) {
+	if mpol.GetNamespace() != "" {
+		exprs := mpolExpressions(spec)
+		if compiler.ExpressionsUseGlobalContext(exprs...) {
+			err = append(err, field.Forbidden(field.NewPath("spec"), "globalContext.* is not allowed in namespaced policies"))
+		}
+		if !toggle.AllowHTTPInNamespacedPolicies.Enabled() && compiler.ExpressionsUseHTTP(exprs...) {
 			err = append(err, field.Forbidden(field.NewPath("spec"), "http.* is not allowed in namespaced policies; set --allowHTTPInNamespacedPolicies to enable"))
 		}
 	}
@@ -81,6 +85,14 @@ func mpolExpressions(spec *v1beta1.MutatingPolicySpec) []string {
 	}
 	for _, a := range spec.AuditAnnotations {
 		exprs = append(exprs, a.ValueExpression)
+	}
+	// target selection expressions are compiled and evaluated by the mpol
+	// compiler as well, so they must be scanned for forbidden libraries too
+	if spec.TargetMatchConstraints != nil && spec.TargetMatchConstraints.Expression != "" {
+		exprs = append(exprs, spec.TargetMatchConstraints.Expression)
+	}
+	for _, mc := range spec.TargetMatchConditions {
+		exprs = append(exprs, mc.Expression)
 	}
 	return exprs
 }

--- a/pkg/cel/policies/mpol/validate_test.go
+++ b/pkg/cel/policies/mpol/validate_test.go
@@ -234,6 +234,34 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "namespaced policy using globalContext is rejected",
+			pol: &v1beta1.MutatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ns-globalcontext-mpol",
+					Namespace: "tenant-ns",
+				},
+				Spec: v1beta1.MutatingPolicySpec{
+					MatchConstraints: &v1.MatchResources{
+						ResourceRules: []v1.NamedRuleWithOperations{
+							{
+								RuleWithOperations: v1.RuleWithOperations{
+									Rule: v1.Rule{
+										APIGroups: []string{""},
+										Resources: []string{"pods"},
+									},
+								},
+							},
+						},
+					},
+					Variables: []v1.Variable{{
+						Name:       "gctx",
+						Expression: `globalContext.get("cluster-entry", "")`,
+					}},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -249,4 +277,62 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_Validate_NamespacedPolicyRejectsGlobalContextInTargetSelection(t *testing.T) {
+	basePolicy := func() *v1beta1.MutatingPolicy {
+		return &v1beta1.MutatingPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ns-globalcontext-targets-mpol",
+				Namespace: "tenant-ns",
+			},
+			Spec: v1beta1.MutatingPolicySpec{
+				MatchConstraints: &v1.MatchResources{
+					ResourceRules: []v1.NamedRuleWithOperations{{
+						RuleWithOperations: v1.RuleWithOperations{
+							Rule: v1.Rule{
+								APIGroups: []string{""},
+								Resources: []string{"pods"},
+							},
+						},
+					}},
+				},
+				EvaluationConfiguration: &v1beta1.MutatingPolicyEvaluationConfiguration{
+					MutateExistingConfiguration: &v1beta1.MutateExistingConfiguration{
+						Enabled: ptr.To(true),
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("globalContext in targetMatchConstraints expression is rejected", func(t *testing.T) {
+		pol := basePolicy()
+		pol.Spec.TargetMatchConstraints = &v1beta1.TargetMatchConstraints{
+			Expression: `globalContext.get("cluster-entry", "")`,
+		}
+		_, err := Validate(pol)
+		assert.ErrorContains(t, err, "globalContext.* is not allowed in namespaced policies")
+	})
+
+	t.Run("globalContext in targetMatchConditions is rejected", func(t *testing.T) {
+		pol := basePolicy()
+		pol.Spec.TargetMatchConditions = []v1.MatchCondition{{
+			Name:       "uses-gctx",
+			Expression: `globalContext.get("cluster-entry", "") != ""`,
+		}}
+		_, err := Validate(pol)
+		assert.ErrorContains(t, err, "globalContext.* is not allowed in namespaced policies")
+	})
+
+	t.Run("cluster-scoped policy may use globalContext in target selection", func(t *testing.T) {
+		pol := basePolicy()
+		pol.Namespace = ""
+		pol.Spec.TargetMatchConditions = []v1.MatchCondition{{
+			Name:       "uses-gctx",
+			Expression: `globalContext.get("cluster-entry", "") != ""`,
+		}}
+		_, err := Validate(pol)
+		assert.NoError(t, err)
+	})
 }

--- a/pkg/cel/policies/vpol/compiler/compiler.go
+++ b/pkg/cel/policies/vpol/compiler/compiler.go
@@ -241,7 +241,7 @@ func (c *compilerImpl) createBaseVpolEnv(libsctx libs.Context, namespace string)
 		ext.NativeTypes(reflect.TypeFor[libs.Exception](), ext.ParseStructTags(true)),
 		cel.Variable(compiler.ExceptionsKey, types.NewObjectType("libs.Exception")),
 		globalcontext.Lib(
-			globalcontext.Context{ContextInterface: libsctx},
+			globalcontext.Context{ContextInterface: compiler.ConfineGlobalContext(libsctx, namespace)},
 			globalcontext.Latest(),
 		),
 		resource.Lib(

--- a/pkg/cel/policies/vpol/validate.go
+++ b/pkg/cel/policies/vpol/validate.go
@@ -33,8 +33,12 @@ func Validate(vpol v1beta1.ValidatingPolicyLike) ([]string, error) {
 		err = append(err, field.Required(field.NewPath("spec").Child("matchConstraints"), "a matchConstraints with at least one resource rule is required"))
 	}
 
-	if vpol.GetNamespace() != "" && !toggle.AllowHTTPInNamespacedPolicies.Enabled() {
-		if compiler.ExpressionsUseHTTP(vpolExpressions(spec)...) {
+	if vpol.GetNamespace() != "" {
+		exprs := vpolExpressions(spec)
+		if compiler.ExpressionsUseGlobalContext(exprs...) {
+			err = append(err, field.Forbidden(field.NewPath("spec"), "globalContext.* is not allowed in namespaced policies"))
+		}
+		if !toggle.AllowHTTPInNamespacedPolicies.Enabled() && compiler.ExpressionsUseHTTP(exprs...) {
 			err = append(err, field.Forbidden(field.NewPath("spec"), "http.* is not allowed in namespaced policies; set --allowHTTPInNamespacedPolicies to enable"))
 		}
 	}

--- a/pkg/cel/policies/vpol/validate_test.go
+++ b/pkg/cel/policies/vpol/validate_test.go
@@ -1,0 +1,31 @@
+package vpol
+
+import (
+	"testing"
+
+	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/stretchr/testify/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_Validate_NamespacedPolicyRejectsGlobalContext(t *testing.T) {
+	vpol := &v1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "gctx", Namespace: "tenant-ns"},
+		Spec: v1beta1.ValidatingPolicySpec{
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+					RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+						Rule: admissionregistrationv1.Rule{APIGroups: []string{""}, Resources: []string{"pods"}},
+					},
+				}},
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{Expression: `globalContext.get("cluster-entry", "") == null`},
+			},
+		},
+	}
+
+	_, err := Validate(vpol)
+	assert.ErrorContains(t, err, "globalContext.* is not allowed in namespaced policies")
+}

--- a/pkg/engine/context/loaders/configmap_test.go
+++ b/pkg/engine/context/loaders/configmap_test.go
@@ -141,3 +141,12 @@ func Test_ConfigMapAccess_WithNonStringNameSubstitution(t *testing.T) {
 	assert.ErrorContains(t, err, "expected string")
 	assert.Equal(t, resolver.called, false)
 }
+
+func Test_NamespacedPolicyCannotLoadGlobalReference(t *testing.T) {
+	entry := kyvernov1.ContextEntry{
+		Name:            "gctx",
+		GlobalReference: &kyvernov1.GlobalContextEntryReference{Name: "entry"},
+	}
+	err := NewGCTXLoader(context.TODO(), logr.Discard(), entry, enginecontext.NewContext(jp), jp, nil, "tenant-ns").LoadData()
+	assert.ErrorContains(t, err, "globalReference is not allowed in namespaced policies")
+}

--- a/pkg/engine/context/loaders/globalcontext.go
+++ b/pkg/engine/context/loaders/globalcontext.go
@@ -19,13 +19,14 @@ type Store interface {
 }
 
 type gctxLoader struct {
-	ctx       context.Context //nolint:containedctx
-	logger    logr.Logger
-	entry     kyvernov1.ContextEntry
-	enginectx enginecontext.Interface
-	jp        jmespath.Interface
-	gctxStore Store
-	data      []byte
+	ctx             context.Context //nolint:containedctx
+	logger          logr.Logger
+	entry           kyvernov1.ContextEntry
+	enginectx       enginecontext.Interface
+	jp              jmespath.Interface
+	gctxStore       Store
+	policyNamespace string
+	data            []byte
 }
 
 func NewGCTXLoader(
@@ -35,14 +36,16 @@ func NewGCTXLoader(
 	enginectx enginecontext.Interface,
 	jp jmespath.Interface,
 	gctxStore Store,
+	policyNamespace string,
 ) enginecontext.Loader {
 	return &gctxLoader{
-		ctx:       ctx,
-		logger:    logger,
-		entry:     entry,
-		enginectx: enginectx,
-		jp:        jp,
-		gctxStore: gctxStore,
+		ctx:             ctx,
+		logger:          logger,
+		entry:           entry,
+		enginectx:       enginectx,
+		jp:              jp,
+		gctxStore:       gctxStore,
+		policyNamespace: policyNamespace,
 	}
 }
 
@@ -51,6 +54,9 @@ func (g *gctxLoader) HasLoaded() bool {
 }
 
 func (g *gctxLoader) LoadData() error {
+	if g.policyNamespace != "" {
+		return fmt.Errorf("context entry %s: globalReference is not allowed in namespaced policies", g.entry.Name)
+	}
 	contextData, err := g.loadGctxData()
 	if err != nil {
 		g.logger.Error(err, "failed to marshal APICall data for context entry")

--- a/pkg/engine/factories/contextloaderfactory.go
+++ b/pkg/engine/factories/contextloaderfactory.go
@@ -166,7 +166,7 @@ func (l *contextLoader) newLoader(
 		}
 	} else if entry.GlobalReference != nil {
 		if gctx != nil {
-			ldr := loaders.NewGCTXLoader(ctx, l.logger, entry, jsonContext, jp, gctx)
+			ldr := loaders.NewGCTXLoader(ctx, l.logger, entry, jsonContext, jp, gctx, l.policyNamespace)
 			return enginecontext.NewDeferredLoader(entry.Name, ldr, l.logger)
 		} else {
 			l.logger.V(3).Info("disabled loading of GlobalContext context entry", "name", entry.Name)

--- a/pkg/image/verification/evaluator/compiler.go
+++ b/pkg/image/verification/evaluator/compiler.go
@@ -178,6 +178,7 @@ func (c *compilerImpl) Compile(ivpolicy policiesv1beta1.ImageValidatingPolicyLik
 	}
 
 	return &compiledPolicy{
+		namespace:            ivpolicy.GetNamespace(),
 		failurePolicy:        ivpolicy.GetFailurePolicy(toggle.FromContext(context.TODO()).ForceFailurePolicyIgnore()),
 		verifyDigest:         spec.ValidationConfigurations.VerifyDigest == nil || *spec.ValidationConfigurations.VerifyDigest,
 		matchConditions:      matchConditions,
@@ -233,7 +234,7 @@ func (c *compilerImpl) createBaseIvpolEnv(libsctx libs.Context, ivpol policiesv1
 	namespace := ivpol.GetNamespace()
 	libEnvOpts := []cel.EnvOption{
 		globalcontext.Lib(
-			globalcontext.Context{ContextInterface: libsctx},
+			globalcontext.Context{ContextInterface: engine.ConfineGlobalContext(libsctx, namespace)},
 			globalcontext.Latest(),
 		),
 		image.Lib(

--- a/pkg/image/verification/evaluator/policy.go
+++ b/pkg/image/verification/evaluator/policy.go
@@ -55,6 +55,7 @@ type CompiledPolicy interface {
 }
 
 type compiledPolicy struct {
+	namespace            string
 	failurePolicy        admissionregistrationv1.FailurePolicyType
 	verifyDigest         bool
 	matchConditions      []cel.Program
@@ -145,7 +146,9 @@ func (c *compiledPolicy) Evaluate(ctx context.Context, ictx imagedataloader.Imag
 		data[engine.ObjectKey] = objectVal
 		data[engine.OldObjectKey] = oldObjectVal
 		data[engine.VariablesKey] = vars
-		data[engine.GlobalContextKey] = globalcontext.Context{ContextInterface: context}
+		// The activation overrides the Lib's cel.Globals binding, so confine here too
+		// or a namespaced policy would reach the raw context at evaluation time.
+		data[engine.GlobalContextKey] = globalcontext.Context{ContextInterface: engine.ConfineGlobalContext(context, c.namespace)}
 		data[engine.ImageDataKey] = imagedata.Context{ContextInterface: context} // the thing that actually does the fetching and validation of images
 		data[engine.ResourceKey] = resource.Context{ContextInterface: context}
 	} else {

--- a/pkg/image/verification/evaluator/validate.go
+++ b/pkg/image/verification/evaluator/validate.go
@@ -41,8 +41,12 @@ func Validate(ivpol policiesv1beta1.ImageValidatingPolicyLike, lister corev1list
 		errs = errList
 	}
 
-	if ivpol.GetNamespace() != "" && !toggle.AllowHTTPInNamespacedPolicies.Enabled() {
-		if engine.ExpressionsUseHTTP(ivpolExpressions(ivpol)...) {
+	if ivpol.GetNamespace() != "" {
+		exprs := ivpolExpressions(ivpol)
+		if engine.ExpressionsUseGlobalContext(exprs...) {
+			errs = append(errs, field.Forbidden(field.NewPath("spec"), "globalContext.* is not allowed in namespaced policies"))
+		}
+		if !toggle.AllowHTTPInNamespacedPolicies.Enabled() && engine.ExpressionsUseHTTP(exprs...) {
 			errs = append(errs, field.Forbidden(field.NewPath("spec"), "http.* is not allowed in namespaced policies; set --allowHTTPInNamespacedPolicies to enable"))
 		}
 	}
@@ -83,6 +87,41 @@ func ivpolExpressions(ivpol policiesv1beta1.ImageValidatingPolicyLike) []string 
 	for _, mir := range spec.MatchImageReferences {
 		if mir.Expression != "" {
 			exprs = append(exprs, mir.Expression)
+		}
+	}
+	// attestor CEL inputs are compiled and evaluated at verification time
+	// (see pkg/image/verification/variables/attestors.go), so they must be
+	// scanned for forbidden libraries too
+	for _, att := range spec.Attestors {
+		exprs = append(exprs, attestorExpressions(att)...)
+	}
+	return exprs
+}
+
+func attestorExpressions(att policiesv1beta1.Attestor) []string {
+	exprs := make([]string, 0, 6)
+	if att.Cosign != nil {
+		if att.Cosign.Key != nil && att.Cosign.Key.Expression != "" {
+			exprs = append(exprs, att.Cosign.Key.Expression)
+		}
+		if att.Cosign.Certificate != nil {
+			if att.Cosign.Certificate.Certificate != nil && att.Cosign.Certificate.Certificate.Expression != "" {
+				exprs = append(exprs, att.Cosign.Certificate.Certificate.Expression)
+			}
+			if att.Cosign.Certificate.CertificateChain != nil && att.Cosign.Certificate.CertificateChain.Expression != "" {
+				exprs = append(exprs, att.Cosign.Certificate.CertificateChain.Expression)
+			}
+		}
+		if att.Cosign.TrustedRoot != nil && att.Cosign.TrustedRoot.Expression != "" {
+			exprs = append(exprs, att.Cosign.TrustedRoot.Expression)
+		}
+	}
+	if att.Notary != nil {
+		if att.Notary.Certs != nil && att.Notary.Certs.Expression != "" {
+			exprs = append(exprs, att.Notary.Certs.Expression)
+		}
+		if att.Notary.TSACerts != nil && att.Notary.TSACerts.Expression != "" {
+			exprs = append(exprs, att.Notary.TSACerts.Expression)
 		}
 	}
 	return exprs

--- a/pkg/image/verification/evaluator/validate_test.go
+++ b/pkg/image/verification/evaluator/validate_test.go
@@ -1,0 +1,146 @@
+package evaluator
+
+import (
+	"context"
+	"testing"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/pkg/cel/libs"
+	imageverifycache "github.com/kyverno/kyverno/pkg/image/verification/cache"
+	"github.com/kyverno/sdk/extensions/imagedataloader"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+func gctxPolicy(namespace string) *policiesv1beta1.ImageValidatingPolicy {
+	return &policiesv1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "gctx", Namespace: namespace},
+		Spec: policiesv1beta1.ImageValidatingPolicySpec{
+			Validations: []admissionregistrationv1.Validation{
+				{Expression: `globalContext.get("cluster-entry", "") == null`},
+			},
+		},
+	}
+}
+
+func Test_Validate_NamespacedPolicyRejectsGlobalContext(t *testing.T) {
+	_, err := Validate(gctxPolicy("tenant-ns"), nil)
+	assert.ErrorContains(t, err, "globalContext.* is not allowed in namespaced policies")
+}
+
+func Test_Evaluate_NamespacedPolicyGlobalContextDeniedAtRuntime(t *testing.T) {
+	libctx := libs.NewFakeContextProvider()
+	libctx.AddGlobalReference("cluster-entry", map[string]any{"leaked": "data"})
+	ictx, err := imagedataloader.NewImageContext(nil, nil, nil)
+	require.NoError(t, err)
+	attr := admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{}, "tenant-ns", "p", schema.GroupVersionResource{}, "", admission.Create, nil, false, nil)
+
+	tests := []struct {
+		name      string
+		namespace string
+		wantErr   string
+	}{
+		{
+			name:      "namespaced policy is denied",
+			namespace: "tenant-ns",
+			wantErr:   "not allowed in namespaced policies",
+		},
+		{
+			name:      "cluster-scoped policy reads the entry",
+			namespace: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compiled, errs := NewCompiler(ictx, nil, nil, imageverifycache.DisabledImageVerifyCache()).Compile(gctxPolicy(tt.namespace), nil, nil)
+			require.Empty(t, errs)
+
+			result, err := compiled.Evaluate(context.Background(), ictx, attr, &admissionv1.AdmissionRequest{}, nil, true, libctx)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.False(t, result.Result)
+		})
+	}
+}
+
+func Test_Validate_NamespacedPolicyRejectsGlobalContextInAttestors(t *testing.T) {
+	basePolicy := func(attestor policiesv1beta1.Attestor) *policiesv1beta1.ImageValidatingPolicy {
+		return &policiesv1beta1.ImageValidatingPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "gctx-attestor", Namespace: "tenant-ns"},
+			Spec: policiesv1beta1.ImageValidatingPolicySpec{
+				MatchConstraints: &admissionregistrationv1.MatchResources{
+					ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+						{
+							RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+								Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+								Rule: admissionregistrationv1.Rule{
+									APIGroups:   []string{""},
+									APIVersions: []string{"v1"},
+									Resources:   []string{"pods"},
+								},
+							},
+						},
+					},
+				},
+				Attestors: []policiesv1beta1.Attestor{attestor},
+				Validations: []admissionregistrationv1.Validation{
+					{Expression: `images.containers.map(image, verifyImageSignatures(image, [attestors.att])).all(e, e > 0)`},
+				},
+			},
+		}
+	}
+	gctxExpr := &policiesv1beta1.StringOrExpression{Expression: `globalContext.get("cluster-entry", "")`}
+
+	tests := []struct {
+		name     string
+		attestor policiesv1beta1.Attestor
+	}{
+		{
+			name:     "cosign key expression",
+			attestor: policiesv1beta1.Attestor{Name: "att", Cosign: &policiesv1beta1.Cosign{Key: &policiesv1beta1.Key{Expression: `globalContext.get("cluster-entry", "")`}}},
+		},
+		{
+			name:     "cosign certificate expression",
+			attestor: policiesv1beta1.Attestor{Name: "att", Cosign: &policiesv1beta1.Cosign{Certificate: &policiesv1beta1.Certificate{Certificate: gctxExpr}}},
+		},
+		{
+			name:     "cosign certificate chain expression",
+			attestor: policiesv1beta1.Attestor{Name: "att", Cosign: &policiesv1beta1.Cosign{Certificate: &policiesv1beta1.Certificate{CertificateChain: gctxExpr}}},
+		},
+		{
+			name:     "cosign trusted root expression",
+			attestor: policiesv1beta1.Attestor{Name: "att", Cosign: &policiesv1beta1.Cosign{TrustedRoot: gctxExpr}},
+		},
+		{
+			name:     "notary certs expression",
+			attestor: policiesv1beta1.Attestor{Name: "att", Notary: &policiesv1beta1.Notary{Certs: gctxExpr}},
+		},
+		{
+			name:     "notary tsa certs expression",
+			attestor: policiesv1beta1.Attestor{Name: "att", Notary: &policiesv1beta1.Notary{TSACerts: gctxExpr}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Validate(basePolicy(tt.attestor), nil)
+			assert.ErrorContains(t, err, "globalContext.* is not allowed in namespaced policies")
+		})
+	}
+
+	t.Run("cluster-scoped policy may use globalContext in attestors", func(t *testing.T) {
+		pol := basePolicy(tests[0].attestor)
+		pol.Namespace = ""
+		_, err := Validate(pol, nil)
+		assert.NoError(t, err)
+	})
+}

--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -312,7 +312,7 @@ func Validate(policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interf
 			return warnings, err
 		}
 
-		if err := validateRuleContext(rule); err != nil {
+		if err := validateRuleContext(rule, policy.IsNamespaced()); err != nil {
 			return warnings, fmt.Errorf("path: spec.rules[%d]: %v", i, err)
 		}
 
@@ -1280,7 +1280,7 @@ func validateConditionValuesKeyRequestOperation(c kyvernov1.Condition) (string, 
 	return "", nil
 }
 
-func validateRuleContext(rule kyvernov1.Rule) error {
+func validateRuleContext(rule kyvernov1.Rule, namespaced bool) error {
 	if len(rule.Context) == 0 {
 		return nil
 	}
@@ -1305,7 +1305,11 @@ func validateRuleContext(rule kyvernov1.Rule) error {
 		} else if entry.ConfigMap == nil && entry.APICall != nil && entry.GlobalReference == nil && entry.ImageRegistry == nil && entry.Variable == nil {
 			err = validateAPICall(entry)
 		} else if entry.ConfigMap == nil && entry.APICall == nil && entry.GlobalReference != nil && entry.ImageRegistry == nil && entry.Variable == nil {
-			err = validateGlobalReference(entry)
+			if namespaced {
+				err = fmt.Errorf("globalReference is not allowed in namespaced policies")
+			} else {
+				err = validateGlobalReference(entry)
+			}
 		} else if entry.ConfigMap == nil && entry.APICall == nil && entry.GlobalReference == nil && entry.ImageRegistry != nil && entry.Variable == nil {
 			err = validateImageRegistry(entry)
 		} else if entry.ConfigMap == nil && entry.APICall == nil && entry.GlobalReference == nil && entry.ImageRegistry == nil && entry.Variable != nil {

--- a/pkg/validation/policy/validate_test.go
+++ b/pkg/validation/policy/validate_test.go
@@ -3614,6 +3614,17 @@ func Test_validateGlobalReference_WithName_Allowed(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func Test_validateRuleContext_NamespacedPolicyRejectsGlobalReference(t *testing.T) {
+	rule := kyverno.Rule{
+		Context: []kyverno.ContextEntry{{
+			Name:            "gctx",
+			GlobalReference: &kyverno.GlobalContextEntryReference{Name: "entry"},
+		}},
+	}
+	err := validateRuleContext(rule, true)
+	assert.ErrorContains(t, err, "globalReference is not allowed in namespaced policies")
+}
+
 func Test_validateGlobalReference_WithNameAndJMESPath_Allowed(t *testing.T) {
 	entry := kyverno.ContextEntry{
 		Name: "gctx",


### PR DESCRIPTION
## Explanation

Cherry-pick of #17377 (merge commit 795394e1ced43b1cee53854157d7f7a43804f083) to `release-1.19`, addressing GHSA-59v6-2x73-wfg4: namespaced policies could read any cluster-scoped `GlobalContextEntry` via `globalContext.get(...)` (CEL policies) or `globalReference` context entries (classic `Policy`), letting a namespace admin pull data cached from other namespaces or cluster-scoped resources. The fix denies these lookups in namespaced policies at both validation (admission) time and evaluation (runtime) time, following the same confinement approach used for `http.*`, ConfigMap, and `apiCall` access.

**Note**: breaking change for namespaced policies performing globalContext lookups — must be called out in the 1.19.x release notes together with the advisory.

### Conflict resolutions (vs main)

- `pkg/image/verification/evaluator/validate.go`: dropped the `matchConstraints`-required validation block, which exists only on `main`.
- `pkg/image/verification/evaluator/validate_test.go`: file is new on this branch; dropped the main-only `TestValidate_MatchConstraints` and kept all globalContext regression tests.

Verified on this branch: `go build`, `go test -race -count=1` across all touched packages (cel compiler + all policy types, image verification, validation/policy, engine loaders/factories, background/mpol) — all pass.

## Related issue

GHSA-59v6-2x73-wfg4 (backport of #17377)

## Milestone of this PR

/milestone 1.19.1

## What type of PR is this

/kind bug

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
