### PR TITLE
[release-1.19] fix(cel): read PolicyExceptions from the manager cache, not a second informer (#16993)

### DIFF
--- a/cmd/background-controller/main.go
+++ b/cmd/background-controller/main.go
@@ -375,7 +375,13 @@ func main() {
 				}
 
 				c := mpolcompiler.NewCompiler()
-				mpolProvider, typeConverter, err := mpolengine.NewKubeProvider(mgrCtx, c, contextProvider, mgr, setup.KubeClient.Discovery().OpenAPIV3(), celengine.NewPolicyExceptionLister(kyvernoInformer.Policies().V1beta1().PolicyExceptions().Lister(), internal.ExceptionNamespace()), internal.PolicyExceptionEnabled())
+				// The mpol reconciler registers its PolicyException watch on this manager's
+				// cache and caches compiled results between triggering events. Reading
+				// exceptions from the same manager cache (rather than the separately synced
+				// kyvernoInformer used above for the fetch-per-request gpol provider) avoids a
+				// race where a reconcile triggered by the watch reads a lister that hasn't
+				// caught up yet, compiles the policy without the exception, and never retries.
+				mpolProvider, typeConverter, err := mpolengine.NewKubeProvider(mgrCtx, c, contextProvider, mgr, setup.KubeClient.Discovery().OpenAPIV3(), celengine.NewManagerPolicyExceptionLister(mgr.GetClient(), internal.ExceptionNamespace()), internal.PolicyExceptionEnabled())
 				if err != nil {
 					setup.Logger.Error(err, "failed to create mpol provider")
 					os.Exit(1)

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -735,7 +735,13 @@ func main() {
 				setup.Logger.Error(err, "failed to construct manager")
 				os.Exit(1)
 			}
-			celExceptionLister := celengine.NewPolicyExceptionLister(kyvernoInformer.Policies().V1beta1().PolicyExceptions().Lister(), internal.ExceptionNamespace())
+			// The vpol/ivpol/mpol reconcilers below register their PolicyException watch
+			// on this manager's cache and cache compiled results between triggering events.
+			// Sourcing the exception list from the same manager cache (rather than a
+			// separately synced informer) avoids a race where the reconcile triggered by
+			// the watch reads a lister that hasn't caught up yet, compiles the policy
+			// without the exception, and never gets retried.
+			celExceptionLister := celengine.NewManagerPolicyExceptionLister(mgr.GetClient(), internal.ExceptionNamespace())
 			// create compiler
 			compiler := vpolcompiler.NewCompiler()
 			// create vpolProvider

--- a/pkg/cel/engine/exception.go
+++ b/pkg/cel/engine/exception.go
@@ -1,9 +1,12 @@
 package engine
 
 import (
+	"context"
+
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	policiesv1beta1listers "github.com/kyverno/kyverno/pkg/client/listers/policies.kyverno.io/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type PolicyExceptionLister interface {
@@ -16,6 +19,49 @@ func NewPolicyExceptionLister(lister policiesv1beta1listers.PolicyExceptionListe
 	}
 
 	return lister.PolicyExceptions(namespace)
+}
+
+// managerPolicyExceptionLister implements PolicyExceptionLister on top of a
+// controller-runtime cache reader (typically a ctrl.Manager's client) instead of a
+// standalone client-go SharedInformerFactory.
+//
+// The CEL policy engines (vpol, ivpol, mpol) register their PolicyException watch on
+// the controller-runtime manager cache and cache the compiled result of a reconcile
+// until the next triggering event. If exceptions were read from a *different* watch
+// stream than the one that triggered the reconcile, the two caches could observe the
+// same object at different times: a reconcile could run before the second cache had
+// caught up, compile the policy without the exception, and never be retried, leaving
+// the exception permanently ignored on that replica. Sourcing the list from the same
+// manager cache that delivers the watch event guarantees the object is already present
+// by the time a reconcile it triggered runs, since controller-runtime only invokes
+// watch handlers after updating the cache's local store.
+type managerPolicyExceptionLister struct {
+	reader    client.Reader
+	namespace string
+}
+
+// NewManagerPolicyExceptionLister returns a PolicyExceptionLister backed by reader,
+// scoped to namespace (all namespaces if empty or "*"). Pass the same ctrl.Manager
+// client used to register the PolicyException watch that triggers reconciliation, so
+// reads and watch events are served from a single cache.
+func NewManagerPolicyExceptionLister(reader client.Reader, namespace string) PolicyExceptionLister {
+	return &managerPolicyExceptionLister{reader: reader, namespace: namespace}
+}
+
+func (l *managerPolicyExceptionLister) List(selector labels.Selector) ([]*policiesv1beta1.PolicyException, error) {
+	var list policiesv1beta1.PolicyExceptionList
+	opts := []client.ListOption{client.MatchingLabelsSelector{Selector: selector}}
+	if l.namespace != "" && l.namespace != "*" {
+		opts = append(opts, client.InNamespace(l.namespace))
+	}
+	if err := l.reader.List(context.Background(), &list, opts...); err != nil {
+		return nil, err
+	}
+	out := make([]*policiesv1beta1.PolicyException, 0, len(list.Items))
+	for i := range list.Items {
+		out = append(out, &list.Items[i])
+	}
+	return out, nil
 }
 
 func ListExceptions(lister PolicyExceptionLister, kind, name string) ([]*policiesv1beta1.PolicyException, error) {

--- a/pkg/cel/engine/exception_test.go
+++ b/pkg/cel/engine/exception_test.go
@@ -7,8 +7,11 @@ import (
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type fakePolicyExceptionLister struct {
@@ -113,4 +116,49 @@ func TestListExceptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestManagerPolicyExceptionLister_ReadsThroughSharedReader is a regression test
+// for issue #16989: the CEL policy engines (vpol, ivpol, mpol) register their
+// PolicyException watch on a controller-runtime manager cache and cache compiled
+// results between triggering events. Looking exceptions up through a *different*
+// cache than the one that delivered the watch event risks reading a stale view
+// and permanently compiling the policy without an exception that already exists.
+// NewManagerPolicyExceptionLister must read through the same reader (typically
+// the manager's own client) used to drive reconciliation, so it always observes
+// an exception the reconcile it triggered is meant to see.
+func TestManagerPolicyExceptionLister_ReadsThroughSharedReader(t *testing.T) {
+	scheme := kruntime.NewScheme()
+	require.NoError(t, policiesv1beta1.Install(scheme))
+
+	exception := &policiesv1beta1.PolicyException{
+		ObjectMeta: metav1.ObjectMeta{Name: "exempt", Namespace: "kyverno"},
+		Spec: policiesv1beta1.PolicyExceptionSpec{
+			PolicyRefs: []policiesv1beta1.PolicyRef{{Kind: "ValidatingPolicy", Name: "require-team"}},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(exception).Build()
+
+	t.Run("cluster-wide", func(t *testing.T) {
+		lister := NewManagerPolicyExceptionLister(fakeClient, "")
+		got, err := ListExceptions(lister, "ValidatingPolicy", "require-team")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "exempt", got[0].Name)
+	})
+
+	t.Run("namespace scoped to a different namespace finds nothing", func(t *testing.T) {
+		lister := NewManagerPolicyExceptionLister(fakeClient, "other-namespace")
+		got, err := ListExceptions(lister, "ValidatingPolicy", "require-team")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("namespace scoped to the matching namespace finds it", func(t *testing.T) {
+		lister := NewManagerPolicyExceptionLister(fakeClient, "kyverno")
+		got, err := ListExceptions(lister, "ValidatingPolicy", "require-team")
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "exempt", got[0].Name)
+	})
 }

--- a/pkg/cel/policies/vpol/engine/reconciler_test.go
+++ b/pkg/cel/policies/vpol/engine/reconciler_test.go
@@ -1,0 +1,199 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	policieskyvernoio "github.com/kyverno/api/api/policies.kyverno.io"
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	celengine "github.com/kyverno/kyverno/pkg/cel/engine"
+	"github.com/kyverno/kyverno/pkg/cel/policies/vpol/compiler"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// fakeVpolClient serves a single ValidatingPolicy by name and a fixed list of
+// PolicyExceptions, standing in for a controller-runtime manager cache that has
+// already observed both objects (e.g. because it is the same cache that delivered
+// the watch event which triggered reconciliation).
+type fakeVpolClient struct {
+	client.Client
+	policy     *policiesv1beta1.ValidatingPolicy
+	exceptions []policiesv1beta1.PolicyException
+}
+
+func (f *fakeVpolClient) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	if f.policy != nil && key.Name == f.policy.Name {
+		if o, ok := obj.(*policiesv1beta1.ValidatingPolicy); ok {
+			*o = *f.policy
+			return nil
+		}
+	}
+	return apierrors.NewNotFound(schema.GroupResource{}, key.Name)
+}
+
+func (f *fakeVpolClient) List(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	if l, ok := list.(*policiesv1beta1.PolicyExceptionList); ok {
+		l.Items = f.exceptions
+		return nil
+	}
+	return nil
+}
+
+// fakeClient serves a fixed ValidatingPolicy by name so the reconciler can be driven without an API
+// server.
+type fakeClient struct {
+	client.Client
+	policy *policiesv1beta1.ValidatingPolicy
+}
+
+func (f *fakeClient) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	if vp, ok := obj.(*policiesv1beta1.ValidatingPolicy); ok && f.policy != nil && key.Name == f.policy.Name {
+		*vp = *f.policy
+		return nil
+	}
+	return apierrors.NewNotFound(schema.GroupResource{}, key.Name)
+}
+
+// staleExceptionLister always reports no exceptions. It stands in for the
+// pre-fix wiring, where exceptions were read through a separate client-go
+// SharedInformerFactory lister that is not guaranteed to have caught up with the
+// controller-runtime manager cache that triggered the reconcile (issue #16989).
+type staleExceptionLister struct{}
+
+func (staleExceptionLister) List(labels.Selector) ([]*policiesv1beta1.PolicyException, error) {
+	return nil, nil
+}
+
+// denyMissingTeamLabelPolicy is a JSON-mode ValidatingPolicy that fails any payload
+// without a "team" field.
+func denyMissingTeamLabelPolicy(name string) *policiesv1beta1.ValidatingPolicy {
+	return &policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: policiesv1beta1.ValidatingPolicySpec{
+			EvaluationConfiguration: &policiesv1beta1.EvaluationConfiguration{
+				Mode: policieskyvernoio.EvaluationModeJSON,
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{Expression: "has(object.team)", Message: "object must carry a team field"},
+			},
+		},
+	}
+}
+
+// disallowLatestTagPolicy matches Pods and autogens onto both a built-in kind (deployments) and a
+// custom workload CRD named by the explicit "<resource>.<version>.<group>" format, which does not
+// need a live cluster to resolve.
+func disallowLatestTagPolicy() *policiesv1beta1.ValidatingPolicy {
+	return &policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "disallow-latest-tag"},
+		Spec: policiesv1beta1.ValidatingPolicySpec{
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+					RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"pods"},
+						},
+					},
+				}},
+			},
+			AutogenConfiguration: &policiesv1beta1.ValidatingPolicyAutogenConfiguration{
+				PodControllers: &policiesv1beta1.PodControllersGenerationConfiguration{
+					Controllers: []string{"deployments", "jobsets.v1alpha2.jobset.x-k8s.io"},
+				},
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{Expression: "object.spec.containers.all(c, !c.image.endsWith(':latest'))"},
+			},
+		},
+	}
+}
+
+// fullExemption is a PolicyException that unconditionally exempts every resource
+// from policyName: no MatchConditions (always matches) and no Images/AllowedValues
+// scoping (grants a full exemption rather than a partial CEL-visible allowlist).
+func fullExemption(name, policyName string) policiesv1beta1.PolicyException {
+	return policiesv1beta1.PolicyException{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: policiesv1beta1.PolicyExceptionSpec{
+			PolicyRefs: []policiesv1beta1.PolicyRef{{
+				Name: policyName,
+				Kind: policieskyvernoio.ValidatingPolicyKind,
+			}},
+		},
+	}
+}
+
+// TestReconcile_ExceptionLister_StaleCacheMissesException reproduces the bug in
+// issue #16989: when exceptions are looked up through a lister backed by a cache
+// different from (and lagging behind) the one that triggered the reconcile, a
+// PolicyException that already exists in the cluster is compiled out of the
+// policy and the resource is denied as if the exception did not exist.
+func TestReconcile_ExceptionLister_StaleCacheMissesException(t *testing.T) {
+	ctx := context.Background()
+	policy := denyMissingTeamLabelPolicy("require-team")
+	fc := &fakeVpolClient{
+		policy:     policy,
+		exceptions: []policiesv1beta1.PolicyException{fullExemption("exempt-all", policy.Name)},
+	}
+
+	// The stale lister never sees the exception that fc (the reconciling cache)
+	// already has, mirroring the dual-cache race.
+	rec := newReconciler(compiler.NewCompiler(), fc, staleExceptionLister{}, true)
+	_, err := rec.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: policy.Name}})
+	require.NoError(t, err)
+
+	eng := NewEngine(rec, nil, nil)
+	payload := &unstructured.Unstructured{Object: map[string]any{"name": "no-team-field"}}
+	resp, err := eng.Handle(ctx, celengine.RequestFromJSON(nil, payload), nil)
+	require.NoError(t, err)
+	require.Len(t, resp.Policies, 1)
+	require.Len(t, resp.Policies[0].Rules, 1)
+
+	// Bug reproduced: the exception is silently ignored and the rule fails.
+	require.Equal(t, engineapi.RuleStatusFail, resp.Policies[0].Rules[0].Status(),
+		"a stale exception lister must reproduce the pre-fix behavior of ignoring an existing PolicyException")
+}
+
+// TestReconcile_ManagerCacheExceptionLister_SeesException verifies the fix: sourcing
+// exceptions from the same manager-cache-backed reader used to fetch the policy
+// (celengine.NewManagerPolicyExceptionLister) guarantees a PolicyException that
+// exists by the time reconciliation runs is always picked up, because
+// controller-runtime only invokes watch handlers after the cache's local store has
+// already been updated.
+func TestReconcile_ManagerCacheExceptionLister_SeesException(t *testing.T) {
+	ctx := context.Background()
+	policy := denyMissingTeamLabelPolicy("require-team")
+	fc := &fakeVpolClient{
+		policy:     policy,
+		exceptions: []policiesv1beta1.PolicyException{fullExemption("exempt-all", policy.Name)},
+	}
+
+	polexLister := celengine.NewManagerPolicyExceptionLister(fc, "")
+	rec := newReconciler(compiler.NewCompiler(), fc, polexLister, true)
+	_, err := rec.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: policy.Name}})
+	require.NoError(t, err)
+
+	eng := NewEngine(rec, nil, nil)
+	payload := &unstructured.Unstructured{Object: map[string]any{"name": "no-team-field"}}
+	resp, err := eng.Handle(ctx, celengine.RequestFromJSON(nil, payload), nil)
+	require.NoError(t, err)
+	require.Len(t, resp.Policies, 1)
+	require.Len(t, resp.Policies[0].Rules, 1)
+
+	// Fixed: the exception is honored and the rule is skipped instead of failing.
+	require.Equal(t, engineapi.RuleStatusSkip, resp.Policies[0].Rules[0].Status(),
+		"the manager-cache-backed lister must honor a PolicyException present in the same cache used to trigger reconciliation")
+}

--- a/test/integration/framework/ivpol.go
+++ b/test/integration/framework/ivpol.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	celengine "github.com/kyverno/kyverno/pkg/cel/engine"
 	"github.com/kyverno/kyverno/pkg/cel/matching"
 	ivpolengine "github.com/kyverno/kyverno/pkg/cel/policies/ivpol/engine"
 	"github.com/kyverno/kyverno/pkg/config"
@@ -37,10 +38,10 @@ func NewIvpolEngine(mgr ctrl.Manager, kubeClient kubernetes.Interface) (ivpoleng
 }
 
 // NewIvpolEngineWithExceptions creates an ivpol engine with PolicyException support enabled.
-// Reuses managerPolexLister (defined in vpol.go) so the controller watches and the lister share
-// the manager's cache, avoiding the dual-cache race.
+// Uses celengine.NewManagerPolicyExceptionLister so the controller watches and the lister
+// share the manager's cache, avoiding the dual-cache race.
 func NewIvpolEngineWithExceptions(mgr ctrl.Manager, kubeClient kubernetes.Interface) (ivpolengine.Engine, ivpolengine.Provider, error) {
-	polexLister := &managerPolexLister{client: mgr.GetClient()}
+	polexLister := celengine.NewManagerPolicyExceptionLister(mgr.GetClient(), "")
 
 	provider, err := ivpolengine.NewKubeProvider(mgr, polexLister, true)
 	if err != nil {

--- a/test/integration/framework/mpol.go
+++ b/test/integration/framework/mpol.go
@@ -8,8 +8,6 @@ import (
 	"github.com/kyverno/kyverno/pkg/cel/matching"
 	mpolcompiler "github.com/kyverno/kyverno/pkg/cel/policies/mpol/compiler"
 	mpolengine "github.com/kyverno/kyverno/pkg/cel/policies/mpol/engine"
-	kyvernoclient "github.com/kyverno/kyverno/pkg/client/clientset/versioned"
-	kyvernoinformer "github.com/kyverno/kyverno/pkg/client/informers/externalversions"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -23,9 +21,11 @@ func NewMpolEngine(ctx context.Context, mgr ctrl.Manager, kubeClient kubernetes.
 }
 
 // NewMpolEngineWithExceptions creates an mpol engine with PolicyException support enabled.
-// This mirrors production wiring with celExceptionLister passed to NewKubeProvider.
-func NewMpolEngineWithExceptions(ctx context.Context, mgr ctrl.Manager, kubeClient kubernetes.Interface, kyvernoClient kyvernoclient.Interface, contextProvider libs.Context) (mpolengine.Engine, mpolengine.Provider, error) {
-	polexLister := NewPolexLister(ctx, kyvernoClient)
+// Uses celengine.NewManagerPolicyExceptionLister (mirroring production wiring in
+// cmd/kyverno/main.go) so the controller watches and the lister share the manager's
+// cache, avoiding the dual-cache race described in issue #16989.
+func NewMpolEngineWithExceptions(ctx context.Context, mgr ctrl.Manager, kubeClient kubernetes.Interface, contextProvider libs.Context) (mpolengine.Engine, mpolengine.Provider, error) {
+	polexLister := celengine.NewManagerPolicyExceptionLister(mgr.GetClient(), "")
 	return newMpolEngine(ctx, mgr, kubeClient, contextProvider, polexLister, true)
 }
 
@@ -42,14 +42,4 @@ func newMpolEngine(ctx context.Context, mgr ctrl.Manager, kubeClient kubernetes.
 	matcher := matching.NewMatcher()
 
 	return mpolengine.NewEngine(provider, nsResolver, matcher, typeConverter, contextProvider), provider, nil
-}
-
-// NewPolexLister creates a real informer-backed PolicyException lister,
-// mirroring the production wiring: kyvernoClient → SharedInformerFactory → Lister.
-func NewPolexLister(ctx context.Context, kyvernoClient kyvernoclient.Interface) celengine.PolicyExceptionLister {
-	factory := kyvernoinformer.NewSharedInformerFactory(kyvernoClient, 0)
-	lister := factory.Policies().V1beta1().PolicyExceptions().Lister()
-	factory.Start(ctx.Done())
-	factory.WaitForCacheSync(ctx.Done())
-	return celengine.NewPolicyExceptionLister(lister, "")
 }

--- a/test/integration/framework/options.go
+++ b/test/integration/framework/options.go
@@ -183,7 +183,7 @@ func wirePolicyType(ctx context.Context, env *TestEnv, pt PolicyType, polexEnabl
 			err      error
 		)
 		if polexEnabled {
-			engine, provider, err = NewMpolEngineWithExceptions(ctx, env.Mgr, env.KubeClient, env.KyvernoClient, env.ContextProvider)
+			engine, provider, err = NewMpolEngineWithExceptions(ctx, env.Mgr, env.KubeClient, env.ContextProvider)
 		} else {
 			engine, provider, err = NewMpolEngine(ctx, env.Mgr, env.KubeClient, env.ContextProvider)
 		}

--- a/test/integration/framework/vpol.go
+++ b/test/integration/framework/vpol.go
@@ -1,17 +1,12 @@
 package framework
 
 import (
-	"context"
-
-	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
-	"github.com/kyverno/kyverno/pkg/cel/engine"
+	celengine "github.com/kyverno/kyverno/pkg/cel/engine"
 	"github.com/kyverno/kyverno/pkg/cel/matching"
 	vpolcompiler "github.com/kyverno/kyverno/pkg/cel/policies/vpol/compiler"
 	vpolengine "github.com/kyverno/kyverno/pkg/cel/policies/vpol/engine"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewVpolEngine creates a vpol engine using the real controller code path (NewKubeProvider).
@@ -30,36 +25,12 @@ func NewVpolEngine(mgr ctrl.Manager) (vpolengine.Engine, vpolengine.Provider, er
 	return vpolengine.NewEngine(provider, nsResolver, matcher), provider, nil
 }
 
-// managerPolexLister implements engine.PolicyExceptionLister using the manager's
-// cache client. This avoids the dual-cache race condition that occurs when using
-// a separate informer factory — the controller watches and the lister both read
-// from the same cache, so exceptions are visible when reconciliation triggers.
-type managerPolexLister struct {
-	client client.Reader
-}
-
-func (l *managerPolexLister) List(selector labels.Selector) ([]*policiesv1beta1.PolicyException, error) {
-	var list policiesv1beta1.PolicyExceptionList
-	if err := l.client.List(context.Background(), &list); err != nil {
-		return nil, err
-	}
-	result := make([]*policiesv1beta1.PolicyException, 0, len(list.Items))
-	for i := range list.Items {
-		if selector.Matches(labels.Set(list.Items[i].Labels)) {
-			result = append(result, &list.Items[i])
-		}
-	}
-	return result, nil
-}
-
-// Ensure managerPolexLister satisfies the interface at compile time.
-var _ engine.PolicyExceptionLister = (*managerPolexLister)(nil)
-
 // NewVpolEngineWithExceptions creates a vpol engine with PolicyException support enabled.
-// Uses the manager's cache as the exception lister so the controller watches and
-// lister share one cache — no dual-cache race conditions.
+// Uses the manager's cache as the exception lister (celengine.NewManagerPolicyExceptionLister,
+// the same helper production wiring uses) so the controller watches and lister share
+// one cache — no dual-cache race conditions.
 func NewVpolEngineWithExceptions(mgr ctrl.Manager) (vpolengine.Engine, vpolengine.Provider, error) {
-	polexLister := &managerPolexLister{client: mgr.GetClient()}
+	polexLister := celengine.NewManagerPolicyExceptionLister(mgr.GetClient(), "")
 
 	compiler := vpolcompiler.NewCompiler()
 	provider, err := vpolengine.NewKubeProvider(compiler, mgr, polexLister, true)

--- a/test/integration/mpol/handler_test.go
+++ b/test/integration/mpol/handler_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 
 	// Use exception-enabled engine for all tests. When no PolicyExceptions exist,
 	// behavior is identical to the non-exception engine (ListExceptions returns nil).
-	engine, provider, err = framework.NewMpolEngineWithExceptions(context.Background(), testEnv.Mgr, testEnv.KubeClient, testEnv.KyvernoClient, testEnv.ContextProvider)
+	engine, provider, err = framework.NewMpolEngineWithExceptions(context.Background(), testEnv.Mgr, testEnv.KubeClient, testEnv.ContextProvider)
 	if err != nil {
 		testEnv.Stop()
 		panic(err)


### PR DESCRIPTION
## Explanation

Cherry-pick of #16993 (merge commit 47f45aebe) to `release-1.19`.

CEL `PolicyException`s were read from a second informer cache (`kyvernoInformer`) while vpol/ivpol/mpol are watched, compiled, and cached via the controller-runtime manager cache. Because reconcilers cache compiled results, a stale exception read from the second cache could become permanently baked into a compiled policy. This change adds a manager-cache-backed exception lister (`pkg/cel/engine/exception.go`) and wires it into the admission controller and background controller so all consumers observe the same cache.

### Conflict resolution (vs main)

- `pkg/cel/policies/vpol/engine/reconciler_test.go` (new file on this branch): kept both PolicyException regression tests; dropped the main-only `TestReconcile_ExtractionMode`, which exercises the extraction-mode feature that does not exist on `release-1.19` (and its then-unused `assert` import).

Verified on this branch: `go build ./...`, `go vet` (incl. `test/integration/...`), and `go test -race -count=1 ./pkg/cel/engine/... ./pkg/cel/policies/vpol/...` — all pass.

## Related issue

Backport of #16993

## Milestone of this PR

/milestone 1.19.1

## What type of PR is this

/kind bug

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
