### PR TITLE
fix(webhook): fix concurrent map race in expressionCache.GetOrCompile

### DIFF
--- a/pkg/controllers/webhook/expression_cache.go
+++ b/pkg/controllers/webhook/expression_cache.go
@@ -36,18 +36,28 @@ func NewExpressionCache() *expressionCache {
 func (c *expressionCache) GetOrCompile(condition admissionregistrationv1.MatchCondition) *compiledExpression {
 	hash := c.hashMatchCondition(condition)
 
+	// Fast path: cache hit — read lock only.
 	c.mu.RLock()
 	if cached, exists := c.cache[hash]; exists {
 		c.mu.RUnlock()
 		return cached
 	}
-	c.mu.RUnlock()
-
-	c.mu.RLock()
+	// Take a defensive snapshot of preexistingExpressions so we can release
+	// the read lock before the (potentially slow) CEL compilation step.
+	// Passing the live map to CompileMatchConditionsWithKubernetesEnv without a
+	// lock would race with concurrent AddExpression writers.
+	snapshot := make(map[string]bool, len(c.preexistingExpressions))
+	for k, v := range c.preexistingExpressions {
+		snapshot[k] = v
+	}
 	isPreexisting := c.preexistingExpressions[condition.Expression]
 	c.mu.RUnlock()
 
-	errors := compiler.CompileMatchConditionsWithKubernetesEnv([]admissionregistrationv1.MatchCondition{condition}, c.preexistingExpressions)
+	// Compile against the snapshot — no lock needed here; snapshot is thread-local.
+	errors := compiler.CompileMatchConditionsWithKubernetesEnv(
+		[]admissionregistrationv1.MatchCondition{condition},
+		snapshot,
+	)
 
 	compiled := &compiledExpression{
 		expression: condition.Expression,
@@ -59,6 +69,12 @@ func (c *expressionCache) GetOrCompile(condition admissionregistrationv1.MatchCo
 	}
 
 	c.mu.Lock()
+	// Another goroutine may have compiled and stored the same expression while
+	// we were working; prefer the already-stored entry to avoid redundant writes.
+	if existing, exists := c.cache[hash]; exists {
+		c.mu.Unlock()
+		return existing
+	}
 	c.cache[hash] = compiled
 	c.preexistingExpressions[condition.Expression] = true
 	c.mu.Unlock()

--- a/pkg/controllers/webhook/expression_cache_race_test.go
+++ b/pkg/controllers/webhook/expression_cache_race_test.go
@@ -1,0 +1,118 @@
+package webhook
+
+// Regression test for https://github.com/kyverno/kyverno/issues/17463
+//
+// Run with: go test -race -count=1 -run TestGetOrCompile_RaceWithAddExpression ./...
+//
+// Before the fix: fatal error: concurrent map read and map write (detected by -race
+// or the Go runtime on maps).
+// After the fix:  test passes cleanly under -race.
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+)
+
+func makeCondition(name, expr string) admissionregistrationv1.MatchCondition {
+	return admissionregistrationv1.MatchCondition{Name: name, Expression: expr}
+}
+
+// TestGetOrCompile_RaceWithAddExpression reproduces the crash described in #17463.
+//
+// It fires concurrent AddExpression writers (simulating informer resync callbacks)
+// against a concurrent GetOrCompile reader (simulating the webhook-controller
+// reconcile path on the elected leader).  Without the fix the race detector or Go's
+// runtime map-protection fires within milliseconds; with the fix the test completes
+// cleanly.
+func TestGetOrCompile_RaceWithAddExpression(t *testing.T) {
+	cache := NewExpressionCache()
+
+	// Pre-seed a handful of expressions so preexistingExpressions is non-empty,
+	// which is what makes the map-read in validateMatchConditionsExpression
+	// (matchconditions.go:68) interesting.
+	for i := 0; i < 5; i++ {
+		cache.AddExpression(makeCondition(
+			"seed",
+			"true", // simple expression that always compiles
+		))
+	}
+
+	conditions := []admissionregistrationv1.MatchCondition{
+		makeCondition("c1", "object.metadata.name.startsWith('foo') && object.metadata.namespace in ['a','b','c','d','e']"),
+		makeCondition("c2", "has(object.metadata.labels) && object.metadata.labels.exists(k, k.startsWith('app'))"),
+		makeCondition("c3", "request.userInfo.username != 'system:anonymous' && request.userInfo.groups.exists(g, g == 'system:masters')"),
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writer goroutines — simulate informer Add/Update/Delete callbacks.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					for _, c := range conditions {
+						cache.AddExpression(c)
+					}
+				}
+			}
+		}()
+	}
+
+	// Reader goroutine — simulates the leader's reconcile path.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		deadline := time.After(500 * time.Millisecond)
+		for {
+			select {
+			case <-deadline:
+				close(stop)
+				return
+			default:
+				cache.ValidateMatchConditions(conditions)
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestGetOrCompile_ConcurrentCompileSameKey checks that two goroutines compiling
+// the same key simultaneously produce a consistent result and don't double-write
+// in a racy way — the check-then-store in GetOrCompile prefers an already-stored
+// entry.
+func TestGetOrCompile_ConcurrentCompileSameKey(t *testing.T) {
+	cache := NewExpressionCache()
+	cond := makeCondition("dup", "true")
+
+	var wg sync.WaitGroup
+	results := make([]*compiledExpression, 10)
+
+	for i := 0; i < 10; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i] = cache.GetOrCompile(cond)
+		}()
+	}
+	wg.Wait()
+
+	for i, r := range results {
+		if r == nil {
+			t.Errorf("goroutine %d got nil result", i)
+		}
+		if !r.isValid {
+			t.Errorf("goroutine %d got invalid result: %v", i, r.errors)
+		}
+	}
+}


### PR DESCRIPTION
## Explanation

expressionCache.GetOrCompile passed the live preexistingExpressions map directly into CompileMatchConditionsWithKubernetesEnv with no lock held. Concurrently, policy-informer callbacks (AddExpression) write to the same map under c.mu.Lock(). The Go race detector — and in production, the Go runtime — detects this as a concurrent map read and write, causing a fatal error: concurrent map read and map write panic on the elected leader replica (the only replica that runs the reconcile-driven read path).
This is a bug fix. No user-facing behavior is changed.

## Related issue

Closes #17463

## Milestone of this PR

/milestone 1.19.1

## Documentation (required for features)

N/A — bug fix with no user-facing behavior change.

## What type of PR is this

/kind bug

## Proposed Changes

GetOrCompile had a lock gap: it released c.mu.RLock() after checking isPreexisting, then called CompileMatchConditionsWithKubernetesEnv passing the live c.preexistingExpressions map with no lock held. validateMatchConditionsExpression reads that map at matchconditions.go:68 to determine the CEL environment type — a plain map read with no synchronization.

The fix takes a defensive copy (snapshot) of preexistingExpressions while the read lock is still held, then passes the snapshot (thread-local, unshared) to the compiler. No lock is needed during compilation itself.

A secondary improvement: after acquiring the write lock to store the result, GetOrCompile now re-checks whether another goroutine already stored the same entry during compilation and returns the existing one if so, avoiding a redundant overwrite.

Race confirmed on main before fix:

WARNING: DATA RACE
Write at 0x00c0006b6d80 by goroutine 55:
  github.com/kyverno/kyverno/pkg/controllers/webhook.(*expressionCache).AddExpression()
      pkg/controllers/webhook/expression_cache.go:119

Previous read at 0x00c0006b6d80 by goroutine 58:
  github.com/kyverno/kyverno/pkg/cel/compiler.validateMatchConditionsExpression()
      pkg/cel/compiler/matchconditions.go:68
  github.com/kyverno/kyverno/pkg/controllers/webhook.(*expressionCache).GetOrCompile()
      pkg/controllers/webhook/expression_cache.go:50

After fix:

ok      github.com/kyverno/kyverno/pkg/controllers/webhook      1.539s

To reproduce:

bash
go test -race -count=1 -run TestGetOrCompile_Race ./pkg/controllers/webhook/...

### Proof Manifests

N/A — the race is exercised entirely by the unit test; it does not require a running cluster or policy manifests. The added test (expression_cache_race_test.go) is a reliable reproducer.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The crash is confined to the leader replica because only the leader executes reconcileValidatingWebhookConfiguration → buildWebhookRules → validConditions → ValidateMatchConditions → GetOrCompile. The two non-leader replicas run AddExpression via informer callbacks but never hit the read path, so they never crash. This also explains why the same replica keeps crashing after each restart — it immediately reclaims the lease and re-enters the race.

The fix touches only GetOrCompile (~15 lines). AddExpression, RemoveExpression, Invalidate, and all callers are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved webhook expression caching to remain reliable during concurrent updates and validations.
  - Prevented duplicate compilations from replacing an expression that was cached by another request.
  - Ensured concurrent requests receive valid, consistent compiled expressions.

- **Tests**
  - Added coverage for concurrent cache updates and simultaneous compilation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->