### PR TITLE
fix(helm): allow OpenShift to assign container UID and GID

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -31,6 +31,8 @@ annotations:
   # valid kinds are: added, changed, deprecated, removed, fixed and security
   artifacthub.io/changes: |
     - kind: fixed
+      description: Allow platforms such as OpenShift to assign container user and group IDs.
+    - kind: fixed
       description: Bump bundled reports-server dependency to v0.1.7 to fix APIServices being de-registered on pod termination when another replica is still ready.
     - kind: fixed
       description: Ensure spec.template.metadata isn't null

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -291,7 +291,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | crds.migration.podLabels | object | `{}` | Pod labels. |
 | crds.migration.podAnnotations | object | `{}` | Pod annotations. |
 | crds.migration.nodeAffinity | object | `{}` | Node affinity constraints. |
-| crds.migration.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the hook containers |
+| crds.migration.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the hook containers. UID/GID are unset by default so platforms such as OpenShift can assign them. |
 | crds.migration.podResources.limits | object | `{"cpu":"100m","memory":"256Mi"}` | Pod resource limits |
 | crds.migration.podResources.requests | object | `{"cpu":"10m","memory":"64Mi"}` | Pod resource requests |
 | crds.migration.serviceAccount.automountServiceAccountToken | bool | `true` | Toggle automounting of the ServiceAccount. When set to false, a projected service account token is used instead which provides time-limited and audience-bound tokens for improved security. |
@@ -469,7 +469,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | admissionController.initContainer.image.pullPolicy | string | `nil` | Image pull policy If missing, defaults to image.pullPolicy |
 | admissionController.initContainer.resources.limits | object | `{"cpu":"100m","memory":"256Mi"}` | Pod resource limits |
 | admissionController.initContainer.resources.requests | object | `{"cpu":"10m","memory":"64Mi"}` | Pod resource requests |
-| admissionController.initContainer.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context |
+| admissionController.initContainer.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context. UID/GID are unset by default so platforms such as OpenShift can assign them. |
 | admissionController.initContainer.extraArgs | object | `{}` | Additional container args. |
 | admissionController.initContainer.extraEnvVars | list | `[]` | Additional container environment variables. |
 | admissionController.container.image.registry | string | `nil` | Image registry |
@@ -479,7 +479,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | admissionController.container.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | admissionController.container.resources.limits | object | `{"memory":"384Mi"}` | Pod resource limits |
 | admissionController.container.resources.requests | object | `{"cpu":"100m","memory":"128Mi"}` | Pod resource requests |
-| admissionController.container.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context |
+| admissionController.container.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context. UID/GID are unset by default so platforms such as OpenShift can assign them. |
 | admissionController.container.lifecycle | object | `{}` | Container lifecycle hooks (e.g. a preStop sleep for graceful shutdown). The sleep action requires Kubernetes 1.30+. |
 | admissionController.container.extraArgs | object | `{}` | Additional container args. |
 | admissionController.container.extraEnvVars | list | `[]` | Additional container environment variables. |
@@ -573,7 +573,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | backgroundController.nodeAffinity | object | `{}` | Node affinity constraints. |
 | backgroundController.topologySpreadConstraints | list | `[]` | Topology spread constraints. |
 | backgroundController.podSecurityContext | object | `{}` | Security context for the pod |
-| backgroundController.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the containers |
+| backgroundController.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the containers. UID/GID are unset by default so platforms such as OpenShift can assign them. |
 | backgroundController.lifecycle | object | `{}` | Container lifecycle hooks (e.g. a preStop sleep for graceful shutdown). The sleep action requires Kubernetes 1.30+. |
 | backgroundController.podDisruptionBudget.enabled | bool | `false` | Enable PodDisruptionBudget. Will always be enabled if replicas > 1. This non-declarative behavior should ideally be avoided, but changing it now would be breaking. |
 | backgroundController.podDisruptionBudget.minAvailable | int | `1` | Configures the minimum available pods for disruptions. Cannot be used if `maxUnavailable` is set. |
@@ -684,7 +684,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | cleanupController.nodeAffinity | object | `{}` | Node affinity constraints. |
 | cleanupController.topologySpreadConstraints | list | `[]` | Topology spread constraints. |
 | cleanupController.podSecurityContext | object | `{}` | Security context for the pod |
-| cleanupController.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the containers |
+| cleanupController.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the containers. UID/GID are unset by default so platforms such as OpenShift can assign them. |
 | cleanupController.lifecycle | object | `{}` | Container lifecycle hooks (e.g. a preStop sleep for graceful shutdown). The sleep action requires Kubernetes 1.30+. |
 | cleanupController.podDisruptionBudget.enabled | bool | `false` | Enable PodDisruptionBudget. Will always be enabled if replicas > 1. This non-declarative behavior should ideally be avoided, but changing it now would be breaking. |
 | cleanupController.podDisruptionBudget.minAvailable | int | `1` | Configures the minimum available pods for disruptions. Cannot be used if `maxUnavailable` is set. |
@@ -780,7 +780,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | reportsController.nodeAffinity | object | `{}` | Node affinity constraints. |
 | reportsController.topologySpreadConstraints | list | `[]` | Topology spread constraints. |
 | reportsController.podSecurityContext | object | `{}` | Security context for the pod |
-| reportsController.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the containers |
+| reportsController.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the containers. UID/GID are unset by default so platforms such as OpenShift can assign them. |
 | reportsController.lifecycle | object | `{}` | Container lifecycle hooks (e.g. a preStop sleep for graceful shutdown). The sleep action requires Kubernetes 1.30+. |
 | reportsController.podDisruptionBudget.enabled | bool | `false` | Enable PodDisruptionBudget. Will always be enabled if replicas > 1. This non-declarative behavior should ideally be avoided, but changing it now would be breaking. |
 | reportsController.podDisruptionBudget.minAvailable | int | `1` | Configures the minimum available pods for disruptions. Cannot be used if `maxUnavailable` is set. |
@@ -857,7 +857,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | webhooksCleanup.podLabels | object | `{}` | Pod labels. |
 | webhooksCleanup.podAnnotations | object | `{}` | Pod annotations. |
 | webhooksCleanup.nodeAffinity | object | `{}` | Node affinity constraints. |
-| webhooksCleanup.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the hook containers |
+| webhooksCleanup.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the hook containers. UID/GID are unset by default so platforms such as OpenShift can assign them. |
 | webhooksCleanup.resources.limits | object | `{"cpu":"100m","memory":"256Mi"}` | Pod resource limits |
 | webhooksCleanup.resources.requests | object | `{"cpu":"10m","memory":"64Mi"}` | Pod resource requests |
 | webhooksCleanup.serviceAccount.automountServiceAccountToken | bool | `true` | Toggle automounting of the ServiceAccount. When set to false, a projected service account token is used instead which provides time-limited and audience-bound tokens for improved security. |
@@ -877,7 +877,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | test.imagePullSecrets | list | `[]` | Image pull secrets |
 | test.resources.limits | object | `{"cpu":"100m","memory":"256Mi"}` | Pod resource limits |
 | test.resources.requests | object | `{"cpu":"10m","memory":"64Mi"}` | Pod resource requests |
-| test.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the test containers |
+| test.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the test containers. UID/GID are unset by default so platforms such as OpenShift can assign them. |
 | test.automountServiceAccountToken | bool | `true` | Toggle automounting of the ServiceAccount. When set to false, a projected service account token is used instead which provides time-limited and audience-bound tokens for improved security. |
 | test.projectedServiceAccountToken | object | `{"audience":"","expirationSeconds":3600}` | Projected service account token configuration (only used when automountServiceAccountToken is false) |
 | test.projectedServiceAccountToken.expirationSeconds | int | `3600` | Token expiration time in seconds. The kubelet will request a new token before the token expires. |

--- a/charts/kyverno/templates/reports-server/_helpers.tpl
+++ b/charts/kyverno/templates/reports-server/_helpers.tpl
@@ -27,8 +27,6 @@ Reports Server readiness init container
     - --namespace={{ .Release.Namespace }}
     - --timeout={{ .Values.reportsServer.readinessTimeout }}
   securityContext:
-    runAsUser: 65534
-    runAsGroup: 65534
     runAsNonRoot: true
     privileged: false
     allowPrivilegeEscalation: false

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -223,10 +223,8 @@ crds:
     # -- Node affinity constraints.
     nodeAffinity: {}
 
-    # -- Security context for the hook containers
+    # -- Security context for the hook containers. UID/GID are unset by default so platforms such as OpenShift can assign them.
     securityContext:
-      runAsUser: 65534
-      runAsGroup: 65534
       runAsNonRoot: true
       privileged: false
       allowPrivilegeEscalation: false
@@ -604,10 +602,8 @@ test:
       cpu: 10m
       memory: 64Mi
 
-  # -- Security context for the test containers
+  # -- Security context for the test containers. UID/GID are unset by default so platforms such as OpenShift can assign them.
   securityContext:
-    runAsUser: 65534
-    runAsGroup: 65534
     runAsNonRoot: true
     privileged: false
     allowPrivilegeEscalation: false
@@ -688,10 +684,8 @@ webhooksCleanup:
   # -- Node affinity constraints.
   nodeAffinity: {}
 
-  # -- Security context for the hook containers
+  # -- Security context for the hook containers. UID/GID are unset by default so platforms such as OpenShift can assign them.
   securityContext:
-    runAsUser: 65534
-    runAsGroup: 65534
     runAsNonRoot: true
     privileged: false
     allowPrivilegeEscalation: false
@@ -1288,10 +1282,8 @@ admissionController:
         cpu: 10m
         memory: 64Mi
 
-    # -- Container security context
+    # -- Container security context. UID/GID are unset by default so platforms such as OpenShift can assign them.
     securityContext:
-      runAsUser: 65534
-      runAsGroup: 65534
       runAsNonRoot: true
       privileged: false
       allowPrivilegeEscalation: false
@@ -1335,10 +1327,8 @@ admissionController:
         cpu: 100m
         memory: 128Mi
 
-    # -- Container security context
+    # -- Container security context. UID/GID are unset by default so platforms such as OpenShift can assign them.
     securityContext:
-      runAsUser: 65534
-      runAsGroup: 65534
       runAsNonRoot: true
       privileged: false
       allowPrivilegeEscalation: false
@@ -1713,10 +1703,8 @@ backgroundController:
   # -- Security context for the pod
   podSecurityContext: {}
 
-  # -- Security context for the containers
+  # -- Security context for the containers. UID/GID are unset by default so platforms such as OpenShift can assign them.
   securityContext:
-    runAsUser: 65534
-    runAsGroup: 65534
     runAsNonRoot: true
     privileged: false
     allowPrivilegeEscalation: false
@@ -2134,10 +2122,8 @@ cleanupController:
   # -- Security context for the pod
   podSecurityContext: {}
 
-  # -- Security context for the containers
+  # -- Security context for the containers. UID/GID are unset by default so platforms such as OpenShift can assign them.
   securityContext:
-    runAsUser: 65534
-    runAsGroup: 65534
     runAsNonRoot: true
     privileged: false
     allowPrivilegeEscalation: false
@@ -2477,10 +2463,8 @@ reportsController:
   # -- Security context for the pod
   podSecurityContext: {}
 
-  # -- Security context for the containers
+  # -- Security context for the containers. UID/GID are unset by default so platforms such as OpenShift can assign them.
   securityContext:
-    runAsUser: 65534
-    runAsGroup: 65534
     runAsNonRoot: true
     privileged: false
     allowPrivilegeEscalation: false

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -88654,9 +88654,7 @@ spec:
               - ALL
             privileged: false
             readOnlyRootFilesystem: true
-            runAsGroup: 65534
             runAsNonRoot: true
-            runAsUser: 65534
             seccompProfile:
               type: RuntimeDefault
           env:
@@ -88734,9 +88732,7 @@ spec:
               - ALL
             privileged: false
             readOnlyRootFilesystem: true
-            runAsGroup: 65534
             runAsNonRoot: true
-            runAsUser: 65534
             seccompProfile:
               type: RuntimeDefault
           ports:
@@ -88925,9 +88921,7 @@ spec:
               - ALL
             privileged: false
             readOnlyRootFilesystem: true
-            runAsGroup: 65534
             runAsNonRoot: true
-            runAsUser: 65534
             seccompProfile:
               type: RuntimeDefault
           volumeMounts:
@@ -89060,9 +89054,7 @@ spec:
               - ALL
             privileged: false
             readOnlyRootFilesystem: true
-            runAsGroup: 65534
             runAsNonRoot: true
-            runAsUser: 65534
             seccompProfile:
               type: RuntimeDefault
           startupProbe:
@@ -89228,9 +89220,7 @@ spec:
               - ALL
             privileged: false
             readOnlyRootFilesystem: true
-            runAsGroup: 65534
             runAsNonRoot: true
-            runAsUser: 65534
             seccompProfile:
               type: RuntimeDefault
           volumeMounts:


### PR DESCRIPTION

  ## Explanation

  Kyverno’s Helm chart currently assigns UID and GID `65534` to its containers. OpenShift namespaces use cluster-assigned UID ranges, so the `restricted-v2` Security Context Constraint rejects Kyverno pods when `65534` is outside the namespace’s permitted range.

  This bug fix removes the fixed UID and GID defaults, allowing OpenShift and other platforms to assign an appropriate non-root identity.
  Existing security hardening, including `runAsNonRoot`, dropped capabilities, read-only root filesystems, disabled privilege escalation,  and `RuntimeDefault` seccomp, remains unchanged.

  ## Related issue

  Closes #16160

  ## Milestone of this PR

  To be assigned by maintainers.

  ## Documentation (required for features)

  Not applicable as this is a Helm chart bug fix rather than a new feature. The generated chart README and ArtifactHub release note are updated in this PR.

  ## What type of PR is this

  /kind bug

  ## Proposed Changes

  - Remove the default `runAsUser: 65534` and `runAsGroup: 65534` values from:
    - CRD migration hooks
    - Helm test pods
    - webhook cleanup hooks
    - admission controller init and main containers
    - background controller
    - cleanup controller
    - reports controller
  - Remove the fixed UID/GID from the `wait-for-reports-server` readiness init container.
  - Preserve all existing container security hardening.
  - Preserve support for explicitly configured `runAsUser` and `runAsGroup` values.
  - Regenerate the Helm chart README and installation manifest.
  - Add an ArtifactHub release-note entry.

  This deliberately avoids OpenShift-specific detection or conditional template logic. When no UID is specified, OpenShift can assign one
  from the namespace’s permitted SCC range. Other Kubernetes platforms continue to enforce non-root execution through `runAsNonRoot: true`
  and the container image’s non-root default user.

  ### Proof Manifests

  The default rendered security context no longer specifies a fixed UID or GID:

  ```yaml
  securityContext:
    runAsNonRoot: true
    privileged: false
    allowPrivilegeEscalation: false
    readOnlyRootFilesystem: true
    capabilities:
      drop:
        - ALL
    seccompProfile:
      type: RuntimeDefault
  ```

  Explicit UID/GID configuration remains supported. The following test-only values were used to approximate an OpenShift-assigned high UID:

  ```yaml
  crds:
    migration:
      securityContext: &highUid
        runAsUser: 1000770000
        runAsGroup: 1000770000

  test:
    securityContext: *highUid

  webhooksCleanup:
    securityContext: *highUid

  admissionController:
    initContainer:
      securityContext: *highUid
    container:
      securityContext: *highUid

  backgroundController:
    securityContext: *highUid

  cleanupController:
    securityContext: *highUid

  reportsController:
    securityContext: *highUid
  ```

  Local verification performed:

  - Default Helm render:
    - 13 Kyverno-owned container contexts omitted `runAsUser` and `runAsGroup`.
    - All existing security-hardening fields remained present.
  - Reports-server-enabled render:
    - 17 Kyverno-owned contexts passed.
    - All four `wait-for-reports-server` init containers omitted fixed UID/GID values.
  - Explicit override render:
    - All 13 configurable contexts rendered UID/GID `1000770000`.
  - All 17 chart CI values files passed `helm lint`.
  - Relevant Helm documentation and installation-manifest generation was run twice and produced an identical diff.
  - Kubernetes v1.33.7 Kind cluster with Restricted Pod Security:
    - All four Kyverno controller deployments became Available at UID/GID `1000770000`.
    - All five Helm tests passed.
    - The CRD migration Job was observed and completed successfully at UID/GID `1000770000`.
    - Both pre-delete cleanup Jobs completed successfully at UID/GID `1000770000`.
    - Helm uninstall completed successfully.

  An actual OpenShift cluster was not available for local testing. Kind Restricted Pod Security and the arbitrary high-UID test validate runtime compatibility, but do not emulate OpenShift SCC identity injection.


  The full repository-wide `make codegen-all` target was not completed locally because the installed `client-wrapper` tool was stale and  refreshing it required unavailable network downloads. The generators relevant to this Helm change completed successfully and were verified as idempotent.

  ## Checklist

  - [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
  - [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I
  have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the
  process including adding proof manifests to this PR.
  - [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
    - No new Go unit test was added because this change affects Helm-rendered security contexts. It was covered with targeted render, lint,
    Restricted-PSS, high-UID, hook, and runtime tests.
  - [ ] This is a feature and I have added CLI tests that are applicable.
  - [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
  - [ ] My PR contains new or altered behavior to Kyverno and
    - [ ] CLI support should be added and my PR doesn't contain that functionality.

  ## Further Comments

  Both `runAsUser` and `runAsGroup` were removed to keep container identity assignment consistent. Removing only the UID would still impose
  a fixed Linux group which may conflict with platform-specific security policies.

  The fix removes an invalid cross-platform assumption without adding OpenShift-specific branches, flags, or template complexity.

  AI assistance disclosure: OpenAI Codex assisted with implementation, review, and local verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Helm chart deployments no longer require fixed container user and group IDs.
  - Platforms such as OpenShift can assign suitable IDs automatically while containers continue to run as non-root.
  - Updated security context defaults across Kyverno components and installation configuration for consistent behavior.

- **Documentation**
  - Updated chart documentation and the Artifact Hub changelog to reflect the revised security context defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->