### PR TITLE
fix(exceptions): honour expiresAt in the CEL policy providers

### DIFF
--- a/pkg/cel/engine/exception.go
+++ b/pkg/cel/engine/exception.go
@@ -69,16 +69,25 @@ func ListExceptions(lister PolicyExceptionLister, kind, name string) ([]*policie
 	if err != nil {
 		return nil, err
 	}
+	return MatchExceptions(exceptions, kind, name), nil
+}
+
+// MatchExceptions returns the exceptions in exceptions that apply to the policy
+// identified by kind and name. Expired exceptions are never returned: spec.expiresAt
+// is documented as retiring an exception, so every path that selects exceptions must
+// agree with the admission path about which ones are still live.
+func MatchExceptions(exceptions []*policiesv1beta1.PolicyException, kind, name string) []*policiesv1beta1.PolicyException {
 	var out []*policiesv1beta1.PolicyException
 	for _, exception := range exceptions {
-		if exception.IsExpired() {
+		if exception == nil || exception.IsExpired() {
 			continue
 		}
 		for _, ref := range exception.Spec.PolicyRefs {
 			if ref.Name == name && ref.Kind == kind {
 				out = append(out, exception)
+				break
 			}
 		}
 	}
-	return out, nil
+	return out
 }

--- a/pkg/cel/engine/exception_test.go
+++ b/pkg/cel/engine/exception_test.go
@@ -162,3 +162,79 @@ func TestManagerPolicyExceptionLister_ReadsThroughSharedReader(t *testing.T) {
 		assert.Equal(t, "exempt", got[0].Name)
 	})
 }
+
+func TestMatchExceptions(t *testing.T) {
+	expired := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	future := metav1.NewTime(time.Now().Add(1 * time.Hour))
+
+	polex := func(name string, expiresAt *metav1.Time, refs ...policiesv1beta1.PolicyRef) *policiesv1beta1.PolicyException {
+		return &policiesv1beta1.PolicyException{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: policiesv1beta1.PolicyExceptionSpec{
+				ExpiresAt:  expiresAt,
+				PolicyRefs: refs,
+			},
+		}
+	}
+	ref := policiesv1beta1.PolicyRef{Name: "policy", Kind: "ValidatingPolicy"}
+
+	tests := []struct {
+		name       string
+		exceptions []*policiesv1beta1.PolicyException
+		want       []string
+	}{{
+		name:       "no exceptions",
+		exceptions: nil,
+		want:       nil,
+	}, {
+		name:       "matching exception without expiry is returned",
+		exceptions: []*policiesv1beta1.PolicyException{polex("live", nil, ref)},
+		want:       []string{"live"},
+	}, {
+		name:       "exception expiring in the future is returned",
+		exceptions: []*policiesv1beta1.PolicyException{polex("not-yet-expired", &future, ref)},
+		want:       []string{"not-yet-expired"},
+	}, {
+		name:       "expired exception is skipped",
+		exceptions: []*policiesv1beta1.PolicyException{polex("expired", &expired, ref)},
+		want:       nil,
+	}, {
+		name: "only the live exception is returned",
+		exceptions: []*policiesv1beta1.PolicyException{
+			polex("expired", &expired, ref),
+			polex("live", nil, ref),
+		},
+		want: []string{"live"},
+	}, {
+		name:       "exception referencing another policy name is skipped",
+		exceptions: []*policiesv1beta1.PolicyException{polex("other", nil, policiesv1beta1.PolicyRef{Name: "other-policy", Kind: "ValidatingPolicy"})},
+		want:       nil,
+	}, {
+		name:       "exception referencing another policy kind is skipped",
+		exceptions: []*policiesv1beta1.PolicyException{polex("other-kind", nil, policiesv1beta1.PolicyRef{Name: "policy", Kind: "MutatingPolicy"})},
+		want:       nil,
+	}, {
+		name:       "duplicate policy refs return the exception once",
+		exceptions: []*policiesv1beta1.PolicyException{polex("dup", nil, ref, ref)},
+		want:       []string{"dup"},
+	}, {
+		name:       "nil exception is skipped",
+		exceptions: []*policiesv1beta1.PolicyException{nil, polex("live", nil, ref)},
+		want:       []string{"live"},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MatchExceptions(tt.exceptions, "ValidatingPolicy", "policy")
+			names := make([]string, 0, len(got))
+			for _, e := range got {
+				names = append(names, e.GetName())
+			}
+			if tt.want == nil {
+				assert.Empty(t, names)
+				return
+			}
+			assert.Equal(t, tt.want, names)
+		})
+	}
+}

--- a/pkg/cel/policies/dpol/engine/provider.go
+++ b/pkg/cel/policies/dpol/engine/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/pkg/cel/engine"
 	dpolcompiler "github.com/kyverno/kyverno/pkg/cel/policies/dpol/compiler"
 )
 
@@ -28,15 +29,7 @@ func NewProvider(
 		if policy == nil {
 			continue
 		}
-		policyKind := policy.GetKind()
-		var matchedExceptions []*policiesv1beta1.PolicyException
-		for _, polex := range exceptions {
-			for _, ref := range polex.Spec.PolicyRefs {
-				if ref.Name == policy.GetName() && ref.Kind == policyKind {
-					matchedExceptions = append(matchedExceptions, polex)
-				}
-			}
-		}
+		matchedExceptions := engine.MatchExceptions(exceptions, policy.GetKind(), policy.GetName())
 		compiled, errs := compiler.Compile(policy, matchedExceptions)
 		if len(errs) > 0 {
 			return nil, fmt.Errorf("failed to compile policy %s (%w)", policy.GetName(), errs.ToAggregate())

--- a/pkg/cel/policies/gpol/engine/fetch.go
+++ b/pkg/cel/policies/gpol/engine/fetch.go
@@ -62,20 +62,14 @@ func (fp *fetchProvider) Get(ctx context.Context, name string) (Policy, error) {
 			return Policy{}, fmt.Errorf("generating policy %s not found: %w", name, err)
 		}
 	}
-	var exceptions, matchedExceptions []*policiesv1beta1.PolicyException
+	var exceptions []*policiesv1beta1.PolicyException
 	if fp.polexLister != nil {
 		exceptions, err = fp.polexLister.List(labels.Everything())
 		if err != nil {
 			return Policy{}, err
 		}
 	}
-	for _, polex := range exceptions {
-		for _, ref := range polex.Spec.PolicyRefs {
-			if ref.Name == policy.GetName() && ref.Kind == policy.GetKind() {
-				matchedExceptions = append(matchedExceptions, polex)
-			}
-		}
-	}
+	matchedExceptions := engine.MatchExceptions(exceptions, policy.GetKind(), policy.GetName())
 	compiled, errList := fp.compiler.Compile(policy, matchedExceptions)
 	if errList != nil {
 		return Policy{}, errList.ToAggregate()

--- a/pkg/cel/policies/gpol/engine/fetch_test.go
+++ b/pkg/cel/policies/gpol/engine/fetch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/cel/policies/gpol/compiler"
@@ -79,6 +80,42 @@ func TestGet(t *testing.T) {
 		assert.Equal(t, "test-policy", policy.Policy.GetName())
 		assert.Len(t, policy.Exceptions, 1)
 		assert.NotNil(t, policy.CompiledPolicy)
+	})
+
+	t.Run("expired exception is not attached", func(t *testing.T) {
+		comp := compiler.NewCompiler()
+		gpol := &policiesv1beta1.GeneratingPolicy{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "test-policy",
+			},
+		}
+		gpol.TypeMeta.Kind = "GeneratingPolicy"
+
+		expiresAt := v1.NewTime(time.Now().Add(-1 * time.Hour))
+		exception := &policiesv1beta1.PolicyException{
+			ObjectMeta: v1.ObjectMeta{Name: "expired"},
+			Spec: policiesv1beta1.PolicyExceptionSpec{
+				ExpiresAt: &expiresAt,
+				PolicyRefs: []policiesv1beta1.PolicyRef{
+					{
+						Name: "test-policy",
+						Kind: "GeneratingPolicy",
+					},
+				},
+			},
+		}
+
+		fp := NewFetchProvider(
+			comp,
+			&fakeGpolLister{policy: gpol},
+			&fakeNgpolLister{},
+			&fakePolexLister{exceptions: []*policiesv1beta1.PolicyException{exception}},
+			true,
+		)
+
+		policy, err := fp.Get(context.Background(), "test-policy")
+		assert.NoError(t, err)
+		assert.Empty(t, policy.Exceptions)
 	})
 
 	t.Run("", func(t *testing.T) {

--- a/pkg/cel/policies/ivpol/engine/provider.go
+++ b/pkg/cel/policies/ivpol/engine/provider.go
@@ -29,14 +29,7 @@ func NewProvider(policies []policiesv1beta1.ImageValidatingPolicyLike, exception
 	compiled := make([]Policy, 0, len(policies))
 	for _, policy := range policies {
 		p := policy
-		var matchedExceptions []*policiesv1beta1.PolicyException
-		for _, polex := range exceptions {
-			for _, ref := range polex.Spec.PolicyRefs {
-				if ref.Name == p.GetName() && ref.Kind == p.GetKind() {
-					matchedExceptions = append(matchedExceptions, polex)
-				}
-			}
-		}
+		matchedExceptions := engine.MatchExceptions(exceptions, p.GetKind(), p.GetName())
 		actions := sets.New(p.GetSpec().ValidationActions()...)
 		compiled = append(compiled, Policy{
 			Actions:    actions,

--- a/pkg/cel/policies/ivpol/engine/provider_test.go
+++ b/pkg/cel/policies/ivpol/engine/provider_test.go
@@ -1,0 +1,76 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewProviderExceptionExpiry(t *testing.T) {
+	expired := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+
+	polex := func(name string, expiresAt *metav1.Time) *policiesv1beta1.PolicyException {
+		return &policiesv1beta1.PolicyException{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: policiesv1beta1.PolicyExceptionSpec{
+				ExpiresAt: expiresAt,
+				PolicyRefs: []policiesv1beta1.PolicyRef{{
+					Name: "ivpol",
+					Kind: "ImageValidatingPolicy",
+				}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		exceptions []*policiesv1beta1.PolicyException
+		want       []string
+	}{{
+		name:       "live exception is attached",
+		exceptions: []*policiesv1beta1.PolicyException{polex("live", nil)},
+		want:       []string{"live"},
+	}, {
+		name:       "expired exception is not attached",
+		exceptions: []*policiesv1beta1.PolicyException{polex("expired", &expired)},
+		want:       nil,
+	}, {
+		name: "only the live exception is attached",
+		exceptions: []*policiesv1beta1.PolicyException{
+			polex("expired", &expired),
+			polex("live", nil),
+		},
+		want: []string{"live"},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := &policiesv1beta1.ImageValidatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "ivpol"},
+				TypeMeta:   metav1.TypeMeta{Kind: "ImageValidatingPolicy"},
+			}
+
+			provider, err := NewProvider([]policiesv1beta1.ImageValidatingPolicyLike{policy}, tt.exceptions)
+			require.NoError(t, err)
+
+			policies, err := provider.Fetch(context.Background())
+			require.NoError(t, err)
+			require.Len(t, policies, 1)
+
+			names := make([]string, 0, len(policies[0].Exceptions))
+			for _, e := range policies[0].Exceptions {
+				names = append(names, e.GetName())
+			}
+			if tt.want == nil {
+				assert.Empty(t, names)
+				return
+			}
+			assert.Equal(t, tt.want, names)
+		})
+	}
+}

--- a/pkg/cel/policies/mpol/engine/provider.go
+++ b/pkg/cel/policies/mpol/engine/provider.go
@@ -163,14 +163,7 @@ func NewProvider(
 ) (Provider, error) {
 	out := make([]Policy, 0, len(policies))
 	for _, policy := range policies {
-		var matchedExceptions []*policiesv1beta1.PolicyException
-		for _, polex := range exceptions {
-			for _, ref := range polex.Spec.PolicyRefs {
-				if ref.Name == policy.GetName() && ref.Kind == policy.GetKind() {
-					matchedExceptions = append(matchedExceptions, polex)
-				}
-			}
-		}
+		matchedExceptions := engine.MatchExceptions(exceptions, policy.GetKind(), policy.GetName())
 		compiled, errs := compiler.Compile(policy, matchedExceptions)
 		if len(errs) > 0 {
 			return nil, fmt.Errorf("failed to compile policy %s (%w)", policy.GetName(), errs.ToAggregate())

--- a/pkg/cel/policies/vpol/engine/provider.go
+++ b/pkg/cel/policies/vpol/engine/provider.go
@@ -36,14 +36,7 @@ func NewProvider(
 	for _, policy := range policies {
 		spec := policy.GetValidatingPolicySpec()
 		actions := sets.New(spec.ValidationActions()...)
-		var matchedExceptions []*policiesv1beta1.PolicyException
-		for _, polex := range exceptions {
-			for _, ref := range polex.Spec.PolicyRefs {
-				if ref.Name == policy.GetName() && ref.Kind == policy.GetKind() {
-					matchedExceptions = append(matchedExceptions, polex)
-				}
-			}
-		}
+		matchedExceptions := engine.MatchExceptions(exceptions, policy.GetKind(), policy.GetName())
 		compiled, errs := compiler.Compile(policy, matchedExceptions)
 		if len(errs) > 0 {
 			return nil, fmt.Errorf("failed to compile policy %s (%w)", policy.GetName(), errs.ToAggregate())


### PR DESCRIPTION
## Explanation

While looking at how the CEL policy engines pick up PolicyExceptions, I noticed that `spec.expiresAt` is only honoured on the admission path.

`PolicyException.spec.expiresAt` is documented as retiring an exception, and the API type ships an `IsExpired()` helper for exactly that. #16299 wired that helper into `ListExceptions` in `pkg/cel/engine/exception.go` and into the admission policy generator, but the CEL policy providers never call `ListExceptions`. Each of them carries its own copy of the `spec.policyRefs` matching loop, and none of those copies looks at `expiresAt`.

Those providers are what the background scanner and the CLI use. In `pkg/controllers/report/background/controller.go` the exception list comes from `utils.FetchCELPolicyExceptions`, which lists every exception with no expiry filter and hands the whole slice to `ScanResource`, and that builds the vpol, mpol and ivpol providers from it. The `kyverno apply` and `kyverno test` commands build the same providers the same way.

The result is that admission and reporting disagree about the same object. Once an exception expires the webhook correctly stops honouring it and starts denying the resource again, but the background scan keeps attaching it, so the PolicyReport still reports skip and `kyverno apply` in CI still passes. Anyone using `expiresAt` to hand out a time boxed exception ends up with reports and CI that keep trusting it forever.

This PR fixes the issue by extracting the exception selection into a single `engine.MatchExceptions` helper that skips expired exceptions, and using it from all five providers so every path agrees on which exceptions are still live.

## Related issue

Fixes #17473

## Milestone of this PR

/milestone TBD

## What type of PR is this

/kind bug

## Proposed Changes

- `pkg/cel/engine/exception.go`: add `MatchExceptions`, which selects the exceptions matching a policy kind and name and skips expired and nil entries. `ListExceptions` now delegates to it, so its behaviour is unchanged.
- `pkg/cel/policies/vpol/engine/provider.go`, `mpol/engine/provider.go`, `ivpol/engine/provider.go`, `dpol/engine/provider.go` and `gpol/engine/fetch.go`: replace the duplicated `spec.policyRefs` loop with `engine.MatchExceptions`, which is what brings the expiry check to the background scan and CLI paths.
- Tests covering the helper directly, plus provider level tests for ivpol and gpol showing an expired exception is no longer attached.

### Proof Manifests

Not applicable, this is covered by unit tests.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [x] My PR needs to be cherry picked to a specific release branch which is release-1.19.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

I went with one shared helper rather than adding the same `IsExpired()` line five times, because the duplicated matching loop is what let the expiry check drift out of sync in the first place. Keeping the selection in one place means the next change to it lands everywhere at once.

Every new test fails on main without the change. 1.19 has the same gap and I have ticked the cherry pick box for it. 1.18 and earlier are not affected because `expiresAt` does not exist there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Expired policy exceptions are no longer applied to policies.
  - Policy exceptions with missing data are handled safely without causing failures.
  - Exceptions matching multiple references are applied only once, preventing duplicate processing.
  - Exception matching is now consistent across supported policy types.

- **Tests**
  - Added coverage for expired, missing, duplicate, matching, and non-matching policy exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->