### PR TITLE
fix(ivpol): surface image-verification setup errors instead of masking them as failures

### DIFF
--- a/pkg/cel/libs/imageverify/impl.go
+++ b/pkg/cel/libs/imageverify/impl.go
@@ -41,7 +41,7 @@ type ivfuncs struct {
 	creds           *v1beta1.Credentials
 	imgRules        []compiler.MatchImageReference
 	attestationList map[string]v1beta1.Attestation
-	cosignVerifier  *cosign.Verifier
+	cosignVerifier  cosignImageVerifier
 	notaryVerifier  *notary.Verifier
 	ivCache         imageverifycache.Client
 	authOpts        []remote.Option
@@ -61,6 +61,13 @@ type ivfuncs struct {
 	// never completes the write -- so it would never get a real cache hit
 	// again, defeating caching entirely for that common case.
 	pendingIntotoRestores map[string]map[string][]byte
+}
+
+// cosignImageVerifier is the subset of the cosign verifier used here, as an
+// interface so tests can inject a fake for the setup-error path.
+type cosignImageVerifier interface {
+	VerifyImageSignature(ctx context.Context, image *imagedataloader.ImageData, attestor *v1beta1.Attestor) error
+	VerifyAttestationSignature(ctx context.Context, image *imagedataloader.ImageData, attestation *v1beta1.Attestation, attestor *v1beta1.Attestor) error
 }
 
 func ImageVerifyCELFuncs(
@@ -176,6 +183,9 @@ func (f *ivfuncs) verify_image_signature_string_stringarray(image ref.Val, attes
 			if attestor.IsCosign() {
 				f.logger.V(4).Info("verifying image signature", "image", image, "attestor", attestor.Name, "type", "cosign")
 				if err := f.cosignVerifier.VerifyImageSignature(ctx, img, &attestor); err != nil {
+					if cosign.IsSetup(err) {
+						return types.NewErr("failed to verify image signature: %v", err)
+					}
 					f.logger.V(6).Info("image signature verification failed", "image", image, "attestor", attestor.Name, "type", "cosign", "error", err)
 				} else {
 					f.logger.V(4).Info("image signature verified", "image", image, "attestor", attestor.Name, "type", "cosign")
@@ -272,6 +282,11 @@ func (f *ivfuncs) verify_image_attestations_string_string_stringarray(args ...re
 			if attestor.IsCosign() {
 				f.logger.V(4).Info("verifying attestation signature", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "cosign")
 				if err := f.cosignVerifier.VerifyAttestationSignature(ctx, img, &attest, &attestor); err != nil {
+					// Setup errors mean verification could not run at all;
+					// surface them as evaluation errors so failurePolicy applies.
+					if cosign.IsSetup(err) {
+						return types.NewErr("attestation signature verification failed for %s (%s): %v", image, attestation, err)
+					}
 					f.logger.V(6).Info("attestation signature verification failed", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "cosign", "error", err)
 				} else {
 					f.logger.V(4).Info("attestation signature verified", "image", image, "attestation", attestation, "attestor", attestor.Name, "type", "cosign")

--- a/pkg/cel/libs/imageverify/impl_setup_error_test.go
+++ b/pkg/cel/libs/imageverify/impl_setup_error_test.go
@@ -1,0 +1,110 @@
+package imageverify
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	"github.com/kyverno/kyverno/pkg/image/verifiers/ivpol/cosign"
+	"github.com/kyverno/sdk/extensions/imagedataloader"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeImageContext returns an empty ImageData without touching a registry so
+// the CEL functions reach the verifier call hermetically.
+type fakeImageContext struct{}
+
+func (fakeImageContext) AddImages(ctx context.Context, images []string, authOpts []remote.Option, nameOpts []name.Option) error {
+	return nil
+}
+
+func (fakeImageContext) Get(ctx context.Context, image string, authOpts []remote.Option, nameOpts []name.Option) (*imagedataloader.ImageData, error) {
+	return &imagedataloader.ImageData{}, nil
+}
+
+// fakeCosignVerifier returns a fixed error from both verification methods.
+type fakeCosignVerifier struct {
+	err error
+}
+
+func (f fakeCosignVerifier) VerifyImageSignature(ctx context.Context, image *imagedataloader.ImageData, attestor *v1beta1.Attestor) error {
+	return f.err
+}
+
+func (f fakeCosignVerifier) VerifyAttestationSignature(ctx context.Context, image *imagedataloader.ImageData, attestation *v1beta1.Attestation, attestor *v1beta1.Attestor) error {
+	return f.err
+}
+
+func newSetupErrorFuncs(t *testing.T, verifyErr error) *ivfuncs {
+	t.Helper()
+	return &ivfuncs{
+		Adapter:        types.DefaultTypeAdapter,
+		logger:         logr.Discard(),
+		imgCtx:         fakeImageContext{},
+		policy:         &v1beta1.ImageValidatingPolicy{},
+		cosignVerifier: fakeCosignVerifier{err: verifyErr},
+		attestationList: map[string]v1beta1.Attestation{
+			"vsa": {
+				Name:   "vsa",
+				InToto: &v1beta1.InToto{Type: "https://slsa.dev/verification_summary/v1"},
+			},
+		},
+		verifications: NewImageVerificationResults(),
+	}
+}
+
+func cosignAttestors() []v1beta1.Attestor {
+	return []v1beta1.Attestor{{Name: "producer", Cosign: &v1beta1.Cosign{}}}
+}
+
+// A cosign setup error must surface as a CEL evaluation error (RuleStatusError),
+// not a silent verified-count of 0, so failurePolicy applies and the cause is
+// diagnosable.
+func Test_impl_verify_image_signature_setup_error_surfaces_as_cel_error(t *testing.T) {
+	f := newSetupErrorFuncs(t, cosign.Setup(errors.New("failed to build cosign verification opts")))
+
+	out := f.verify_image_signature_string_stringarray(f.NativeToValue("ghcr.io/org/img:tag"), f.NativeToValue(cosignAttestors()))
+
+	assert.True(t, types.IsError(out), "expected a CEL error for a setup failure, got: %v", out.Value())
+}
+
+// A genuine (non-setup) verification failure must keep the existing behavior: a
+// verified-count of 0, never a CEL error.
+func Test_impl_verify_image_signature_non_setup_error_returns_zero(t *testing.T) {
+	f := newSetupErrorFuncs(t, errors.New("signature not found"))
+
+	out := f.verify_image_signature_string_stringarray(f.NativeToValue("ghcr.io/org/img:tag"), f.NativeToValue(cosignAttestors()))
+
+	assert.False(t, types.IsError(out), "a genuine verification failure must not be a CEL error: %v", out.Value())
+	assert.Equal(t, int64(0), out.Value())
+}
+
+func Test_impl_verify_attestation_signature_setup_error_surfaces_as_cel_error(t *testing.T) {
+	f := newSetupErrorFuncs(t, cosign.Setup(errors.New("failed to build cosign verification opts")))
+
+	out := f.verify_image_attestations_string_string_stringarray(
+		f.NativeToValue("ghcr.io/org/img:tag"),
+		f.NativeToValue("vsa"),
+		f.NativeToValue(cosignAttestors()),
+	)
+
+	assert.True(t, types.IsError(out), "expected a CEL error for a setup failure, got: %v", out.Value())
+}
+
+func Test_impl_verify_attestation_signature_non_setup_error_returns_zero(t *testing.T) {
+	f := newSetupErrorFuncs(t, errors.New("attestation not found"))
+
+	out := f.verify_image_attestations_string_string_stringarray(
+		f.NativeToValue("ghcr.io/org/img:tag"),
+		f.NativeToValue("vsa"),
+		f.NativeToValue(cosignAttestors()),
+	)
+
+	assert.False(t, types.IsError(out), "a genuine verification failure must not be a CEL error: %v", out.Value())
+	assert.Equal(t, int64(0), out.Value())
+}

--- a/pkg/image/verifiers/ivpol/cosign/classify_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/classify_test.go
@@ -1,0 +1,69 @@
+package cosign
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNoBundle(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"no matching attestations (empty referrers index)", &cosign.ErrNoMatchingAttestations{}, true},
+		{"image tag not found", &cosign.ErrImageTagNotFound{}, true},
+		{"wrapped no matching attestations", fmt.Errorf("detect: %w", &cosign.ErrNoMatchingAttestations{}), true},
+		{"transport/infra error", errors.New("dial tcp: connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isNoBundle(tt.err))
+		})
+	}
+}
+
+func TestIsInfraError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"registry HTTP error", &transport.Error{StatusCode: 403}, true},
+		{"tls unknown authority", x509.UnknownAuthorityError{}, true},
+		{"url error", &url.Error{Op: "Get", URL: "https://ghcr.io", Err: errors.New("boom")}, true},
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"wrapped registry error", fmt.Errorf("fetch: %w", &transport.Error{StatusCode: 500}), true},
+		{"genuine verification failure", &cosign.ErrNoMatchingSignatures{}, false},
+		{"generic verification failure", &cosign.VerificationFailure{}, false},
+		{"unknown/opaque error", errors.New("something went wrong"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isInfraError(tt.err))
+		})
+	}
+}
+
+// Only a recognizable infra failure becomes a SetupError; genuine and
+// unrecognized errors must fail closed.
+func TestClassifyVerifyError(t *testing.T) {
+	genuine := classifyVerifyError(&cosign.ErrNoMatchingSignatures{})
+	assert.False(t, IsSetup(genuine), "genuine verification failure must not be a SetupError")
+
+	unknown := classifyVerifyError(errors.New("some future cosign error we don't recognize"))
+	assert.False(t, IsSetup(unknown), "unknown errors must fail closed, not be treated as setup errors")
+
+	infra := classifyVerifyError(&transport.Error{StatusCode: 403})
+	assert.True(t, IsSetup(infra), "infrastructure failure must be a SetupError")
+}

--- a/pkg/image/verifiers/ivpol/cosign/errors.go
+++ b/pkg/image/verifiers/ivpol/cosign/errors.go
@@ -1,0 +1,26 @@
+package cosign
+
+import "errors"
+
+// SetupError marks a failure while preparing verification (CheckOpts, TUF/trust
+// material, keys) rather than a genuine "not verified" result, so callers can
+// surface it as an evaluation error subject to failurePolicy.
+type SetupError struct{ Err error }
+
+func (e *SetupError) Error() string { return e.Err.Error() }
+
+func (e *SetupError) Unwrap() error { return e.Err }
+
+// Setup wraps err as a SetupError. It returns nil when err is nil.
+func Setup(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &SetupError{Err: err}
+}
+
+// IsSetup reports whether err is (or wraps) a SetupError.
+func IsSetup(err error) bool {
+	var s *SetupError
+	return errors.As(err, &s)
+}

--- a/pkg/image/verifiers/ivpol/cosign/errors_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/errors_test.go
@@ -1,0 +1,41 @@
+package cosign
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Locks in the Setup/IsSetup contract that pkg/cel/libs/imageverify/impl.go
+// relies on to tell an infrastructure/setup failure (surface as an evaluation
+// error so failurePolicy applies) from a genuine "not verified" result.
+func TestSetupError(t *testing.T) {
+	t.Run("Setup(nil) is nil", func(t *testing.T) {
+		assert.NoError(t, Setup(nil))
+	})
+
+	t.Run("IsSetup is true for a wrapped setup error", func(t *testing.T) {
+		err := Setup(errors.New("tuf unreachable"))
+		assert.True(t, IsSetup(err))
+		assert.EqualError(t, err, "tuf unreachable")
+	})
+
+	t.Run("IsSetup is false for a plain error", func(t *testing.T) {
+		assert.False(t, IsSetup(errors.New("no matching attestations")))
+		assert.False(t, IsSetup(nil))
+	})
+
+	t.Run("IsSetup follows the wrap chain", func(t *testing.T) {
+		err := fmt.Errorf("outer: %w", Setup(errors.New("inner")))
+		assert.True(t, IsSetup(err))
+	})
+
+	t.Run("Unwrap returns the cause", func(t *testing.T) {
+		cause := errors.New("cause")
+		var se *SetupError
+		assert.True(t, errors.As(Setup(cause), &se))
+		assert.Equal(t, cause, se.Unwrap())
+	})
+}

--- a/pkg/image/verifiers/ivpol/cosign/verifier.go
+++ b/pkg/image/verifiers/ivpol/cosign/verifier.go
@@ -2,9 +2,14 @@ package cosign
 
 import (
 	"context"
+	"crypto/x509"
+	stderrors "errors"
 	"fmt"
+	"net"
+	"net/url"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/logging"
 	"github.com/kyverno/sdk/extensions/imagedataloader"
@@ -35,9 +40,13 @@ func (v *Verifier) buildCheckOptsWithBundleDetection(ctx context.Context, attest
 		return nil, err
 	}
 
-	// Auto-detect if new bundle format (cosign v3) is actually present
+	// Detect the cosign v3 bundle format. A benign "no bundle" result falls back
+	// to the legacy format; any other error is an infra failure and must surface.
 	newBundles, _, err := cosign.GetBundles(ctx, image.NameRef(), cOpts.RegistryClientOpts)
-	bundleDetected := len(newBundles) > 0 && err == nil
+	if err != nil && !isNoBundle(err) {
+		return nil, errors.Wrapf(err, "failed to detect cosign bundle format")
+	}
+	bundleDetected := len(newBundles) > 0
 	cOpts.NewBundleFormat = bundleDetected
 	if bundleDetected && shouldUseSignedTimestamps(cOpts.IgnoreTlog, cOpts.UseSignedTimestamps, cOpts.TrustedMaterial) {
 		cOpts.UseSignedTimestamps = true
@@ -68,6 +77,48 @@ func shouldUseSignedTimestamps(ignoreTlog, useSignedTimestamps bool, trustedMate
 	return ignoreTlog && !useSignedTimestamps && trustedMaterial != nil
 }
 
+// isNoBundle reports whether a GetBundles error is a benign "no v3 bundle"
+// result (empty referrers index or missing tag) rather than an infra failure.
+func isNoBundle(err error) bool {
+	var noBundles *cosign.ErrNoMatchingAttestations
+	var tagNotFound *cosign.ErrImageTagNotFound
+	return stderrors.As(err, &noBundles) || stderrors.As(err, &tagNotFound)
+}
+
+// classifyVerifyError tags a verify-call failure as a SetupError only when it is
+// a recognizable infrastructure failure; anything else (including unrecognized
+// errors) is treated as a genuine verification failure and fails closed.
+func classifyVerifyError(err error) error {
+	wrapped := errors.Wrapf(err, "failed to verify cosign signatures")
+	if isInfraError(err) {
+		return Setup(wrapped)
+	}
+	return wrapped
+}
+
+// isInfraError reports whether err is a registry/network/TLS/timeout failure.
+// It matches only on the transport type and the standard library (not cosign's
+// verification-error types) so it stays stable across cosign upgrades.
+func isInfraError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var te *transport.Error // registry HTTP errors (401/403/5xx/429...)
+	var netErr net.Error
+	var urlErr *url.Error
+	var unknownAuthority x509.UnknownAuthorityError
+	var certInvalid x509.CertificateInvalidError
+	var hostErr x509.HostnameError
+	return stderrors.As(err, &te) ||
+		stderrors.As(err, &netErr) ||
+		stderrors.As(err, &urlErr) ||
+		stderrors.As(err, &unknownAuthority) ||
+		stderrors.As(err, &certInvalid) ||
+		stderrors.As(err, &hostErr) ||
+		stderrors.Is(err, context.DeadlineExceeded) ||
+		stderrors.Is(err, context.Canceled)
+}
+
 func (v *Verifier) VerifyImageSignature(ctx context.Context, image *imagedataloader.ImageData, attestor *policiesv1beta1.Attestor) error {
 	if attestor.Cosign == nil {
 		return fmt.Errorf("cosign verifier only supports cosign attestor")
@@ -78,7 +129,7 @@ func (v *Verifier) VerifyImageSignature(ctx context.Context, image *imagedataloa
 
 	cOpts, err := v.buildCheckOptsWithBundleDetection(ctx, attestor.Cosign, image)
 	if err != nil {
-		err := errors.Wrapf(err, "failed to build cosign verification opts")
+		err := Setup(errors.Wrapf(err, "failed to build cosign verification opts"))
 		logger.Error(err, "image verification failed")
 		return err
 	}
@@ -99,7 +150,7 @@ func (v *Verifier) VerifyImageSignature(ctx context.Context, image *imagedataloa
 		sigs, verified, err = cosign.VerifyImageSignatures(ctx, image.NameRef(), cOpts)
 	}
 	if err != nil {
-		err := errors.Wrapf(err, "failed to verify cosign signatures")
+		err := classifyVerifyError(err)
 		logger.Error(err, "image verification failed")
 		return err
 	} else if !verified {
@@ -145,7 +196,7 @@ func (v *Verifier) VerifyAttestationSignature(ctx context.Context, image *imaged
 
 	cOpts, err := v.buildCheckOptsWithBundleDetection(ctx, attestor.Cosign, image)
 	if err != nil {
-		err := errors.Wrapf(err, "failed to build cosign verification opts")
+		err := Setup(errors.Wrapf(err, "failed to build cosign verification opts"))
 		logger.Error(err, "image verification failed")
 		return err
 	}
@@ -155,7 +206,7 @@ func (v *Verifier) VerifyAttestationSignature(ctx context.Context, image *imaged
 
 	sigs, verified, err := cosign.VerifyImageAttestations(ctx, image.NameRef(), cOpts)
 	if err != nil {
-		err := errors.Wrapf(err, "failed to verify cosign signatures")
+		err := classifyVerifyError(err)
 		logger.Error(err, "image verification failed")
 		return err
 	} else if !verified {

--- a/pkg/webhooks/resource/ivpol/handler.go
+++ b/pkg/webhooks/resource/ivpol/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/engine/mutate/patch"
 	"github.com/kyverno/kyverno/pkg/event"
 	eval "github.com/kyverno/kyverno/pkg/image/verification/evaluator"
+	"github.com/kyverno/kyverno/pkg/toggle"
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	jsonutils "github.com/kyverno/kyverno/pkg/utils/json"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
@@ -113,7 +114,7 @@ func (h *handler) validate(ctx context.Context, logger logr.Logger, admissionReq
 	group.Start(func() {
 		h.audit(ctx, logger, admissionRequest, request, response)
 	})
-	return h.validationResponse(request, response)
+	return h.validationResponse(ctx, request, response)
 }
 
 func (h *handler) mutationResponse(request celengine.EngineRequest, response eval.ImageVerifyEngineResponse, rawPatches []byte) handlers.AdmissionResponse {
@@ -171,16 +172,27 @@ func (h *handler) mutationEvents(ctx context.Context, response eval.ImageVerifyE
 	h.admissionEvent(ctx, responses, blocked)
 }
 
-func (h *handler) validationResponse(request celengine.EngineRequest, response eval.ImageVerifyEngineResponse) handlers.AdmissionResponse {
+func (h *handler) validationResponse(ctx context.Context, request celengine.EngineRequest, response eval.ImageVerifyEngineResponse) handlers.AdmissionResponse {
+	forceFailurePolicyIgnore := toggle.FromContext(ctx).ForceFailurePolicyIgnore()
 	var errs []error
 	var warnings []string
 	for _, policy := range response.Policies {
+		// errorWarned prevents the Warn branch from emitting a duplicate warning
+		// for a RuleStatusError already warned under Deny.
+		errorWarned := false
 		if policy.Actions.Has(admissionregistrationv1.Deny) {
 			switch policy.Result.Status() {
 			case engineapi.RuleStatusFail:
 				errs = append(errs, fmt.Errorf("Policy %s failed: %s", policy.Policy.GetName(), policy.Result.Message()))
 			case engineapi.RuleStatusError:
-				errs = append(errs, fmt.Errorf("Policy %s error: %s", policy.Policy.GetName(), policy.Result.Message()))
+				// Evaluation errors honor failurePolicy: warn and admit under
+				// Ignore, deny under Fail.
+				if policy.Policy.GetFailurePolicy(forceFailurePolicyIgnore) == admissionregistrationv1.Ignore {
+					warnings = append(warnings, fmt.Sprintf("Policy %s error (ignored by failurePolicy): %s", policy.Policy.GetName(), policy.Result.Message()))
+					errorWarned = true
+				} else {
+					errs = append(errs, fmt.Errorf("Policy %s error: %s", policy.Policy.GetName(), policy.Result.Message()))
+				}
 			}
 		}
 		if policy.Actions.Has(admissionregistrationv1.Warn) {
@@ -188,7 +200,9 @@ func (h *handler) validationResponse(request celengine.EngineRequest, response e
 			case engineapi.RuleStatusFail:
 				warnings = append(warnings, fmt.Sprintf("Policy %s failed: %s", policy.Policy.GetName(), policy.Result.Message()))
 			case engineapi.RuleStatusError:
-				warnings = append(warnings, fmt.Sprintf("Policy %s error: %s", policy.Policy.GetName(), policy.Result.Message()))
+				if !errorWarned {
+					warnings = append(warnings, fmt.Sprintf("Policy %s error: %s", policy.Policy.GetName(), policy.Result.Message()))
+				}
 			}
 		}
 	}

--- a/pkg/webhooks/resource/ivpol/handler_test.go
+++ b/pkg/webhooks/resource/ivpol/handler_test.go
@@ -1,0 +1,158 @@
+package ivpol
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	celengine "github.com/kyverno/kyverno/pkg/cel/engine"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	eval "github.com/kyverno/kyverno/pkg/image/verification/evaluator"
+	"github.com/kyverno/kyverno/pkg/toggle"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// forceIgnoreToggles is a Toggles implementation that only forces failurePolicy
+// to Ignore; every other toggle is off. validationResponse consults only
+// ForceFailurePolicyIgnore.
+type forceIgnoreToggles struct{}
+
+func (forceIgnoreToggles) ProtectManagedResources() bool           { return false }
+func (forceIgnoreToggles) ForceFailurePolicyIgnore() bool          { return true }
+func (forceIgnoreToggles) EnableDeferredLoading() bool             { return false }
+func (forceIgnoreToggles) GenerateValidatingAdmissionPolicy() bool { return false }
+func (forceIgnoreToggles) GenerateMutatingAdmissionPolicy() bool   { return false }
+func (forceIgnoreToggles) DumpMutatePatches() bool                 { return false }
+func (forceIgnoreToggles) AutogenV2() bool                         { return false }
+func (forceIgnoreToggles) AllowHTTPInNamespacedPolicies() bool     { return false }
+
+func failurePolicyPtr(f admissionregistrationv1.FailurePolicyType) *admissionregistrationv1.FailurePolicyType {
+	return &f
+}
+
+func ivpolWithFailurePolicy(name string, fp *admissionregistrationv1.FailurePolicyType) *policiesv1beta1.ImageValidatingPolicy {
+	return &policiesv1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       policiesv1beta1.ImageValidatingPolicySpec{FailurePolicy: fp},
+	}
+}
+
+func denyResponse(result *engineapi.RuleResponse, fp *admissionregistrationv1.FailurePolicyType) eval.ImageVerifyEngineResponse {
+	return eval.ImageVerifyEngineResponse{
+		Policies: []eval.ImageVerifyPolicyResponse{
+			{
+				Policy:  ivpolWithFailurePolicy("test-policy", fp),
+				Actions: sets.New(admissionregistrationv1.Deny),
+				Result:  *result,
+			},
+		},
+	}
+}
+
+func TestValidationResponse_FailurePolicyForErrors(t *testing.T) {
+	evalErr := errors.New("verification could not be performed")
+
+	tests := []struct {
+		name          string
+		result        *engineapi.RuleResponse
+		failurePolicy *admissionregistrationv1.FailurePolicyType
+		forceIgnore   bool
+		wantAllowed   bool
+		wantWarnings  int
+	}{
+		{
+			name:          "error under Deny with failurePolicy Ignore is admitted with a warning",
+			result:        engineapi.RuleError("test-rule", engineapi.Validation, "image verification failed", evalErr, nil),
+			failurePolicy: failurePolicyPtr(admissionregistrationv1.Ignore),
+			wantAllowed:   true,
+			wantWarnings:  1,
+		},
+		{
+			name:          "error under Deny with failurePolicy Fail is denied",
+			result:        engineapi.RuleError("test-rule", engineapi.Validation, "image verification failed", evalErr, nil),
+			failurePolicy: failurePolicyPtr(admissionregistrationv1.Fail),
+			wantAllowed:   false,
+			wantWarnings:  0,
+		},
+		{
+			name:          "error under Deny defaults to Fail (nil failurePolicy) and is denied",
+			result:        engineapi.RuleError("test-rule", engineapi.Validation, "image verification failed", evalErr, nil),
+			failurePolicy: nil,
+			wantAllowed:   false,
+			wantWarnings:  0,
+		},
+		{
+			name:          "genuine fail under Deny always denies regardless of failurePolicy Ignore",
+			result:        engineapi.RuleFail("test-rule", engineapi.Validation, "image is not signed", nil),
+			failurePolicy: failurePolicyPtr(admissionregistrationv1.Ignore),
+			wantAllowed:   false,
+			wantWarnings:  0,
+		},
+		{
+			name:          "error under Deny with forceFailurePolicyIgnore is admitted with a warning even when spec is Fail",
+			result:        engineapi.RuleError("test-rule", engineapi.Validation, "image verification failed", evalErr, nil),
+			failurePolicy: failurePolicyPtr(admissionregistrationv1.Fail),
+			forceIgnore:   true,
+			wantAllowed:   true,
+			wantWarnings:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.forceIgnore {
+				ctx = toggle.NewContext(ctx, forceIgnoreToggles{})
+			}
+
+			h := &handler{}
+			request := celengine.EngineRequest{
+				Request: admissionv1.AdmissionRequest{UID: "test-uid"},
+			}
+			response := denyResponse(tt.result, tt.failurePolicy)
+
+			got := h.validationResponse(ctx, request, response)
+
+			assert.Equal(t, tt.wantAllowed, got.Allowed)
+			assert.Len(t, got.Warnings, tt.wantWarnings)
+			if tt.wantAllowed {
+				assert.Nil(t, got.Result)
+			} else {
+				assert.NotNil(t, got.Result)
+			}
+		})
+	}
+}
+
+// A policy carrying both Deny and Warn actions must emit exactly one warning for
+// a RuleStatusError admitted under failurePolicy Ignore, not a duplicate from
+// each branch.
+func TestValidationResponse_DenyAndWarn_ErrorEmitsSingleWarning(t *testing.T) {
+	evalErr := errors.New("verification could not be performed")
+	result := engineapi.RuleError("test-rule", engineapi.Validation, "image verification failed", evalErr, nil)
+
+	response := eval.ImageVerifyEngineResponse{
+		Policies: []eval.ImageVerifyPolicyResponse{
+			{
+				Policy:  ivpolWithFailurePolicy("test-policy", failurePolicyPtr(admissionregistrationv1.Ignore)),
+				Actions: sets.New(admissionregistrationv1.Deny, admissionregistrationv1.Warn),
+				Result:  *result,
+			},
+		},
+	}
+
+	h := &handler{}
+	request := celengine.EngineRequest{
+		Request: admissionv1.AdmissionRequest{UID: "test-uid"},
+	}
+
+	got := h.validationResponse(context.Background(), request, response)
+
+	assert.True(t, got.Allowed)
+	assert.Len(t, got.Warnings, 1)
+}


### PR DESCRIPTION
<!--
Recommended PR title:
fix(ivpol): surface image-verification setup errors instead of masking them as failures
-->

## Explanation

`ImageValidatingPolicy` cosign verification swallows **setup/infrastructure
errors** and reports them as an ordinary verification **failure** instead of an
error. In `pkg/cel/libs/imageverify/impl.go`, any error returned by the cosign
verifier is turned into a verified-count of `0`, which conflates two very
different outcomes:

1. the artifact is genuinely not signed/attested (a real verification failure), and
2. verification could not be performed at all (a setup/infrastructure error... e.g.
   the admission controller cannot reach the Sigstore TUF/Fulcio/Rekor
   infrastructure to build cosign `CheckOpts`, or the registry Referrers API is
   unreachable during bundle-format detection).

Case 2 is silently reported as `result="fail"` (never `result="error"`). Because
that is returned inside a valid admission response, `failurePolicy: Ignore` does
**not** apply, the admission message is generic, and there is no way to
distinguish an outage from a real policy violation.

This reproduces the error-classification symptoms reported in #16678: on an egress-restricted cluster `verifyAttestationSignatures` returns 0 for a perfectly valid keyless attestation (the TUF root fetch is blocked), so the policy reports `result="fail"` (not `"error"`), the pod is denied, and `failurePolicy: Ignore` does not help... while `cosign verify-attestation` passes locally where egress works.

This PR classifies cosign failures at **three layers** so that a failure to
*perform* verification is always distinguishable from a genuine "not verified":

- tags cosign setup/opts-build failures as a distinct `SetupError`;
- surfaces **bundle-format detection** (`GetBundles`) infrastructure errors
  instead of silently falling back to the legacy format and misreporting them
  later as "not attested" (a benign empty referrers index or missing tag still
  falls back, unchanged);
- tags **verify-call** failures as `SetupError` only when they match a
  whitelist of recognizable infrastructure failures (registry transport, network,
  TLS, timeout); anything else - including unrecognized errors - fails closed as
  a verification failure.

Setup errors propagate as CEL evaluation errors (`result="error"`) with the real
cause. The IVP validating handler honors `failurePolicy` for such errors (block
only under `Fail`; warn and admit under `Ignore`), while genuine verification
failures still fail closed under `Deny` (no unsigned-image bypass).

## Related issue

Refs #16678

## Milestone of this PR

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
<!-- Bug fix for existing behavior - no documentation update required per pr_documentation.md -->

## What type of PR is this

/kind bug

## Proposed Changes

### Before this PR

- `pkg/cel/libs/imageverify/impl.go` (`verifyImageSignatures` /
  `verifyAttestationSignatures`) treated **every** verifier error identically:
  it logged the error and left the verified-count at `0`. A setup error (e.g.
  `failed to build cosign verification opts: failed to initialize TUF client …
  403 Forbidden`) therefore produced the same outcome as an unsigned image.
- `pkg/image/verifiers/ivpol/cosign/verifier.go`
  (`buildCheckOptsWithBundleDetection`) discarded the `GetBundles` error into a
  boolean (`len(newBundles) > 0 && err == nil`). A registry/auth/TLS failure
  during bundle detection silently set `NewBundleFormat = false` and fell back
  to the legacy format, later surfacing as an ambiguous `no matching
  attestations`. The verify-call error was wrapped generically, so a transient
  registry/transport error during verification was indistinguishable from a
  genuine "not signed".
- The CEL expression `… > 0` evaluated to false → `RuleStatusFail` →
  `result="fail"`, a generic admission message, and no `result="error"` metric.
- `pkg/webhooks/resource/ivpol/handler.go` (`validationResponse`) denied a `Deny`
  policy on **both** `RuleStatusFail` and `RuleStatusError`, ignoring
  `failurePolicy`, so `failurePolicy: Ignore` could not admit on an evaluation
  error.

### This PR

1. **Classify setup errors.** Add a `SetupError` type with `Setup()`/`IsSetup()`
   in `pkg/image/verifiers/ivpol/cosign/errors.go` and tag the
   `buildCheckOptsWithBundleDetection` failure as a `SetupError` in both
   `VerifyImageSignature` and `VerifyAttestationSignature`.
2. **Stop swallowing bundle-detection errors.** In
   `buildCheckOptsWithBundleDetection`, a `GetBundles` error now surfaces unless
   it is a benign "no v3 bundle present" result (`ErrNoMatchingAttestations` /
   `ErrImageTagNotFound`), which still falls back to the legacy format. This
   resolves the ambiguous `no matching attestations` outcome by failing at
   detection when the referrers index cannot be fetched.
3. **Classify verify-call errors.** Route verify-call failures through a helper
   that tags them as `SetupError` only when `isInfraError` recognizes an
   infrastructure failure (`transport.Error`, `net.Error`, `url.Error`, x509
   errors, `context.DeadlineExceeded`/`Canceled`). Matching on transport/stdlib
   types rather than cosign's verification-error types keeps the classification
   stable across cosign upgrades, and any unrecognized error fails closed as a
   verification failure.
4. **Surface them.** In `impl.go`, when the cosign verifier returns an error,
   propagate it as a CEL error (`types.NewErr`) if `cosign.IsSetup(err)` → the
   result is `RuleStatusError` (`result="error"`, real cause in the message).
   Genuine "not verified" results keep the existing behavior (`V(6)` log,
   count `0`). Applied to the cosign branches only; notary is unchanged.
5. **Honor failurePolicy.** In `validationResponse`, a `RuleStatusError` under a
   `Deny` action now respects the policy's `failurePolicy`: block only under
   `Fail`; under `Ignore`, surface a warning and admit. A single warning is
   emitted when a policy carries both `Deny` and `Warn` actions. This mirrors
   matchCondition-error handling (`evaluator/policy.go`) and
   ValidatingAdmissionPolicy semantics. `RuleStatusFail` still always denies
   under `Deny`.

### After this PR

| Outcome | Audit | Deny + `Ignore` | Deny + `Fail` |
|---|---|---|---|
| **setup/infra error** (opts build, bundle detection, verify transport) | admit, `result="error"`, real cause | **admit + warning** | **deny** (real cause) |
| **genuine "not verified"** | admit, `result="fail"` | **deny** | **deny** |

- Operators regain the `failurePolicy` fail-open/fail-closed choice for transient
  Sigstore/registry outages, and get the real cause instead of a generic message.
- Unsigned/unattested images still fail closed under `Deny`... no regression.

### Proof Manifests

The policy used to reproduce (a keyless VSA attestation on GHCR):

```yaml
apiVersion: policies.kyverno.io/v1
kind: ImageValidatingPolicy
metadata:
  name: require-vsa
spec:
  validationActions: [Audit]   # also reproduced with [Deny]
  failurePolicy: Ignore
  evaluation:
    background:
      enabled: false
  matchConstraints:
    resourceRules:
      - apiGroups: [""]
        apiVersions: ["v1"]
        operations: ["CREATE", "UPDATE"]
        resources: ["pods"]
  matchImageReferences:
    - glob: "ghcr.io/<org>/*"
  attestations:
    - name: vsa
      intoto:
        type: https://slsa.dev/verification_summary/v1
  attestors:
    - name: producer
      cosign:
        keyless:
          identities:
            - issuer: https://token.actions.githubusercontent.com
              subjectRegExp: <producer workflow SAN regex>
        ctlog:
          url: https://rekor.sigstore.dev
  validationConfigurations:
    mutateDigest: false
    verifyDigest: true
    required: true
  validations:
    - expression: >-
        images.containers.map(image,
          verifyAttestationSignatures(image, attestations.vsa, [attestors.producer])).all(e, e > 0)
      message: image must carry a verified VSA
```

Reproduced in-cluster (Kyverno v1.19.0) with the admission controller unable to
reach `tuf-repo-cdn.sigstore.dev`:

- **Before this PR** - Audit: event `require-vsa fail: image must carry a
  verified VSA`; metric `…execution_duration_seconds_count{policy_name="require-vsa",
  result="fail"}` increments while `result="error"` stays 0; the `kyverno.io/imageverify-outcomes` annotation has no entry (unchanged by this PR). Deny + `failurePolicy: Ignore`: the pod is **denied** (via the `…svc-ignore-…` webhook), so Ignore does not help.
- **After this PR** - same condition surfaces `result="error"` with the real
  cause (`… failed to initialize TUF client … 403 Forbidden`); Deny +
  `failurePolicy: Ignore` **admits** with a warning; Deny + `failurePolicy: Fail`
  **denies** with the real cause. A genuine "not verified" still denies under
  `Deny` regardless of `failurePolicy`. The `kyverno.io/imageverify-outcomes` still has no entry for 
  this error case.. that annotation path is out of scope here.

Unit tests proving the fix (all hermetic, no registry/network):

- `pkg/image/verifiers/ivpol/cosign/errors_test.go` - `Setup`/`IsSetup` contract
  (nil handling, `errors.As` wrap-chain, `Unwrap`).
- `pkg/image/verifiers/ivpol/cosign/classify_test.go` - `isNoBundle`,
  `isInfraError`, and `classifyVerifyError`: benign "no bundle" vs infra
  detection error; only recognizable infra errors (registry HTTP, TLS, url,
  timeout) are tagged `SetupError` while genuine verification failures and
  unknown errors fail closed (incl. wrapped-error chains).
- `pkg/cel/libs/imageverify/impl_setup_error_test.go` - with a fake image context
  and fake verifier: a setup error surfaces as a CEL error (`RuleStatusError`)
  for both `verifyImageSignatures` and `verifyAttestationSignatures`, while a
  non-setup error keeps count `0` (no bypass).
- `pkg/webhooks/resource/ivpol/handler_test.go` - error+Deny+Ignore →
  admit+warn; error+Deny+Fail → deny; error+Deny+nil (defaults to Fail) → deny;
  **genuine fail+Deny+Ignore → deny** (no bypass); error+Deny+Fail+
  `forceFailurePolicyIgnore` → admit+warn; Deny+Warn error emits a single
  warning.

## Checklist

<!--
Please mark any checkboxes that do not apply to this PR as [N/A].
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

- **Behavior change to note:** under `failurePolicy: Ignore`, evaluation errors
  now fail **open** (admit with a warning). This is the intended `failurePolicy`
  semantic, but it differs from the prior behavior where IVP denied on any error
  regardless of `failurePolicy`. Operators who want errors to keep blocking
  should set `failurePolicy: Fail`. Genuine verification failures still fail
  closed under `Deny` regardless of `failurePolicy`.
- Scope: cosign attestor paths only; notary is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image signature and attestation verification error handling by distinguishing infrastructure or setup failures from genuine verification failures.
  - Verification setup issues now produce diagnosable evaluation errors instead of being silently treated as zero successful verifications.
  - Failure policies are now correctly honored when verification cannot be completed: **Ignore** generates a warning, while **Fail** reports an error.
  - Prevented duplicate warnings when policies combine Deny and Warn actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->