### PR TITLE
fix(reports): fix label prefix and metadata for namespaced CEL policies

### DIFF
--- a/pkg/engine/api/policy.go
+++ b/pkg/engine/api/policy.go
@@ -287,6 +287,8 @@ func (p *genericPolicy) GetAPIVersion() string {
 		return policiesv1beta1.GroupVersion.String()
 	case p.GeneratingPolicy != nil:
 		return policiesv1beta1.GroupVersion.String()
+	case p.NamespacedGeneratingPolicy != nil:
+		return policiesv1beta1.GroupVersion.String()
 	case p.DeletingPolicy != nil:
 		return policiesv1beta1.GroupVersion.String()
 	case p.CleanupPolicy != nil:
@@ -320,6 +322,8 @@ func (p *genericPolicy) GetKind() string {
 		return p.NamespacedMutatingPolicy.GetKind()
 	case p.GeneratingPolicy != nil:
 		return "GeneratingPolicy"
+	case p.NamespacedGeneratingPolicy != nil:
+		return "NamespacedGeneratingPolicy"
 	case p.DeletingPolicy != nil:
 		return p.DeletingPolicy.GetKind()
 	case p.CleanupPolicy != nil:

--- a/pkg/engine/api/policy_test.go
+++ b/pkg/engine/api/policy_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"testing"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGenericPolicy_NamespacedGeneratingPolicy(t *testing.T) {
+	ngpol := &policiesv1beta1.NamespacedGeneratingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ngpol",
+			Namespace: "test-ns",
+		},
+	}
+
+	p := NewNamespacedGeneratingPolicy(ngpol)
+	assert.Equal(t, "test-ngpol", p.GetName())
+	assert.Equal(t, "test-ns", p.GetNamespace())
+	assert.Equal(t, "NamespacedGeneratingPolicy", p.GetKind())
+	assert.Equal(t, policiesv1beta1.GroupVersion.String(), p.GetAPIVersion())
+	assert.True(t, p.IsNamespaced())
+	assert.NotNil(t, p.AsNamespacedGeneratingPolicy())
+	assert.NotNil(t, p.AsGeneratingPolicyLike())
+	assert.Nil(t, p.AsGeneratingPolicy())
+}
+
+func TestGenericPolicy_GeneratingPolicy(t *testing.T) {
+	gpol := &policiesv1beta1.GeneratingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-gpol",
+		},
+	}
+
+	p := NewGeneratingPolicy(gpol)
+	assert.Equal(t, "test-gpol", p.GetName())
+	assert.Equal(t, "", p.GetNamespace())
+	assert.Equal(t, "GeneratingPolicy", p.GetKind())
+	assert.Equal(t, policiesv1beta1.GroupVersion.String(), p.GetAPIVersion())
+	assert.False(t, p.IsNamespaced())
+	assert.NotNil(t, p.AsGeneratingPolicy())
+	assert.NotNil(t, p.AsGeneratingPolicyLike())
+	assert.Nil(t, p.AsNamespacedGeneratingPolicy())
+}
+
+func TestGenericPolicy_KyvernoPolicy(t *testing.T) {
+	cpol := &kyvernov1.ClusterPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-cpol",
+		},
+	}
+	p := NewKyvernoPolicy(cpol)
+	assert.Equal(t, "ClusterPolicy", p.GetKind())
+	assert.Equal(t, kyvernov1.GroupVersion.String(), p.GetAPIVersion())
+	assert.False(t, p.IsNamespaced())
+
+	pol := &kyvernov1.Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pol",
+			Namespace: "default",
+		},
+	}
+	p = NewKyvernoPolicy(pol)
+	assert.Equal(t, "Policy", p.GetKind())
+	assert.Equal(t, kyvernov1.GroupVersion.String(), p.GetAPIVersion())
+	assert.True(t, p.IsNamespaced())
+}
+
+func TestGenericPolicy_CleanupPolicy(t *testing.T) {
+	clean := &kyvernov2.CleanupPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-clean",
+			Namespace: "default",
+		},
+	}
+	p := NewCleanupPolicyFromInterface(clean)
+	assert.Equal(t, "CleanupPolicy", p.GetKind())
+	assert.True(t, p.IsNamespaced())
+
+	clusterClean := &kyvernov2.ClusterCleanupPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-clusterclean",
+		},
+	}
+	p = NewCleanupPolicyFromInterface(clusterClean)
+	assert.Equal(t, "ClusterCleanupPolicy", p.GetKind())
+	assert.False(t, p.IsNamespaced())
+}

--- a/pkg/utils/report/metadata.go
+++ b/pkg/utils/report/metadata.go
@@ -79,13 +79,13 @@ func PolicyLabelPrefix(policy engineapi.GenericPolicy) string {
 		}
 		return LabelPrefixClusterPolicy
 	}
-	if policy.AsValidatingPolicy() != nil {
+	if policy.AsValidatingPolicyLike() != nil {
 		return LabelPrefixValidatingPolicy
 	}
-	if policy.AsImageValidatingPolicy() != nil {
+	if policy.AsImageValidatingPolicyLike() != nil {
 		return LabelPrefixImageValidatingPolicy
 	}
-	if policy.AsGeneratingPolicy() != nil {
+	if policy.AsGeneratingPolicyLike() != nil {
 		return LabelPrefixGeneratingPolicy
 	}
 	if policy.AsMutatingPolicyLike() != nil {

--- a/pkg/utils/report/metadata_test.go
+++ b/pkg/utils/report/metadata_test.go
@@ -279,6 +279,24 @@ func TestIsPolicyLabel_AllPrefixes(t *testing.T) {
 }
 
 func TestPolicyLabelPrefix_MutatingAndDeletingPolicies(t *testing.T) {
+	vpol := &policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-vpol"},
+	}
+	nsVpol := &policiesv1beta1.NamespacedValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-vpol", Namespace: "default"},
+	}
+	ivpol := &policiesv1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ivpol"},
+	}
+	nsIvpol := &policiesv1beta1.NamespacedImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ivpol", Namespace: "default"},
+	}
+	gpol := &policiesv1beta1.GeneratingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-gpol"},
+	}
+	nsGpol := &policiesv1beta1.NamespacedGeneratingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-gpol", Namespace: "default"},
+	}
 	mpol := &policiesv1beta1.MutatingPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-mpol"},
 	}
@@ -303,6 +321,12 @@ func TestPolicyLabelPrefix_MutatingAndDeletingPolicies(t *testing.T) {
 		policy engineapi.GenericPolicy
 		prefix string
 	}{
+		{"validating policy", engineapi.NewValidatingPolicy(vpol), LabelPrefixValidatingPolicy},
+		{"namespaced validating policy", engineapi.NewNamespacedValidatingPolicy(nsVpol), LabelPrefixValidatingPolicy},
+		{"image validating policy", engineapi.NewImageValidatingPolicy(ivpol), LabelPrefixImageValidatingPolicy},
+		{"namespaced image validating policy", engineapi.NewNamespacedImageValidatingPolicy(nsIvpol), LabelPrefixImageValidatingPolicy},
+		{"generating policy", engineapi.NewGeneratingPolicy(gpol), LabelPrefixGeneratingPolicy},
+		{"namespaced generating policy", engineapi.NewNamespacedGeneratingPolicy(nsGpol), LabelPrefixGeneratingPolicy},
 		{"mutating policy", engineapi.NewMutatingPolicy(mpol), LabelPrefixMutatingPolicy},
 		{"namespaced mutating policy", engineapi.NewNamespacedMutatingPolicy(nsMpol), LabelPrefixMutatingPolicy},
 		{"deleting policy", engineapi.NewDeletingPolicyFromLike(dpol), LabelPrefixDeletingPolicy},


### PR DESCRIPTION

## Explanation

This PR fixes an issue where namespaced CEL policies (`NamespacedValidatingPolicy`, `NamespacedImageValidatingPolicy`, and `NamespacedGeneratingPolicy`) receive an incorrect `validatingadmissionpolicy.apiserver.io/` label prefix on PolicyReports instead of their proper prefixes (`vpol.kyverno.io/`, `ivpol.kyverno.io/`, and `gpol.kyverno.io/`).

In `pkg/utils/report/metadata.go`, `PolicyLabelPrefix` checked only cluster-scoped policies and fell through to returning the ValidatingAdmissionPolicy prefix. This change updates the checks to use `AsValidatingPolicyLike`, `AsImageValidatingPolicyLike`, and `AsGeneratingPolicyLike`. Additionally, it implements missing `NamespacedGeneratingPolicy` handling in `genericPolicy.GetKind()` and `genericPolicy.GetAPIVersion()`.

## Related issue

Closes #17459

## Milestone of this PR

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

- In `pkg/utils/report/metadata.go`: Update `PolicyLabelPrefix` to use `policy.AsValidatingPolicyLike()`, `policy.AsImageValidatingPolicyLike()`, and `policy.AsGeneratingPolicyLike()` so that both cluster-scoped and namespaced CEL policies resolve to their appropriate label prefixes (`vpol.kyverno.io/`, `ivpol.kyverno.io/`, and `gpol.kyverno.io/`).
- In `pkg/engine/api/policy.go`: Add `NamespacedGeneratingPolicy` handling to `genericPolicy.GetKind()` and `genericPolicy.GetAPIVersion()`.
- Add comprehensive unit tests in `pkg/utils/report/metadata_test.go` and `pkg/engine/api/policy_test.go`.

### Proof Manifests

Unit test coverage added in `pkg/utils/report/metadata_test.go` demonstrating prefix resolution for all namespaced CEL policy types:

```go
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies/validating_policy
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies/namespaced_validating_policy
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies/image_validating_policy
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies/namespaced_image_validating_policy
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies/generating_policy
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies/namespaced_generating_policy
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies/mutating_policy
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies/namespaced_mutating_policy
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies/deleting_policy
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies/namespaced_deleting_policy
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies/cleanup_policy
=== RUN   TestPolicyLabelPrefix_MutatingAndDeletingPolicies/cluster_cleanup_policy
--- PASS: TestPolicyLabelPrefix_MutatingAndDeletingPolicies (0.00s)
PASS
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected API version and resource kind reporting for namespaced generating policies.
  - Improved policy classification so validating, image-validating, and generating policy variants receive the correct metadata label prefixes.
  - Added support for namespaced policy variants in metadata handling, improving consistency across policy types.

- **Tests**
  - Expanded coverage for policy metadata, API versions, namespace status, type conversion, and label prefix assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->