### PR TITLE
fix(config): reset matchConditions and updateRequestThreshold on unload, fix defaults and log messages

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -289,6 +289,8 @@ func NewDefaultConfiguration(skipResourceFilters bool) *configuration {
 		skipResourceFilters:           skipResourceFilters,
 		defaultRegistry:               "docker.io",
 		enableDefaultRegistryMutation: true,
+		updateRequestThreshold:        UpdateRequestThreshold,
+		maxContextSize:                DefaultMaxContextSize,
 	}
 }
 
@@ -569,15 +571,15 @@ func (cd *configuration) load(cm *corev1.ConfigMap) {
 	}
 	threshold, ok := data[updateRequestThreshold]
 	if !ok {
-		logger.V(2).Info("enableDefaultRegistryMutation not set")
+		logger.V(2).Info("updateRequestThreshold not set")
 	} else {
-		logger := logger.WithValues("enableDefaultRegistryMutation", enableDefaultRegistryMutation)
+		logger := logger.WithValues("updateRequestThreshold", threshold)
 		urThreshold, err := strconv.ParseInt(threshold, 10, 64)
 		if err != nil {
-			logger.Error(err, "enableDefaultRegistryMutation is not a boolean")
+			logger.Error(err, "updateRequestThreshold is not a valid integer")
 		} else {
 			cd.updateRequestThreshold = urThreshold
-			logger.V(2).Info("enableDefaultRegistryMutation configured")
+			logger.V(2).Info("updateRequestThreshold configured")
 		}
 	}
 	// load maxContextSize (supports Kubernetes quantity format: 100Mi, 2Gi, etc.)
@@ -610,6 +612,8 @@ func (cd *configuration) unload() {
 	cd.webhook = WebhookConfig{}
 	cd.webhookAnnotations = nil
 	cd.webhookLabels = nil
+	cd.matchConditions = nil
+	cd.updateRequestThreshold = UpdateRequestThreshold
 	cd.maxContextSize = DefaultMaxContextSize
 	logger.V(2).Info("configuration unloaded")
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -142,6 +142,75 @@ func TestConfiguration_GetSuccessEventActions_NotSet(t *testing.T) {
 	assert.Equal(t, 0, cfg.GetSuccessEventActions().Len())
 }
 
+func TestNewDefaultConfiguration_Defaults(t *testing.T) {
+	cfg := NewDefaultConfiguration(false)
+	assert.Equal(t, "docker.io", cfg.GetDefaultRegistry())
+	assert.True(t, cfg.GetEnableDefaultRegistryMutation())
+	assert.Equal(t, int64(UpdateRequestThreshold), cfg.GetUpdateRequestThreshold())
+	assert.Equal(t, DefaultMaxContextSize, cfg.GetMaxContextSize())
+}
+
+func TestConfiguration_UnloadResetsMatchConditions(t *testing.T) {
+	cfg := NewDefaultConfiguration(false)
+
+	cfg.Load(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "kyverno", Namespace: "kyverno"},
+		Data: map[string]string{
+			"matchConditions": `[{"name":"exclude-leases","expression":"!(request.resource.resource == 'leases')"}]`,
+		},
+	})
+	assert.NotEmpty(t, cfg.GetMatchConditions())
+
+	cfg.Load(nil)
+	assert.Empty(t, cfg.GetMatchConditions())
+}
+
+func TestConfiguration_UnloadResetsUpdateRequestThreshold(t *testing.T) {
+	cfg := NewDefaultConfiguration(false)
+
+	cfg.Load(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "kyverno", Namespace: "kyverno"},
+		Data: map[string]string{
+			"updateRequestThreshold": "500",
+		},
+	})
+	assert.Equal(t, int64(500), cfg.GetUpdateRequestThreshold())
+
+	cfg.Load(nil)
+	assert.Equal(t, int64(UpdateRequestThreshold), cfg.GetUpdateRequestThreshold())
+}
+
+func TestConfiguration_LoadUpdateRequestThreshold(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected int64
+	}{
+		{"custom value", "500", 500},
+		{"zero", "0", 0},
+		{"large value", "5000", 5000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewDefaultConfiguration(false)
+			cfg.Load(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "kyverno", Namespace: "kyverno"},
+				Data:       map[string]string{"updateRequestThreshold": tt.value},
+			})
+			assert.Equal(t, tt.expected, cfg.GetUpdateRequestThreshold())
+		})
+	}
+}
+
+func TestConfiguration_LoadUpdateRequestThreshold_Invalid(t *testing.T) {
+	cfg := NewDefaultConfiguration(false)
+	cfg.Load(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "kyverno", Namespace: "kyverno"},
+		Data:       map[string]string{"updateRequestThreshold": "not-a-number"},
+	})
+	assert.Equal(t, int64(UpdateRequestThreshold), cfg.GetUpdateRequestThreshold())
+}
+
 func TestConfiguration_GetMaxContextSize_KubernetesQuantityFormat(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

Fixes three related bugs in `pkg/config/config.go` that cause incorrect behavior when the Kyverno ConfigMap is deleted or when a fresh `configuration` is constructed.

### Bug 1: State leak on ConfigMap unload

`unload()` resets most fields back to their defaults but skips `matchConditions` and `updateRequestThreshold`. When a cluster admin deletes the Kyverno ConfigMap (or it temporarily disappears during a Helm upgrade), these two fields retain their old custom values in memory until the controller is restarted. Every other config field resets correctly, so this is an inconsistency that breaks operator expectations.

**Before:** Deleting the ConfigMap leaves stale `matchConditions` active on webhooks and a non-default `updateRequestThreshold` in effect.
**After:** Both fields reset to their documented defaults (`nil` and `1000`).

### Bug 2: Missing defaults in `NewDefaultConfiguration()`

The constructor initializes `defaultRegistry` and `enableDefaultRegistryMutation` but leaves `updateRequestThreshold` and `maxContextSize` as zero-values. Any code path that reads these fields before a ConfigMap load (e.g., startup before the informer fires) sees `0` instead of `1000` and `2MB`.

**Before:** `GetUpdateRequestThreshold()` returns `0` and `GetMaxContextSize()` returns `0` on a freshly constructed configuration.
**After:** Both return their documented defaults immediately.

### Bug 3: Copy-pasted log messages for `updateRequestThreshold`

The `updateRequestThreshold` parsing block in `load()` was copy-pasted from the `enableDefaultRegistryMutation` block. All four log messages reference the wrong field name and describe the wrong data type ("is not a boolean" for an integer field).

**Before:**
```
enableDefaultRegistryMutation not set       # when updateRequestThreshold key is missing
enableDefaultRegistryMutation is not a boolean  # when the value isn't parseable as int
enableDefaultRegistryMutation configured     # on success
```

**After:**
```
updateRequestThreshold not set
updateRequestThreshold is not a valid integer
updateRequestThreshold configured
```

## Which issue(s) this PR fixes

Fixes https://github.com/kyverno/kyverno/issues/17406

## How has this been tested?

Added 5 new unit tests covering all three bugs:

- `TestNewDefaultConfiguration_Defaults` -- verifies constructor sets correct defaults for all key fields
- `TestConfiguration_UnloadResetsMatchConditions` -- loads custom matchConditions, unloads, asserts they reset to nil
- `TestConfiguration_UnloadResetsUpdateRequestThreshold` -- loads threshold=500, unloads, asserts it resets to 1000
- `TestConfiguration_LoadUpdateRequestThreshold` -- table-driven test for valid threshold values (500, 0, 5000)
- `TestConfiguration_LoadUpdateRequestThreshold_Invalid` -- verifies invalid input falls back to the default

All existing tests continue to pass.

```
$ go test ./pkg/config/... -v -count=1
PASS
ok  github.com/kyverno/kyverno/pkg/config  0.030s
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md)
- [x] My change is scoped to a single bug fix with no unrelated changes
- [x] I have added tests that prove my fix is correct
- [x] All new and existing unit tests pass