### PR TITLE
fix(exceptions): honour the operations field when matching PolicyExceptions

### DIFF
--- a/pkg/engine/utils/exceptions.go
+++ b/pkg/engine/utils/exceptions.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"slices"
 
 	"github.com/go-logr/logr"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
@@ -28,6 +29,7 @@ func MatchesException(client engineapi.Client, polexs []*kyvernov2.PolicyExcepti
 	if resource.Object == nil {
 		resource = policyContext.OldResource()
 	}
+	operation := policyContext.Operation()
 	nsLabels := policyContext.NamespaceLabels()
 	// Namespace labels are only consumed by namespaceSelector evaluation, so only
 	// fetch them when at least one exception actually defines a namespaceSelector.
@@ -50,6 +52,7 @@ func MatchesException(client engineapi.Client, polexs []*kyvernov2.PolicyExcepti
 			policyContext.AdmissionInfo(),
 			gvk,
 			subresource,
+			operation,
 		)
 		if match {
 			if polex.Spec.Conditions != nil {
@@ -94,17 +97,18 @@ func checkMatchesResources(
 	admissionInfo kyvernov2.RequestInfo,
 	gvk schema.GroupVersionKind,
 	subresource string,
+	operation kyvernov1.AdmissionOperation,
 ) bool {
 	if len(statement.Any) > 0 {
 		for _, rmr := range statement.Any {
-			if checkResourceFilter(rmr, resource, namespaceLabels, admissionInfo, gvk, subresource) {
+			if checkResourceFilter(rmr, resource, namespaceLabels, admissionInfo, gvk, subresource, operation) {
 				return true
 			}
 		}
 		return false
 	} else if len(statement.All) > 0 {
 		for _, rmr := range statement.All {
-			if !checkResourceFilter(rmr, resource, namespaceLabels, admissionInfo, gvk, subresource) {
+			if !checkResourceFilter(rmr, resource, namespaceLabels, admissionInfo, gvk, subresource, operation) {
 				return false
 			}
 		}
@@ -120,11 +124,12 @@ func checkResourceFilter(
 	admissionInfo kyvernov2.RequestInfo,
 	gvk schema.GroupVersionKind,
 	subresource string,
+	operation kyvernov1.AdmissionOperation,
 ) bool {
 	if statement.IsEmpty() {
 		return false
 	}
-	return checkResourceDescription(statement.ResourceDescription, resource, namespaceLabels, gvk, subresource) &&
+	return checkResourceDescription(statement.ResourceDescription, resource, namespaceLabels, gvk, subresource, operation) &&
 		checkUserInfo(statement.UserInfo, admissionInfo)
 }
 
@@ -134,7 +139,15 @@ func checkResourceDescription(
 	namespaceLabels map[string]string,
 	gvk schema.GroupVersionKind,
 	subresource string,
+	operation kyvernov1.AdmissionOperation,
 ) bool {
+	// an exception that scopes itself to a set of operations must not apply to
+	// any other operation, mirroring rule matching in doesResourceMatchConditionBlock.
+	if len(conditionBlock.Operations) > 0 {
+		if !slices.Contains(conditionBlock.Operations, operation) {
+			return false
+		}
+	}
 	if len(conditionBlock.Kinds) > 0 {
 		if !matched.CheckKind(conditionBlock.Kinds, gvk, subresource, true) {
 			return false

--- a/pkg/engine/utils/exceptions_test.go
+++ b/pkg/engine/utils/exceptions_test.go
@@ -388,7 +388,6 @@ func TestMatchesException_ClusterScopedResource_SkipsNamespaceGet(t *testing.T) 
 	assert.Equal(t, 0, client.getNamespaceCalls, "cluster-scoped resources have no namespace to fetch")
 }
 
-
 func TestCheckResourceDescription_MatchingOperation(t *testing.T) {
 	conditionBlock := kyvernov1.ResourceDescription{
 		Operations: []kyvernov1.AdmissionOperation{kyvernov1.Create},

--- a/pkg/engine/utils/exceptions_test.go
+++ b/pkg/engine/utils/exceptions_test.go
@@ -83,7 +83,7 @@ func TestCheckResourceDescription_EmptyConditionBlock(t *testing.T) {
 	resource := unstructured.Unstructured{}
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 
-	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "")
+	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "", kyvernov1.Create)
 	assert.True(t, result, "empty condition block should match")
 }
 
@@ -94,7 +94,7 @@ func TestCheckResourceDescription_MatchingKind(t *testing.T) {
 	resource := unstructured.Unstructured{}
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 
-	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "")
+	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "", kyvernov1.Create)
 	assert.True(t, result, "should match when kind matches")
 }
 
@@ -105,7 +105,7 @@ func TestCheckResourceDescription_NonMatchingKind(t *testing.T) {
 	resource := unstructured.Unstructured{}
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 
-	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "")
+	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "", kyvernov1.Create)
 	assert.False(t, result, "should not match when kind differs")
 }
 
@@ -117,7 +117,7 @@ func TestCheckResourceDescription_MatchingName(t *testing.T) {
 	resource.SetName("test-pod")
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 
-	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "")
+	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "", kyvernov1.Create)
 	assert.True(t, result, "should match when name matches wildcard")
 }
 
@@ -129,7 +129,7 @@ func TestCheckResourceDescription_NonMatchingName(t *testing.T) {
 	resource.SetName("prod-pod")
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 
-	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "")
+	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "", kyvernov1.Create)
 	assert.False(t, result, "should not match when name doesn't match wildcard")
 }
 
@@ -141,7 +141,7 @@ func TestCheckResourceDescription_MatchingNamespace(t *testing.T) {
 	resource.SetNamespace("default")
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 
-	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "")
+	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "", kyvernov1.Create)
 	assert.True(t, result, "should match when namespace is in list")
 }
 
@@ -153,7 +153,7 @@ func TestCheckResourceDescription_NonMatchingNamespace(t *testing.T) {
 	resource.SetNamespace("default")
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 
-	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "")
+	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "", kyvernov1.Create)
 	assert.False(t, result, "should not match when namespace is not in list")
 }
 
@@ -163,7 +163,7 @@ func TestCheckResourceFilter_EmptyStatement(t *testing.T) {
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 	admissionInfo := kyvernov2.RequestInfo{}
 
-	result := checkResourceFilter(statement, resource, nil, admissionInfo, gvk, "")
+	result := checkResourceFilter(statement, resource, nil, admissionInfo, gvk, "", kyvernov1.Create)
 	assert.False(t, result, "empty statement should not match")
 }
 
@@ -173,7 +173,7 @@ func TestCheckMatchesResources_EmptyStatement(t *testing.T) {
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 	admissionInfo := kyvernov2.RequestInfo{}
 
-	result := checkMatchesResources(resource, statement, nil, admissionInfo, gvk, "")
+	result := checkMatchesResources(resource, statement, nil, admissionInfo, gvk, "", kyvernov1.Create)
 	assert.False(t, result, "empty match statement should not match")
 }
 
@@ -191,7 +191,7 @@ func TestCheckMatchesResources_AnyMatches(t *testing.T) {
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 	admissionInfo := kyvernov2.RequestInfo{}
 
-	result := checkMatchesResources(resource, statement, nil, admissionInfo, gvk, "")
+	result := checkMatchesResources(resource, statement, nil, admissionInfo, gvk, "", kyvernov1.Create)
 	assert.True(t, result, "should match when any filter matches")
 }
 
@@ -209,7 +209,7 @@ func TestCheckMatchesResources_AllMatchesFail(t *testing.T) {
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 	admissionInfo := kyvernov2.RequestInfo{}
 
-	result := checkMatchesResources(resource, statement, nil, admissionInfo, gvk, "")
+	result := checkMatchesResources(resource, statement, nil, admissionInfo, gvk, "", kyvernov1.Create)
 	assert.False(t, result, "should not match when all filter doesn't match")
 }
 
@@ -307,6 +307,35 @@ func polexMatchingNamespaceSelector(matchLabels map[string]string) *kyvernov2.Po
 	}
 }
 
+func polexMatchingOperations(operations ...kyvernov1.AdmissionOperation) *kyvernov2.PolicyException {
+	return &kyvernov2.PolicyException{
+		Spec: kyvernov2.PolicyExceptionSpec{
+			Exceptions: []kyvernov2.Exception{
+				{PolicyName: "disallow-capabilities", RuleNames: []string{"*"}},
+			},
+			Match: kyvernov2beta1.MatchResources{
+				Any: kyvernov1.ResourceFilters{
+					{
+						ResourceDescription: kyvernov1.ResourceDescription{
+							Namespaces: []string{"default"},
+							Operations: operations,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newExceptionTestPolicyContextForOperation(t *testing.T, resource unstructured.Unstructured, operation kyvernov1.AdmissionOperation) engineapi.PolicyContext {
+	t.Helper()
+	cfg := config.NewDefaultConfiguration(false)
+	jp := jmespath.New(cfg)
+	pc, err := policycontext.NewPolicyContext(jp, resource, operation, nil, cfg)
+	assert.NoError(t, err)
+	return pc.WithNewResource(resource)
+}
+
 func TestMatchesException_NoNamespaceSelector_SkipsNamespaceGet(t *testing.T) {
 	client := &countingClient{}
 	polexs := []*kyvernov2.PolicyException{polexMatchingNamespaces("kube-system")}
@@ -357,4 +386,82 @@ func TestMatchesException_ClusterScopedResource_SkipsNamespaceGet(t *testing.T) 
 	matched := MatchesException(client, polexs, newExceptionTestPolicyContext(t, resource), true, logr.Discard())
 	assert.Empty(t, matched)
 	assert.Equal(t, 0, client.getNamespaceCalls, "cluster-scoped resources have no namespace to fetch")
+}
+
+
+func TestCheckResourceDescription_MatchingOperation(t *testing.T) {
+	conditionBlock := kyvernov1.ResourceDescription{
+		Operations: []kyvernov1.AdmissionOperation{kyvernov1.Create},
+	}
+	resource := unstructured.Unstructured{}
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+
+	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "", kyvernov1.Create)
+	assert.True(t, result, "should match when the operation is listed")
+}
+
+func TestCheckResourceDescription_NonMatchingOperation(t *testing.T) {
+	conditionBlock := kyvernov1.ResourceDescription{
+		Operations: []kyvernov1.AdmissionOperation{kyvernov1.Create},
+	}
+	resource := unstructured.Unstructured{}
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+
+	result := checkResourceDescription(conditionBlock, resource, nil, gvk, "", kyvernov1.Delete)
+	assert.False(t, result, "should not match when the operation is not listed")
+}
+
+func TestCheckResourceDescription_EmptyOperationsMatchesAny(t *testing.T) {
+	conditionBlock := kyvernov1.ResourceDescription{
+		Kinds: []string{"Pod"},
+	}
+	resource := unstructured.Unstructured{}
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+
+	for _, op := range []kyvernov1.AdmissionOperation{kyvernov1.Create, kyvernov1.Update, kyvernov1.Delete, kyvernov1.Connect} {
+		result := checkResourceDescription(conditionBlock, resource, nil, gvk, "", op)
+		assert.True(t, result, "an unset operations list must not restrict the match")
+	}
+}
+
+// A PolicyException that scopes itself to a set of operations must only apply to
+// those operations. Before this was honoured, an exception limited to CREATE also
+// exempted UPDATE and DELETE, silently widening the exception.
+func TestMatchesException_OperationsAreHonoured(t *testing.T) {
+	client := &countingClient{}
+	polexs := []*kyvernov2.PolicyException{polexMatchingOperations(kyvernov1.Create)}
+	resource := newPodResource("test-pod", "default")
+
+	matched := MatchesException(client, polexs, newExceptionTestPolicyContextForOperation(t, resource, kyvernov1.Create), true, logr.Discard())
+	assert.Len(t, matched, 1, "CREATE must match an exception scoped to CREATE")
+
+	for _, op := range []kyvernov1.AdmissionOperation{kyvernov1.Update, kyvernov1.Delete, kyvernov1.Connect} {
+		matched = MatchesException(client, polexs, newExceptionTestPolicyContextForOperation(t, resource, op), true, logr.Discard())
+		assert.Empty(t, matched, "%s must not match an exception scoped to CREATE", op)
+	}
+}
+
+func TestMatchesException_MultipleOperations(t *testing.T) {
+	client := &countingClient{}
+	polexs := []*kyvernov2.PolicyException{polexMatchingOperations(kyvernov1.Create, kyvernov1.Update)}
+	resource := newPodResource("test-pod", "default")
+
+	for _, op := range []kyvernov1.AdmissionOperation{kyvernov1.Create, kyvernov1.Update} {
+		matched := MatchesException(client, polexs, newExceptionTestPolicyContextForOperation(t, resource, op), true, logr.Discard())
+		assert.Len(t, matched, 1, "%s must match an exception scoped to CREATE and UPDATE", op)
+	}
+
+	matched := MatchesException(client, polexs, newExceptionTestPolicyContextForOperation(t, resource, kyvernov1.Delete), true, logr.Discard())
+	assert.Empty(t, matched, "DELETE must not match an exception scoped to CREATE and UPDATE")
+}
+
+func TestMatchesException_NoOperationsAppliesToAll(t *testing.T) {
+	client := &countingClient{}
+	polexs := []*kyvernov2.PolicyException{polexMatchingNamespaces("default")}
+	resource := newPodResource("test-pod", "default")
+
+	for _, op := range []kyvernov1.AdmissionOperation{kyvernov1.Create, kyvernov1.Update, kyvernov1.Delete, kyvernov1.Connect} {
+		matched := MatchesException(client, polexs, newExceptionTestPolicyContextForOperation(t, resource, op), true, logr.Discard())
+		assert.Len(t, matched, 1, "an exception without operations must still apply to %s", op)
+	}
 }


### PR DESCRIPTION
## Explanation

`PolicyException` match blocks accept an `operations` field. The CRD exposes it and describes it as *"used to match a specific action"*, and `kyverno create exception --resource operation=CREATE` generates it. The engine never read it.

`checkResourceDescription` in `pkg/engine/utils/exceptions.go` evaluated `kinds`, `name`, `names`, `namespaces`, `annotations`, `selector` and `namespaceSelector`, but had no branch for `operations`, so the field was silently discarded. An exception scoped to a single operation applied to every operation instead.

The practical effect is that exceptions are broader than the user declared. Someone who scopes an exception to `CREATE` in order to keep enforcing a policy on `UPDATE` and `DELETE` silently gets no enforcement on those operations at all.

This is a fix of existing behavior. It only narrows exceptions that already set `operations`; exceptions that leave the field unset are unaffected.

## Related issue

Fixes #17461

## Milestone of this PR

/milestone TBD

## What type of PR is this

/kind bug

## Proposed Changes

- Thread `policyContext.Operation()` through `checkMatchesResources` → `checkResourceFilter` → `checkResourceDescription` in `pkg/engine/utils/exceptions.go`.
- Skip an exception whose match block sets `operations` when the admission operation is not in that list.

The check mirrors rule matching in `doesResourceMatchConditionBlock` (`pkg/engine/utils/match.go`), and uses the same operation value: `pkg/engine/background.go` already passes `policyContext.Operation()` to `MatchesResourceDescription` for rules, so exception matching and rule matching now agree in every path.

An empty `operations` list keeps its current "matches any operation" meaning, so this is not a behavior change for exceptions that do not use the field.

### Proof Manifests

Given this policy and exception, `disallow-capabilities` should still be enforced on `UPDATE` and `DELETE`, and only be waived on `CREATE`:

```yaml
apiVersion: kyverno.io/v2
kind: PolicyException
metadata:
  name: exempt-on-create-only
  namespace: default
spec:
  exceptions:
    - policyName: disallow-capabilities
      ruleNames:
        - "*"
  match:
    any:
      - resources:
          namespaces:
            - default
          operations:
            - CREATE
```

Before this change the exception applied to `CREATE`, `UPDATE`, `DELETE` and `CONNECT` alike. After it, only `CREATE` is exempted.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

Tests added in `pkg/engine/utils/exceptions_test.go`:

- `TestCheckResourceDescription_MatchingOperation` / `_NonMatchingOperation` — the predicate itself.
- `TestCheckResourceDescription_EmptyOperationsMatchesAny` — an unset list still matches every operation.
- `TestMatchesException_OperationsAreHonoured` — an exception scoped to `CREATE` matches `CREATE` and not `UPDATE`/`DELETE`/`CONNECT`.
- `TestMatchesException_MultipleOperations` — a two-operation list matches both and rejects the third.
- `TestMatchesException_NoOperationsAppliesToAll` — regression guard for existing exceptions that omit `operations`.

All four fail on `main` without the fix and pass with it. `go test ./pkg/engine/...` is green.

`release-1.19` and `release-1.18` are affected as well; happy to `/cherry-pick` once this lands if that's wanted.
