### PR TITLE
fix(webhook): guard nil Scope dereference in sortedRules to prevent controller panic

### DIFF
--- a/pkg/controllers/webhook/utils.go
+++ b/pkg/controllers/webhook/utils.go
@@ -221,6 +221,13 @@ func deDuplicatedRules(rules []admissionregistrationv1.RuleWithOperations) []adm
 	return uniqueRules
 }
 
+func scopeString(s *admissionregistrationv1.ScopeType) string {
+	if s == nil {
+		return string(admissionregistrationv1.AllScopes)
+	}
+	return string(*s)
+}
+
 func sortedRules(rules []admissionregistrationv1.RuleWithOperations) []admissionregistrationv1.RuleWithOperations {
 	out := make([]admissionregistrationv1.RuleWithOperations, 0, len(rules))
 	for _, rule := range rules {
@@ -246,7 +253,7 @@ func sortedRules(rules []admissionregistrationv1.RuleWithOperations) []admission
 		if x := less(a.Operations, b.Operations); x != 0 {
 			return x
 		}
-		if x := strings.Compare(string(*a.Scope), string(*b.Scope)); x != 0 {
+		if x := strings.Compare(scopeString(a.Scope), scopeString(b.Scope)); x != 0 {
 			return x
 		}
 		return 0

--- a/pkg/controllers/webhook/utils_test.go
+++ b/pkg/controllers/webhook/utils_test.go
@@ -890,6 +890,80 @@ func TestSortedRules(t *testing.T) {
 	}
 }
 
+func TestSortedRules_NilScope(t *testing.T) {
+	ruleNilScope := admissionregistrationv1.RuleWithOperations{
+		Rule: admissionregistrationv1.Rule{
+			APIGroups:   []string{"apps"},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"deployments"},
+		},
+		Operations: []admissionregistrationv1.OperationType{
+			admissionregistrationv1.Create,
+		},
+	}
+	ruleNamespacedScope := admissionregistrationv1.RuleWithOperations{
+		Rule: admissionregistrationv1.Rule{
+			APIGroups:   []string{"apps"},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"deployments"},
+			Scope:       ptr.To(admissionregistrationv1.NamespacedScope),
+		},
+		Operations: []admissionregistrationv1.OperationType{
+			admissionregistrationv1.Create,
+		},
+	}
+	ruleClusterScope := admissionregistrationv1.RuleWithOperations{
+		Rule: admissionregistrationv1.Rule{
+			APIGroups:   []string{"apps"},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"deployments"},
+			Scope:       ptr.To(admissionregistrationv1.ClusterScope),
+		},
+		Operations: []admissionregistrationv1.OperationType{
+			admissionregistrationv1.Create,
+		},
+	}
+
+	t.Run("nil scope does not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			sortedRules([]admissionregistrationv1.RuleWithOperations{ruleNilScope, ruleNamespacedScope})
+		})
+	})
+
+	t.Run("both nil scopes do not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			sortedRules([]admissionregistrationv1.RuleWithOperations{ruleNilScope, ruleNilScope})
+		})
+	})
+
+	t.Run("nil scope treated as AllScopes sorts before Cluster and Namespaced", func(t *testing.T) {
+		result := sortedRules([]admissionregistrationv1.RuleWithOperations{
+			ruleNamespacedScope, ruleNilScope, ruleClusterScope,
+		})
+		assert.Equal(t, scopeString(result[0].Scope), string(admissionregistrationv1.AllScopes))
+		assert.Equal(t, scopeString(result[1].Scope), string(admissionregistrationv1.ClusterScope))
+		assert.Equal(t, scopeString(result[2].Scope), string(admissionregistrationv1.NamespacedScope))
+	})
+}
+
+func TestScopeString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *admissionregistrationv1.ScopeType
+		expected string
+	}{
+		{"nil returns AllScopes", nil, string(admissionregistrationv1.AllScopes)},
+		{"Namespaced", ptr.To(admissionregistrationv1.NamespacedScope), string(admissionregistrationv1.NamespacedScope)},
+		{"Cluster", ptr.To(admissionregistrationv1.ClusterScope), string(admissionregistrationv1.ClusterScope)},
+		{"AllScopes", ptr.To(admissionregistrationv1.AllScopes), string(admissionregistrationv1.AllScopes)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, scopeString(tt.input))
+		})
+	}
+}
+
 func TestIvpolsNeedingMutation(t *testing.T) {
 	trueVal := true
 	falseVal := false


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

The webhook controller panics with a nil pointer dereference when sorting `RuleWithOperations` entries whose `Scope` field is nil.

### Root cause

`sortedRules()` in `pkg/controllers/webhook/utils.go` unconditionally dereferences the `Scope` pointer during comparison:

```go
strings.Compare(string(*a.Scope), string(*b.Scope))
```

But [`admissionregistrationv1.Rule.Scope`](https://pkg.go.dev/k8s.io/api/admissionregistration/v1#Rule) is defined as `*ScopeType` and is optional. When omitted, it defaults to nil.

### How nil Scope enters the pipeline

`CreateMatchConstraints()` in `pkg/cel/autogen/match.go` builds `RuleWithOperations` without setting `Scope`:

```go
rules = append(rules, admissionregistrationv1.NamedRuleWithOperations{
    RuleWithOperations: admissionregistrationv1.RuleWithOperations{
        Rule: admissionregistrationv1.Rule{
            APIGroups:   []string{gv.Group},
            APIVersions: []string{gv.Version},
            Resources:   sets.List(resources),
            // Scope is not set — remains nil
        },
        Operations: operations,
    },
})
```

These rules flow through the webhook generation pipeline:

```
CreateMatchConstraints()
  → buildWebhookRules()
    → buildForJSONPoliciesValidation()
      → sortedRules()
        → strings.Compare(string(*a.Scope), ...) // panic
```

### The fix

Introduces a `scopeString()` helper that safely dereferences `Scope`, treating nil as `AllScopes` (`"*"`), consistent with Kubernetes semantics where an omitted scope matches all resource scopes.

Notably, `generateRuleKey()` in the same file already handles nil Scope correctly (line 279), but `sortedRules()` did not.

**Before:**
```go
if x := strings.Compare(string(*a.Scope), string(*b.Scope)); x != 0 {
```

**After:**
```go
func scopeString(s *admissionregistrationv1.ScopeType) string {
    if s == nil {
        return string(admissionregistrationv1.AllScopes)
    }
    return string(*s)
}

// in sortedRules():
if x := strings.Compare(scopeString(a.Scope), scopeString(b.Scope)); x != 0 {
```

## Which issue(s) this PR fixes

Fixes https://github.com/kyverno/kyverno/issues/17131

## How has this been tested?

Added 7 new test cases across 2 test functions:

**`TestSortedRules_NilScope`** (3 subtests):
- `nil scope does not panic` — verifies the crash no longer occurs when sorting a nil-Scope rule against a non-nil-Scope rule
- `both nil scopes do not panic` — verifies sorting two nil-Scope rules is safe
- `nil scope treated as AllScopes sorts before Cluster and Namespaced` — verifies sort-order semantics: nil (= `"*"`) < `Cluster` < `Namespaced`

**`TestScopeString`** (4 subtests):
- nil input returns `AllScopes`
- `Namespaced`, `Cluster`, and `AllScopes` pass through correctly

All existing `TestSortedRules` tests continue to pass, confirming no change in behavior for non-nil Scope values.

```
$ go test ./pkg/controllers/webhook/... -v -count=1
PASS
ok  github.com/kyverno/kyverno/pkg/controllers/webhook  0.207s
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md)
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). AI assistance is disclosed via `Co-authored-by` trailer.
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.