### PR TITLE
fix(background): use dynamic restmapper and enable crd watcher

### DIFF
--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -552,6 +552,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | backgroundController.replicas | int | `nil` | Desired number of pods |
 | backgroundController.revisionHistoryLimit | int | `10` | The number of revisions to keep |
 | backgroundController.resyncPeriod | string | `"15m"` | Resync period for informers |
+| backgroundController.crdWatcher | bool | `false` | Enable/Disable custom resource watcher to invalidate cache |
 | backgroundController.podLabels | object | `{}` | Additional labels to add to each pod |
 | backgroundController.podAnnotations | object | `{}` | Additional annotations to add to each pod |
 | backgroundController.labels | object | `{}` | Deployment labels. |

--- a/charts/kyverno/templates/background-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/background-controller/clusterrole.yaml
@@ -26,6 +26,14 @@ rules:
       - customresourcedefinitions
     verbs:
       - get
+      {{- $crdWatcher := .Values.global.crdWatcher }}
+      {{- if hasKey .Values.backgroundController "crdWatcher" }}
+      {{- $crdWatcher = .Values.backgroundController.crdWatcher }}
+      {{- end }}
+      {{- if $crdWatcher }}
+      - list
+      - watch
+      {{- end }}
   - apiGroups:
       - kyverno.io
     resources:

--- a/charts/kyverno/templates/background-controller/deployment.yaml
+++ b/charts/kyverno/templates/background-controller/deployment.yaml
@@ -138,6 +138,11 @@ spec:
               {{- join "," $secretNames -}}
             {{- end }}
             - --resyncPeriod={{ .Values.backgroundController.resyncPeriod | default .Values.global.resyncPeriod }}
+            {{- $crdWatcher := .Values.global.crdWatcher }}
+            {{- if hasKey .Values.backgroundController "crdWatcher" }}
+            {{- $crdWatcher = .Values.backgroundController.crdWatcher }}
+            {{- end }}
+            - --crdWatcher={{ $crdWatcher }}
             {{- include "kyverno.features.flags" (pick (mergeOverwrite (deepCopy .Values.features) .Values.backgroundController.featuresOverride)
               "reporting"
               "configMapCaching"

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -1614,6 +1614,9 @@ backgroundController:
   # -- Resync period for informers
   resyncPeriod: 15m
 
+  # -- Enable/Disable custom resource watcher to invalidate cache
+  crdWatcher: false
+
   # -- Additional labels to add to each pod
   podLabels: {}
   # example.com/label: foo

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -88923,6 +88923,7 @@ spec:
             - --otelConfig=prometheus
             - --metricsPort=8000
             - --resyncPeriod=15m
+            - --crdWatcher=false
             - --enableConfigMapCaching=true
             - --controllerRuntimeMetricsAddress=:8080
             - --enableDeferredLoading=true

--- a/pkg/background/gpol/dynamic_watcher.go
+++ b/pkg/background/gpol/dynamic_watcher.go
@@ -12,13 +12,13 @@ import (
 	"github.com/kyverno/kyverno/pkg/background/common"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
+	restmapperutils "github.com/kyverno/kyverno/pkg/utils/restmapper"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
 	watchTools "k8s.io/client-go/tools/watch"
 )
@@ -55,8 +55,11 @@ type watcher struct {
 }
 
 func NewWatchManager(log logr.Logger, client dclient.Interface) *WatchManager {
-	apiGroupResources, _ := restmapper.GetAPIGroupResources(client.GetKubeClient().Discovery())
-	restMapper := restmapper.NewDiscoveryRESTMapper(apiGroupResources)
+	restMapper, err := restmapperutils.GetRESTMapper(client)
+	if err != nil || restMapper == nil {
+		log.Error(err, "failed to get RESTMapper, falling back to default mapper")
+		restMapper = meta.NewDefaultRESTMapper(nil)
+	}
 	return &WatchManager{
 		log:             log,
 		client:          client,

--- a/pkg/background/gpol/generate_controller.go
+++ b/pkg/background/gpol/generate_controller.go
@@ -19,12 +19,12 @@ import (
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	event "github.com/kyverno/kyverno/pkg/event"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
+	restmapperutils "github.com/kyverno/kyverno/pkg/utils/restmapper"
 	"go.uber.org/multierr"
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/restmapper"
 )
 
 // CELGenerateController is used to process URs that are generated as a result of an event from the trigger resource.
@@ -64,8 +64,11 @@ func NewCELGenerateController(
 	log logr.Logger,
 	configuration config.Configuration,
 ) *CELGenerateController {
-	apiGroupResources, _ := restmapper.GetAPIGroupResources(client.GetKubeClient().Discovery())
-	restMapper := restmapper.NewDiscoveryRESTMapper(apiGroupResources)
+	restMapper, err := restmapperutils.GetRESTMapper(client)
+	if err != nil || restMapper == nil {
+		log.Error(err, "failed to get RESTMapper, falling back to default mapper")
+		restMapper = meta.NewDefaultRESTMapper(nil)
+	}
 	return &CELGenerateController{
 		client:        client,
 		kyvernoClient: kyvernoClient,

--- a/pkg/clients/dclient/discovery.go
+++ b/pkg/clients/dclient/discovery.go
@@ -57,6 +57,7 @@ type IDiscovery interface {
 	GetGVKFromGVR(schema.GroupVersionResource) (schema.GroupVersionKind, error)
 	OpenAPISchema() (*openapiv2.Document, error)
 	CachedDiscoveryInterface() discovery.CachedDiscoveryInterface
+	RESTMapper() meta.RESTMapper
 	OnChanged(callback func())
 }
 
@@ -72,6 +73,10 @@ type serverResources struct {
 	mapper       meta.ResettableRESTMapper
 	mux          sync.RWMutex
 	callbacks    []func()
+}
+
+func (c *serverResources) RESTMapper() meta.RESTMapper {
+	return c.mapper
 }
 
 func (c *serverResources) OnChanged(callback func()) {

--- a/pkg/clients/dclient/discovery_test.go
+++ b/pkg/clients/dclient/discovery_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -202,4 +203,24 @@ func Test_findResourceFromResourceName(t *testing.T) {
 	assert.Equal(t, apiResource.Kind, podEvictionAPIResource.Kind)
 	assert.Equal(t, apiResource.Group, podEvictionAPIResource.Group)
 	assert.Equal(t, apiResource.Version, podEvictionAPIResource.Version)
+}
+
+type mockResettableMapper struct {
+	meta.RESTMapper
+}
+
+func (m *mockResettableMapper) Reset() {}
+
+func TestServerResources_RESTMapper(t *testing.T) {
+	mockMapper := &mockResettableMapper{
+		RESTMapper: meta.NewDefaultRESTMapper([]schema.GroupVersion{}),
+	}
+	sr := &serverResources{
+		mapper: mockMapper,
+	}
+	assert.NotNil(t, sr.RESTMapper())
+	assert.Same(t, mockMapper, sr.RESTMapper())
+
+	fakeDisco := &fakeDiscoveryClient{}
+	assert.Nil(t, fakeDisco.RESTMapper())
 }

--- a/pkg/clients/dclient/fake.go
+++ b/pkg/clients/dclient/fake.go
@@ -7,6 +7,7 @@ import (
 
 	openapiv2 "github.com/google/gnostic-models/openapiv2"
 	kubeutils "github.com/kyverno/kyverno/pkg/utils/kube"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -188,6 +189,10 @@ func (c *fakeDiscoveryClient) OpenAPISchema() (*openapiv2.Document, error) {
 }
 
 func (c *fakeDiscoveryClient) CachedDiscoveryInterface() discovery.CachedDiscoveryInterface {
+	return nil
+}
+
+func (c *fakeDiscoveryClient) RESTMapper() meta.RESTMapper {
 	return nil
 }
 

--- a/pkg/utils/fuzz/fuzz_interface.go
+++ b/pkg/utils/fuzz/fuzz_interface.go
@@ -8,6 +8,7 @@ import (
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	openapiv2 "github.com/google/gnostic-models/openapiv2"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -222,6 +223,10 @@ func (fid FuzzIDiscovery) OpenAPISchema() (*openapiv2.Document, error) {
 }
 
 func (fid FuzzIDiscovery) CachedDiscoveryInterface() discovery.CachedDiscoveryInterface {
+	return nil
+}
+
+func (fid FuzzIDiscovery) RESTMapper() meta.RESTMapper {
 	return nil
 }
 

--- a/pkg/utils/restmapper/restmapper.go
+++ b/pkg/utils/restmapper/restmapper.go
@@ -10,6 +10,10 @@ import (
 )
 
 func GetRESTMapper(client dclient.Interface) (meta.RESTMapper, error) {
+	if client != nil && client.Discovery() != nil && client.Discovery().RESTMapper() != nil {
+		return client.Discovery().RESTMapper(), nil
+	}
+
 	var restMapper meta.RESTMapper
 
 	var apiGroupResources []*restmapper.APIGroupResources

--- a/pkg/utils/restmapper/restmapper_test.go
+++ b/pkg/utils/restmapper/restmapper_test.go
@@ -1,0 +1,49 @@
+package restmapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kyverno/kyverno/pkg/clients/dclient"
+)
+
+type mockDiscoveryWithMapper struct {
+	dclient.IDiscovery
+	mapper meta.RESTMapper
+}
+
+func (m *mockDiscoveryWithMapper) RESTMapper() meta.RESTMapper {
+	return m.mapper
+}
+
+type mockClientWithDiscovery struct {
+	dclient.Interface
+	disco dclient.IDiscovery
+}
+
+func (m *mockClientWithDiscovery) Discovery() dclient.IDiscovery {
+	return m.disco
+}
+
+func TestGetRESTMapper_WithClientMapper(t *testing.T) {
+	expectedMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+	client := &mockClientWithDiscovery{
+		disco: &mockDiscoveryWithMapper{
+			mapper: expectedMapper,
+		},
+	}
+
+	mapper, err := GetRESTMapper(client)
+	assert.NoError(t, err)
+	assert.Same(t, expectedMapper, mapper)
+}
+
+func TestGetRESTMapper_FallbackForFakeClient(t *testing.T) {
+	client := dclient.NewEmptyFakeClient()
+	mapper, err := GetRESTMapper(client)
+	assert.NoError(t, err)
+	assert.NotNil(t, mapper)
+}


### PR DESCRIPTION

## Explanation

This PR fixes an issue where Kyverno's `background-controller` fails to recognize Custom Resource Definitions (CRDs) that are installed or updated after the controller has already started up. When generating resources or watching CRDs dynamically, the controller previously created a static snapshot of cluster resources that never refreshed or invalidated upon CRD changes. Additionally, the `--crdWatcher` flag was not exposed or enabled in the background-controller Helm chart and deployment manifests.

This PR represents a **fix of existing behavior** by:
1. Exposing the dynamic, resettable RESTMapper already maintained by `dclient` so that `background-controller` automatically refreshes its resource mappings when CRDs are created or updated.
2. Exposing and enabling the `--crdWatcher` flag and required RBAC permissions (`list`, `watch` on `customresourcedefinitions`) in the Helm chart.

## Related issue

Closes #17374

## Milestone of this PR

<!-- Add the milestone label by commenting /milestone 1.x.x -->

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno. 
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:
  <!-- https://github.com/kyverno/website/pull/123 -->

## What type of PR is this

/kind bug

## Proposed Changes

- **Expose Dynamic RESTMapper in `dclient`**:
  - Added `RESTMapper() meta.RESTMapper` to `IDiscovery` in `pkg/clients/dclient/discovery.go`.
  - Returned the underlying `c.mapper` (a `meta.ResettableRESTMapper` that resets on CRD watcher events and discovery polling).
  - Added stubs for `fakeDiscoveryClient` and `FuzzIDiscovery`.
- **Wire dynamic RESTMapper into utility**:
  - Updated `pkg/utils/restmapper/restmapper.go` (`GetRESTMapper`) to return `client.Discovery().RESTMapper()` when available.
- **Use dynamic RESTMapper in `background-controller`**:
  - Replaced the static `restmapper.NewDiscoveryRESTMapper(apiGroupResources)` calls in `pkg/background/gpol/dynamic_watcher.go` and `pkg/background/gpol/generate_controller.go` with `restmapperutils.GetRESTMapper(client)`.
- **Helm Chart & RBAC**:
  - Added `backgroundController.crdWatcher: false` in `charts/kyverno/values.yaml` and documented it in `charts/kyverno/README.md`.
  - Added `- --crdWatcher={{ .Values.backgroundController.crdWatcher | default .Values.global.crdWatcher }}` to `charts/kyverno/templates/background-controller/deployment.yaml`.
  - Added `list` and `watch` permissions for `customresourcedefinitions` in `charts/kyverno/templates/background-controller/clusterrole.yaml` when `crdWatcher` is enabled.
- **Unit Tests**:
  - Added unit tests in `pkg/utils/restmapper/restmapper_test.go` and `pkg/clients/dclient/discovery_test.go`.

### Proof Manifests

# 1. Custom Resource Definition (installed after startup)

```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: dynamicconfigs.example.com
spec:
  group: example.com
  names:
    kind: DynamicConfig
    listKind: DynamicConfigList
    plural: dynamicconfigs
    singular: dynamicconfig
  scope: Namespaced
  versions:
  - name: v1
    served: true
    storage: true
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              data:
                type: string
```

# 2. Trigger Resource & Kyverno Generate Policy

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: generate-dynamic-config
spec:
  rules:
  - name: generate-on-namespace
    match:
      any:
      - resources:
          kinds:
          - Namespace
    generate:
      apiVersion: example.com/v1
      kind: DynamicConfig
      name: default-config
      namespace: "{{request.object.metadata.name}}"
      synchronize: true
      data:
        spec:
          data: "initialized"
```

# 3. Unit Test Verification Results

```text
=== RUN   TestGetRESTMapper_WithClientMapper
--- PASS: TestGetRESTMapper_WithClientMapper (0.00s)
=== RUN   TestGetRESTMapper_FallbackForFakeClient
--- PASS: TestGetRESTMapper_FallbackForFakeClient (0.00s)
PASS
ok  	github.com/kyverno/kyverno/pkg/utils/restmapper	(cached)

=== RUN   TestServerResources_RESTMapper
--- PASS: TestServerResources_RESTMapper (0.00s)
PASS
ok  	github.com/kyverno/kyverno/pkg/clients/dclient	(cached)

=== RUN   TestNewWatchManager
--- PASS: TestNewWatchManager (0.00s)
=== RUN   TestSyncWatchers
--- PASS: TestSyncWatchers (0.00s)
PASS
ok  	github.com/kyverno/kyverno/pkg/background/gpol	(cached)
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

`dclient.serverResources` already establishes a watcher and periodic poll on CRDs that calls `mapper.Reset()`. Rather than creating separate watchers or duplicating caching logic in `background-controller`, this PR simply exposes that existing dynamic mapper through `dclient.IDiscovery` and plugs it into `restmapperutils.GetRESTMapper(client)`. This minimizes memory overhead and prevents redundant discovery calls against the Kubernetes API server.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable custom resource watcher for the background controller, disabled by default.
  - The setting can inherit the global watcher configuration when not explicitly specified.
  - When enabled, the watcher detects custom resource definition changes and invalidates cached data.

- **Bug Fixes**
  - Improved REST mapper reuse and fallback behavior for more reliable resource discovery.

- **Documentation**
  - Documented the new watcher setting in the Helm chart values and README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->