### PR TITLE
fix: improve generate rule immutability error message

### DIFF
--- a/pkg/validation/policy/generate.go
+++ b/pkg/validation/policy/generate.go
@@ -1,11 +1,13 @@
 package policy
 
 import (
+	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"sort"
+	"strings"
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -31,8 +33,12 @@ func immutableGenerateFields(new, old kyvernov1.PolicyInterface) (string, error)
 		return "changes in the generate rule pattern could result in stale targets", nil
 	}
 
-	if !newRuleHashes.IsSuperset(oldRuleHashes) {
-		return "", errors.New("changes of immutable fields of a rule spec in a generate rule is disallowed")
+	changed, err := changedImmutableRules(oldRuleHashes, newRuleHashes)
+	if err != nil {
+		return "", err
+	}
+	if len(changed) > 0 {
+		return "", fmt.Errorf("changes of immutable fields of a rule spec in a generate rule is disallowed: %s; add a new rule instead of changing the existing one, or delete and recreate the policy", strings.Join(changed, ", "))
 	}
 
 	return "", nil
@@ -60,8 +66,11 @@ func resetMutableFields(rule kyvernov1.Rule, oldHasSynchronizingRule bool) (*kyv
 	return new, generation
 }
 
-func buildHashes(rules []kyvernov1.Rule, oldHasSynchronizingRule bool) (ruleHashes sets.Set[string], generationHashes sets.Set[string], _ error) {
-	ruleHashes, generationHashes = sets.New[string](), sets.New[string]()
+// buildHashes returns the hashes of the immutable part of every generate rule, keyed by hash and
+// mapped to the rule (after resetMutableFields) they were computed from, and the set of hashes of
+// the generate patterns.
+func buildHashes(rules []kyvernov1.Rule, oldHasSynchronizingRule bool) (ruleHashes map[string]*kyvernov1.Rule, generationHashes sets.Set[string], _ error) {
+	ruleHashes, generationHashes = map[string]*kyvernov1.Rule{}, sets.New[string]()
 
 	for _, rule := range rules {
 		if !rule.HasGenerate() {
@@ -80,9 +89,73 @@ func buildHashes(rules []kyvernov1.Rule, oldHasSynchronizingRule bool) (ruleHash
 			return ruleHashes, generationHashes, fmt.Errorf("failed to create hash from the generate rule %v", err)
 		}
 		hash = md5.Sum(data)
-		ruleHashes.Insert(hex.EncodeToString(hash[:]))
+		ruleHashes[hex.EncodeToString(hash[:])] = r
 	}
 	return ruleHashes, generationHashes, nil
+}
+
+// changedImmutableRules describes every old generate rule whose immutable fields have no identical
+// counterpart in the new policy: the rule name and, when a rule with the same name still exists, the
+// top-level fields that differ between the two rules after resetMutableFields.
+func changedImmutableRules(oldRuleHashes, newRuleHashes map[string]*kyvernov1.Rule) ([]string, error) {
+	newRulesByName := make(map[string]*kyvernov1.Rule, len(newRuleHashes))
+	for _, rule := range newRuleHashes {
+		newRulesByName[rule.Name] = rule
+	}
+
+	var changed []string
+	for hash, oldRule := range oldRuleHashes {
+		if _, ok := newRuleHashes[hash]; ok {
+			continue
+		}
+		newRule, ok := newRulesByName[oldRule.Name]
+		if !ok {
+			changed = append(changed, fmt.Sprintf("rule %q was removed or renamed", oldRule.Name))
+			continue
+		}
+		fields, err := changedRuleFields(oldRule, newRule)
+		if err != nil {
+			return nil, err
+		}
+		changed = append(changed, fmt.Sprintf("rule %q changed fields [%s]", oldRule.Name, strings.Join(fields, ", ")))
+	}
+	sort.Strings(changed)
+	return changed, nil
+}
+
+func changedRuleFields(oldRule, newRule *kyvernov1.Rule) ([]string, error) {
+	oldFields, err := ruleFields(oldRule)
+	if err != nil {
+		return nil, err
+	}
+	newFields, err := ruleFields(newRule)
+	if err != nil {
+		return nil, err
+	}
+	changed := sets.New[string]()
+	for name, value := range oldFields {
+		if !bytes.Equal(value, newFields[name]) {
+			changed.Insert(name)
+		}
+	}
+	for name := range newFields {
+		if _, ok := oldFields[name]; !ok {
+			changed.Insert(name)
+		}
+	}
+	return sets.List(changed), nil
+}
+
+func ruleFields(rule *kyvernov1.Rule) (map[string]json.RawMessage, error) {
+	data, err := json.Marshal(rule)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the generate rule %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the generate rule %v", err)
+	}
+	return fields, nil
 }
 
 func hasSynchronizingRule(rules []kyvernov1.Rule) bool {

--- a/pkg/validation/policy/validate_test.go
+++ b/pkg/validation/policy/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
@@ -2243,6 +2244,8 @@ func Test_GenerateFieldsUpdates(t *testing.T) {
 		newPolicy     []byte
 		expectedErr   bool
 		expectWarning bool
+		errContains   []string
+		errExcludes   []string
 	}{
 		{
 			name: "update-apiVersion",
@@ -3465,6 +3468,298 @@ func Test_GenerateFieldsUpdates(t *testing.T) {
 			expectedErr:   false,
 			expectWarning: false,
 		},
+		{
+			name: "multi-rule-change-match-and-preconditions-of-one-rule",
+			oldPolicy: []byte(`
+			{
+				"apiVersion": "kyverno.io/v1",
+				"kind": "ClusterPolicy",
+				"metadata": {
+					"name": "generate-multi-rule"
+				},
+				"spec": {
+					"rules": [
+						{
+							"name": "gen-a",
+							"match": {
+								"any": [
+									{
+										"resources": {
+											"kinds": [
+												"Namespace"
+											]
+										}
+									}
+								]
+							},
+							"generate": {
+								"apiVersion": "v1",
+								"kind": "ConfigMap",
+								"name": "cm-a",
+								"namespace": "{{request.object.metadata.name}}",
+								"synchronize": true,
+								"data": {
+									"data": {
+										"a": "1"
+									}
+								}
+							}
+						},
+						{
+							"name": "gen-b",
+							"match": {
+								"any": [
+									{
+										"resources": {
+											"kinds": [
+												"Namespace"
+											],
+											"names": [
+												"team-a"
+											]
+										}
+									}
+								]
+							},
+							"generate": {
+								"apiVersion": "v1",
+								"kind": "ConfigMap",
+								"name": "cm-b",
+								"namespace": "{{request.object.metadata.name}}",
+								"synchronize": true,
+								"data": {
+									"data": {
+										"b": "1"
+									}
+								}
+							}
+						}
+					]
+				}
+			}`),
+			newPolicy: []byte(`
+			{
+				"apiVersion": "kyverno.io/v1",
+				"kind": "ClusterPolicy",
+				"metadata": {
+					"name": "generate-multi-rule"
+				},
+				"spec": {
+					"rules": [
+						{
+							"name": "gen-a",
+							"match": {
+								"any": [
+									{
+										"resources": {
+											"kinds": [
+												"Namespace"
+											]
+										}
+									}
+								]
+							},
+							"generate": {
+								"apiVersion": "v1",
+								"kind": "ConfigMap",
+								"name": "cm-a",
+								"namespace": "{{request.object.metadata.name}}",
+								"synchronize": true,
+								"data": {
+									"data": {
+										"a": "1"
+									}
+								}
+							}
+						},
+						{
+							"name": "gen-b",
+							"match": {
+								"any": [
+									{
+										"resources": {
+											"kinds": [
+												"Namespace"
+											],
+											"names": [
+												"team-a",
+												"team-b"
+											]
+										}
+									}
+								]
+							},
+							"preconditions": {
+								"all": [
+									{
+										"key": "{{request.operation}}",
+										"operator": "Equals",
+										"value": "CREATE"
+									}
+								]
+							},
+							"generate": {
+								"apiVersion": "v1",
+								"kind": "ConfigMap",
+								"name": "cm-b",
+								"namespace": "{{request.object.metadata.name}}",
+								"synchronize": true,
+								"data": {
+									"data": {
+										"b": "1"
+									}
+								}
+							}
+						}
+					]
+				}
+			}`),
+			expectedErr:   true,
+			expectWarning: false,
+			errContains:   []string{`rule "gen-b"`, "match, preconditions"},
+			errExcludes:   []string{"gen-a"},
+		},
+		{
+			name: "multi-rule-rename-one-rule",
+			oldPolicy: []byte(`
+			{
+				"apiVersion": "kyverno.io/v1",
+				"kind": "ClusterPolicy",
+				"metadata": {
+					"name": "generate-multi-rule"
+				},
+				"spec": {
+					"rules": [
+						{
+							"name": "gen-a",
+							"match": {
+								"any": [
+									{
+										"resources": {
+											"kinds": [
+												"Namespace"
+											]
+										}
+									}
+								]
+							},
+							"generate": {
+								"apiVersion": "v1",
+								"kind": "ConfigMap",
+								"name": "cm-a",
+								"namespace": "{{request.object.metadata.name}}",
+								"synchronize": true,
+								"data": {
+									"data": {
+										"a": "1"
+									}
+								}
+							}
+						},
+						{
+							"name": "gen-b",
+							"match": {
+								"any": [
+									{
+										"resources": {
+											"kinds": [
+												"Namespace"
+											],
+											"names": [
+												"team-a"
+											]
+										}
+									}
+								]
+							},
+							"generate": {
+								"apiVersion": "v1",
+								"kind": "ConfigMap",
+								"name": "cm-b",
+								"namespace": "{{request.object.metadata.name}}",
+								"synchronize": true,
+								"data": {
+									"data": {
+										"b": "1"
+									}
+								}
+							}
+						}
+					]
+				}
+			}`),
+			newPolicy: []byte(`
+			{
+				"apiVersion": "kyverno.io/v1",
+				"kind": "ClusterPolicy",
+				"metadata": {
+					"name": "generate-multi-rule"
+				},
+				"spec": {
+					"rules": [
+						{
+							"name": "gen-a",
+							"match": {
+								"any": [
+									{
+										"resources": {
+											"kinds": [
+												"Namespace"
+											]
+										}
+									}
+								]
+							},
+							"generate": {
+								"apiVersion": "v1",
+								"kind": "ConfigMap",
+								"name": "cm-a",
+								"namespace": "{{request.object.metadata.name}}",
+								"synchronize": true,
+								"data": {
+									"data": {
+										"a": "1"
+									}
+								}
+							}
+						},
+						{
+							"name": "gen-c",
+							"match": {
+								"any": [
+									{
+										"resources": {
+											"kinds": [
+												"Namespace"
+											],
+											"names": [
+												"team-a"
+											]
+										}
+									}
+								]
+							},
+							"generate": {
+								"apiVersion": "v1",
+								"kind": "ConfigMap",
+								"name": "cm-b",
+								"namespace": "{{request.object.metadata.name}}",
+								"synchronize": true,
+								"data": {
+									"data": {
+										"b": "1"
+									}
+								}
+							}
+						}
+					]
+				}
+			}`),
+			expectedErr:   true,
+			expectWarning: false,
+			errContains:   []string{`rule "gen-b" was removed or renamed`},
+			errExcludes:   []string{"gen-a"},
+		},
 	}
 
 	for _, test := range tests {
@@ -3477,7 +3772,12 @@ func Test_GenerateFieldsUpdates(t *testing.T) {
 		warning, err := immutableGenerateFields(new, old)
 		golangassert.Assert(t, (warning != "") == test.expectWarning, "%s: %v", test.name, err)
 		golangassert.Assert(t, (err != nil) == test.expectedErr, "%s: %v", test.name, err)
-
+		for _, s := range test.errContains {
+			assert.ErrorContains(t, err, s, test.name)
+		}
+		for _, s := range test.errExcludes {
+			golangassert.Assert(t, err == nil || !strings.Contains(err.Error(), s), "%s: %v", test.name, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Explanation

This is a fix to an existing error message. When a policy update changes an immutable part of a `generate` rule, the validation webhook rejected it with a generic `changes of immutable fields of a rule spec in a generate rule is disallowed` that named neither the rule nor what changed. The error now names the offending rule, the top-level fields that differ (derived from the same `resetMutableFields` comparison the check is based on), and what the user can do instead.

## Related issue

Closes #17501

## Milestone of this PR

/milestone 1.20.0

## Documentation (required for features)

Not a feature; only the wording of an existing validation error changes. No documentation change needed.

## What type of PR is this

/kind bug

## Proposed Changes

### Problem

Updating a `ClusterPolicy` with several `generate` rules and touching, for example, `match.any[].resources.names` of one of them is rejected with:

```
changes of immutable fields of a rule spec in a generate rule is disallowed
```

In a GitOps setup (Argo CD) the sync retries forever with only this line, and the operator has to guess which rule and which field is the problem.

### Root cause

`immutableGenerateFields` in `pkg/validation/policy/generate.go` hashes every generate rule after `resetMutableFields` and compares the old and new hash *sets*. Once the hash sets were built, the relation between a hash and its rule was gone, so the only possible message was the generic one. The set of protected fields is "everything `resetMutableFields` keeps", not a fixed list, so hard-coding field names in the message would be wrong (`match` is only protected when the old policy has a synchronizing rule; `context`, `preconditions`, `exclude`, `name` and the other rule fields are always protected).

### Fix

- `buildHashes` now returns `map[hash]*Rule` (the rule *after* `resetMutableFields`) for the rule hashes instead of a `sets.Set[string]`; the generate-pattern hashes are unchanged and the warning path is untouched.
- New `changedImmutableRules` walks the old hashes missing from the new policy, maps each back to its rule and:
  - if a new rule with the same name exists, reports the top-level JSON fields that differ between the two reset rules (`changedRuleFields`, i.e. exactly the fields the hash covered);
  - otherwise reports that the rule was removed or renamed.
- The error keeps its original prefix (so existing greps/docs still match) and appends the per-rule detail and a hint.

Resulting messages:

```
changes of immutable fields of a rule spec in a generate rule is disallowed: rule "gen-b" changed fields [match]; add a new rule instead of changing the existing one, or delete and recreate the policy
changes of immutable fields of a rule spec in a generate rule is disallowed: rule "gen-b" was removed or renamed; add a new rule instead of changing the existing one, or delete and recreate the policy
```

The order of reported rules is sorted, so the message is deterministic.

### Proof Manifests

Existing policy (two synchronizing generate rules):

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: generate-multi-rule
spec:
  rules:
    - name: gen-a
      match:
        any:
          - resources:
              kinds: [Namespace]
      generate:
        apiVersion: v1
        kind: ConfigMap
        name: cm-a
        namespace: "{{request.object.metadata.name}}"
        synchronize: true
        data:
          data:
            a: "1"
    - name: gen-b
      match:
        any:
          - resources:
              kinds: [Namespace]
              names: [team-a]
      generate:
        apiVersion: v1
        kind: ConfigMap
        name: cm-b
        namespace: "{{request.object.metadata.name}}"
        synchronize: true
        data:
          data:
            b: "1"
```

Update that adds `team-b` to `gen-b`'s `match.any[0].resources.names`:

```
# before
admission webhook "validate-policy.kyverno.svc" denied the request: changes of immutable fields of a rule spec in a generate rule is disallowed
# after
admission webhook "validate-policy.kyverno.svc" denied the request: changes of immutable fields of a rule spec in a generate rule is disallowed: rule "gen-b" changed fields [match]; add a new rule instead of changing the existing one, or delete and recreate the policy
```

### How tested

Two cases were added to the existing table test `Test_GenerateFieldsUpdates` in `pkg/validation/policy/validate_test.go` (multi-rule policy: change `match` + add `preconditions` to one rule; rename one rule). They assert on the rule name and key phrase, and that the untouched rule `gen-a` is not named.

Before the fix (test against unmodified `main`):

```
--- FAIL: Test_GenerateFieldsUpdates (0.00s)
    Error "changes of immutable fields of a rule spec in a generate rule is disallowed" does not contain "rule \"gen-b\""
    Error "changes of immutable fields of a rule spec in a generate rule is disallowed" does not contain "match, preconditions"
    Error "changes of immutable fields of a rule spec in a generate rule is disallowed" does not contain "rule \"gen-b\" was removed or renamed"
FAIL	github.com/kyverno/kyverno/pkg/validation/policy	0.042s
```

After:

```
=== RUN   Test_GenerateFieldsUpdates
--- PASS: Test_GenerateFieldsUpdates (0.00s)
ok  	github.com/kyverno/kyverno/pkg/validation/policy	0.090s
ok  	github.com/kyverno/kyverno/pkg/validation/exception
ok  	github.com/kyverno/kyverno/pkg/validation/exception/globalcontext
ok  	github.com/kyverno/kyverno/pkg/validation/globalcontext
ok  	github.com/kyverno/kyverno/pkg/validation/resource
```

`gofmt -l`, `go vet ./pkg/validation/policy/` and `go build ./...` are clean. All pre-existing cases in `Test_GenerateFieldsUpdates` (warning path, allowed updates) pass unchanged.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The message deliberately does not hard-code a list of immutable fields: the fields reported are computed from the same `resetMutableFields` output the hash comparison uses, so the message can never disagree with the check. Removing a generate rule from a policy was already rejected by this check before this PR; the new message now says so explicitly ("removed or renamed") instead of hiding it behind the generic text.

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
