### PR TITLE
fix(cel): generate a ValidatingAdmissionPolicy/MutatingAdmissionPolicy per autogen group

### DIFF
--- a/pkg/admissionpolicy/builder.go
+++ b/pkg/admissionpolicy/builder.go
@@ -8,6 +8,8 @@ import (
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/api/kyverno"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/cel/autogen"
+	mpolautogen "github.com/kyverno/kyverno/pkg/cel/policies/mpol/autogen"
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
@@ -23,12 +25,20 @@ import (
 // specOverride, when non-nil, is used in place of the ValidatingPolicy's own spec - this is how an
 // autogen'd variant (e.g. the "defaults"/"cronjobs" rewritten spec from policy.GetStatus().Autogen.Configs)
 // is turned into its own ValidatingAdmissionPolicy while owner reference and labels still derive from
-// the real policy. Only consulted on the ValidatingPolicy path; ClusterPolicy ignores it.
+// the real policy. group is the matching autogen.ReplacementsMap key ("" for the base/non-autogen'd
+// variant) - it's what lets a PolicyException's match condition, written against the Pod-shaped base
+// object, still work once embedded into an autogen-group VAP whose object is a Deployment/CronJob: the
+// same object.spec-&gt;object.spec.template.spec (etc.) rewrite validations already get is applied to the
+// exception's expression too, using group to look up the right autogen.ReplacementsMap entry. Without
+// this, an exception expression that assumes the Pod shape (e.g. object.spec.containers...) would
+// silently never match, or error, once applied to a Deployment. Only consulted on the ValidatingPolicy
+// path; ClusterPolicy ignores both parameters.
 func BuildValidatingAdmissionPolicy(
 	discoveryClient dclient.IDiscovery,
 	vap *admissionregistrationv1.ValidatingAdmissionPolicy,
 	policy engineapi.GenericPolicy,
 	exceptions []engineapi.GenericException,
+	group string,
 	specOverride *policiesv1beta1.ValidatingPolicySpec,
 ) error {
 	var matchResources admissionregistrationv1.MatchResources
@@ -123,6 +133,13 @@ func BuildValidatingAdmissionPolicy(
 				for _, matchCondition := range celpolex.Spec.MatchConditions {
 					// negate the match condition
 					expression := "!(" + matchCondition.Expression + ")"
+					if group != "" {
+						// The exception was written against the Pod-shaped base object; rewrite it
+						// the same way validations were rewritten for this autogen group, or an
+						// expression like object.spec.containers... would silently never match (or
+						// error) once object is actually a Deployment/CronJob.
+						expression = string(autogen.Apply([]byte(expression), autogen.ReplacementsMap[group]...))
+					}
 					matchConditions = append(matchConditions, admissionregistrationv1.MatchCondition{
 						Name:       matchCondition.Name,
 						Expression: expression,
@@ -267,15 +284,23 @@ func mutatingPolicyOwnerRef(mp *policiesv1beta1.MutatingPolicy) []metav1.OwnerRe
 	}
 }
 
-// negateExceptionMatchConditions returns negated match conditions for each exception,
-// using the v1 MatchCondition type which is structurally identical to the alpha/beta variants.
-func negateExceptionMatchConditions(exceptions []policiesv1beta1.PolicyException) []admissionregistrationv1.MatchCondition {
+// negateExceptionMatchConditions returns negated match conditions for each exception, using the v1
+// MatchCondition type which is structurally identical to the alpha/beta variants. group is the
+// matching mpol autogen config key ("" for the base/non-autogen'd variant) - see
+// BuildValidatingAdmissionPolicy's group parameter for why this rewrite is needed: without it, an
+// exception written against the Pod-shaped base object would silently misbehave once embedded into an
+// autogen-group MutatingAdmissionPolicy whose object is a Deployment/CronJob.
+func negateExceptionMatchConditions(exceptions []policiesv1beta1.PolicyException, group string) []admissionregistrationv1.MatchCondition {
 	var result []admissionregistrationv1.MatchCondition
 	for _, exception := range exceptions {
 		for _, mc := range exception.Spec.MatchConditions {
+			expression := "!(" + mc.Expression + ")"
+			if group != "" {
+				expression = mpolautogen.ConvertPodToTemplateExpression(expression, group)
+			}
 			result = append(result, admissionregistrationv1.MatchCondition{
 				Name:       mc.Name,
-				Expression: "!(" + mc.Expression + ")",
+				Expression: expression,
 			})
 		}
 	}
@@ -284,18 +309,20 @@ func negateExceptionMatchConditions(exceptions []policiesv1beta1.PolicyException
 
 // BuildMutatingAdmissionPolicy is used to build a Kubernetes MutatingAdmissionPolicy from a MutatingPolicy.
 // specOverride, when non-nil, is used in place of mp's own spec - see BuildValidatingAdmissionPolicy's
-// parameter of the same name for why (autogen fan-out).
+// parameter of the same name for why (autogen fan-out). group is threaded through to
+// negateExceptionMatchConditions for the same reason.
 func BuildMutatingAdmissionPolicy(
 	mapol *admissionregistrationv1alpha1.MutatingAdmissionPolicy,
 	mp *policiesv1beta1.MutatingPolicy,
 	exceptions []policiesv1beta1.PolicyException,
+	group string,
 	specOverride *policiesv1beta1.MutatingPolicySpec,
 ) {
 	spec := mp.Spec
 	if specOverride != nil {
 		spec = *specOverride
 	}
-	matchConditions := slicesutils.Map(negateExceptionMatchConditions(exceptions), func(mc admissionregistrationv1.MatchCondition) admissionregistrationv1alpha1.MatchCondition {
+	matchConditions := slicesutils.Map(negateExceptionMatchConditions(exceptions, group), func(mc admissionregistrationv1.MatchCondition) admissionregistrationv1alpha1.MatchCondition {
 		return admissionregistrationv1alpha1.MatchCondition(mc)
 	})
 	for _, mc := range spec.MatchConditions {
@@ -352,18 +379,19 @@ func BuildMutatingAdmissionPolicyBinding(
 }
 
 // BuildMutatingAdmissionPolicyV1 is used to build a Kubernetes MutatingAdmissionPolicy (v1) from a
-// MutatingPolicy. specOverride mirrors BuildMutatingAdmissionPolicy's parameter of the same name.
+// MutatingPolicy. group and specOverride mirror BuildMutatingAdmissionPolicy's parameters of the same name.
 func BuildMutatingAdmissionPolicyV1(
 	mapol *admissionregistrationv1.MutatingAdmissionPolicy,
 	mp *policiesv1beta1.MutatingPolicy,
 	exceptions []policiesv1beta1.PolicyException,
+	group string,
 	specOverride *policiesv1beta1.MutatingPolicySpec,
 ) {
 	spec := mp.Spec
 	if specOverride != nil {
 		spec = *specOverride
 	}
-	matchConditions := negateExceptionMatchConditions(exceptions)
+	matchConditions := negateExceptionMatchConditions(exceptions, group)
 	for _, mc := range spec.MatchConditions {
 		matchConditions = append(matchConditions, mc)
 	}
@@ -424,18 +452,19 @@ func BuildMutatingAdmissionPolicyBindingV1(
 }
 
 // BuildMutatingAdmissionPolicyBeta is used to build a Kubernetes MutatingAdmissionPolicy (v1beta1) from
-// a MutatingPolicy. specOverride mirrors BuildMutatingAdmissionPolicy's parameter of the same name.
+// a MutatingPolicy. group and specOverride mirror BuildMutatingAdmissionPolicy's parameters of the same name.
 func BuildMutatingAdmissionPolicyBeta(
 	mapol *admissionregistrationv1beta1.MutatingAdmissionPolicy,
 	mp *policiesv1beta1.MutatingPolicy,
 	exceptions []policiesv1beta1.PolicyException,
+	group string,
 	specOverride *policiesv1beta1.MutatingPolicySpec,
 ) {
 	spec := mp.Spec
 	if specOverride != nil {
 		spec = *specOverride
 	}
-	matchConditions := slicesutils.Map(negateExceptionMatchConditions(exceptions), func(mc admissionregistrationv1.MatchCondition) admissionregistrationv1beta1.MatchCondition {
+	matchConditions := slicesutils.Map(negateExceptionMatchConditions(exceptions, group), func(mc admissionregistrationv1.MatchCondition) admissionregistrationv1beta1.MatchCondition {
 		return admissionregistrationv1beta1.MatchCondition(mc)
 	})
 	for _, mc := range spec.MatchConditions {

--- a/pkg/admissionpolicy/builder.go
+++ b/pkg/admissionpolicy/builder.go
@@ -19,12 +19,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// BuildValidatingAdmissionPolicy is used to build a Kubernetes ValidatingAdmissionPolicy from a Kyverno policy
+// BuildValidatingAdmissionPolicy is used to build a Kubernetes ValidatingAdmissionPolicy from a Kyverno policy.
+// specOverride, when non-nil, is used in place of the ValidatingPolicy's own spec - this is how an
+// autogen'd variant (e.g. the "defaults"/"cronjobs" rewritten spec from policy.GetStatus().Autogen.Configs)
+// is turned into its own ValidatingAdmissionPolicy while owner reference and labels still derive from
+// the real policy. Only consulted on the ValidatingPolicy path; ClusterPolicy ignores it.
 func BuildValidatingAdmissionPolicy(
 	discoveryClient dclient.IDiscovery,
 	vap *admissionregistrationv1.ValidatingAdmissionPolicy,
 	policy engineapi.GenericPolicy,
 	exceptions []engineapi.GenericException,
+	specOverride *policiesv1beta1.ValidatingPolicySpec,
 ) error {
 	var matchResources admissionregistrationv1.MatchResources
 	var matchConditions []admissionregistrationv1.MatchCondition
@@ -102,11 +107,15 @@ func BuildValidatingAdmissionPolicy(
 		auditAnnotations = rule.Validation.CEL.AuditAnnotations
 		variables = rule.Validation.CEL.Variables
 	} else if vpol := policy.AsValidatingPolicy(); vpol != nil {
-		matchResources = *vpol.Spec.MatchConstraints
-		matchConditions = vpol.Spec.MatchConditions
-		validations = vpol.Spec.Validations
-		auditAnnotations = vpol.Spec.AuditAnnotations
-		variables = vpol.Spec.Variables
+		spec := vpol.Spec
+		if specOverride != nil {
+			spec = *specOverride
+		}
+		matchResources = *spec.MatchConstraints
+		matchConditions = spec.MatchConditions
+		validations = spec.Validations
+		auditAnnotations = spec.AuditAnnotations
+		variables = spec.Variables
 
 		// convert celexceptions if exist
 		for _, exception := range exceptions {
@@ -184,14 +193,19 @@ func replaceExpressions(expr string, replacements map[string]string) string {
 	return expr
 }
 
-// BuildValidatingAdmissionPolicyBinding is used to build a Kubernetes ValidatingAdmissionPolicyBinding from a Kyverno policy
+// BuildValidatingAdmissionPolicyBinding is used to build a Kubernetes ValidatingAdmissionPolicyBinding
+// from a Kyverno policy. vapName is the name of the ValidatingAdmissionPolicy this binding targets -
+// callers already know it (they just created/looked up that object), so it's taken explicitly rather
+// than re-derived here, which lets one policy bind to several generated VAPs (the base one plus one
+// per autogen group). specOverride mirrors BuildValidatingAdmissionPolicy's parameter of the same name.
 func BuildValidatingAdmissionPolicyBinding(
 	vapbinding *admissionregistrationv1.ValidatingAdmissionPolicyBinding,
 	policy engineapi.GenericPolicy,
+	vapName string,
+	specOverride *policiesv1beta1.ValidatingPolicySpec,
 ) error {
 	var validationActions []admissionregistrationv1.ValidationAction
 	var paramRef *admissionregistrationv1.ParamRef
-	var policyName string
 
 	if cpol := policy.AsKyvernoPolicy(); cpol != nil {
 		rule := cpol.GetSpec().Rules[0]
@@ -213,10 +227,12 @@ func BuildValidatingAdmissionPolicyBinding(
 			}
 		}
 		paramRef = rule.Validation.CEL.ParamRef
-		policyName = "cpol-" + cpol.GetName()
 	} else if vpol := policy.AsValidatingPolicy(); vpol != nil {
-		validationActions = vpol.Spec.ValidationActions()
-		policyName = "vpol-" + vpol.GetName()
+		spec := vpol.Spec
+		if specOverride != nil {
+			spec = *specOverride
+		}
+		validationActions = spec.ValidationActions()
 	}
 
 	// set owner reference
@@ -230,7 +246,7 @@ func BuildValidatingAdmissionPolicyBinding(
 	}
 	// set binding spec
 	vapbinding.Spec = admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec{
-		PolicyName:        policyName,
+		PolicyName:        vapName,
 		ParamRef:          paramRef,
 		ValidationActions: validationActions,
 	}
@@ -266,22 +282,29 @@ func negateExceptionMatchConditions(exceptions []policiesv1beta1.PolicyException
 	return result
 }
 
-// BuildMutatingAdmissionPolicy is used to build a Kubernetes MutatingAdmissionPolicy from a MutatingPolicy
+// BuildMutatingAdmissionPolicy is used to build a Kubernetes MutatingAdmissionPolicy from a MutatingPolicy.
+// specOverride, when non-nil, is used in place of mp's own spec - see BuildValidatingAdmissionPolicy's
+// parameter of the same name for why (autogen fan-out).
 func BuildMutatingAdmissionPolicy(
 	mapol *admissionregistrationv1alpha1.MutatingAdmissionPolicy,
 	mp *policiesv1beta1.MutatingPolicy,
 	exceptions []policiesv1beta1.PolicyException,
+	specOverride *policiesv1beta1.MutatingPolicySpec,
 ) {
+	spec := mp.Spec
+	if specOverride != nil {
+		spec = *specOverride
+	}
 	matchConditions := slicesutils.Map(negateExceptionMatchConditions(exceptions), func(mc admissionregistrationv1.MatchCondition) admissionregistrationv1alpha1.MatchCondition {
 		return admissionregistrationv1alpha1.MatchCondition(mc)
 	})
-	for _, mc := range mp.Spec.MatchConditions {
+	for _, mc := range spec.MatchConditions {
 		matchConditions = append(matchConditions, admissionregistrationv1alpha1.MatchCondition(mc))
 	}
 
 	var fpt *admissionregistrationv1alpha1.FailurePolicyType
-	if mp.Spec.FailurePolicy != nil {
-		conv := admissionregistrationv1alpha1.FailurePolicyType(*mp.Spec.FailurePolicy)
+	if spec.FailurePolicy != nil {
+		conv := admissionregistrationv1alpha1.FailurePolicyType(*spec.FailurePolicy)
 		fpt = &conv
 	}
 
@@ -290,7 +313,7 @@ func BuildMutatingAdmissionPolicy(
 	// set policy spec
 	mapol.Spec = admissionregistrationv1alpha1.MutatingAdmissionPolicySpec{
 		MatchConstraints: &admissionregistrationv1alpha1.MatchResources{
-			ResourceRules: slicesutils.Map(mp.Spec.MatchConstraints.ResourceRules, func(rule admissionregistrationv1.NamedRuleWithOperations) admissionregistrationv1alpha1.NamedRuleWithOperations {
+			ResourceRules: slicesutils.Map(spec.MatchConstraints.ResourceRules, func(rule admissionregistrationv1.NamedRuleWithOperations) admissionregistrationv1alpha1.NamedRuleWithOperations {
 				return admissionregistrationv1alpha1.NamedRuleWithOperations{
 					ResourceNames:      rule.ResourceNames,
 					RuleWithOperations: rule.RuleWithOperations,
@@ -298,12 +321,12 @@ func BuildMutatingAdmissionPolicy(
 			}),
 		},
 		MatchConditions: matchConditions,
-		Mutations:       mp.Spec.Mutations,
-		Variables: slicesutils.Map(mp.Spec.Variables, func(v admissionregistrationv1.Variable) admissionregistrationv1alpha1.Variable {
+		Mutations:       spec.Mutations,
+		Variables: slicesutils.Map(spec.Variables, func(v admissionregistrationv1.Variable) admissionregistrationv1alpha1.Variable {
 			return admissionregistrationv1alpha1.Variable(v)
 		}),
 		FailurePolicy:      fpt,
-		ReinvocationPolicy: mp.Spec.GetReinvocationPolicy(),
+		ReinvocationPolicy: spec.GetReinvocationPolicy(),
 	}
 	// set labels
 	controllerutils.SetManagedByKyvernoLabel(mapol)
@@ -313,39 +336,48 @@ func BuildMutatingAdmissionPolicy(
 	}
 }
 
-// BuildMutatingAdmissionPolicyBinding is used to build a Kubernetes MutatingAdmissionPolicyBinding from a MutatingPolicy
+// BuildMutatingAdmissionPolicyBinding is used to build a Kubernetes MutatingAdmissionPolicyBinding from
+// a MutatingPolicy. mapName is the name of the MutatingAdmissionPolicy this binding targets - see
+// BuildValidatingAdmissionPolicyBinding's vapName parameter for why it's taken explicitly.
 func BuildMutatingAdmissionPolicyBinding(
 	mapbinding *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding,
 	mp *policiesv1beta1.MutatingPolicy,
+	mapName string,
 ) {
 	mapbinding.OwnerReferences = mutatingPolicyOwnerRef(mp)
 	mapbinding.Spec = admissionregistrationv1alpha1.MutatingAdmissionPolicyBindingSpec{
-		PolicyName: "mpol-" + mp.GetName(),
+		PolicyName: mapName,
 	}
 	controllerutils.SetManagedByKyvernoLabel(mapbinding)
 }
 
-// BuildMutatingAdmissionPolicyV1 is used to build a Kubernetes MutatingAdmissionPolicy (v1) from a MutatingPolicy.
+// BuildMutatingAdmissionPolicyV1 is used to build a Kubernetes MutatingAdmissionPolicy (v1) from a
+// MutatingPolicy. specOverride mirrors BuildMutatingAdmissionPolicy's parameter of the same name.
 func BuildMutatingAdmissionPolicyV1(
 	mapol *admissionregistrationv1.MutatingAdmissionPolicy,
 	mp *policiesv1beta1.MutatingPolicy,
 	exceptions []policiesv1beta1.PolicyException,
+	specOverride *policiesv1beta1.MutatingPolicySpec,
 ) {
+	spec := mp.Spec
+	if specOverride != nil {
+		spec = *specOverride
+	}
 	matchConditions := negateExceptionMatchConditions(exceptions)
-	for _, mc := range mp.Spec.MatchConditions {
+	for _, mc := range spec.MatchConditions {
 		matchConditions = append(matchConditions, mc)
 	}
 
 	var fpt *admissionregistrationv1.FailurePolicyType
-	if mp.Spec.FailurePolicy != nil {
-		conv := *mp.Spec.FailurePolicy
+	if spec.FailurePolicy != nil {
+		conv := *spec.FailurePolicy
 		fpt = &conv
 	}
 
 	mapol.OwnerReferences = mutatingPolicyOwnerRef(mp)
 	mapol.Spec = admissionregistrationv1.MutatingAdmissionPolicySpec{
 		MatchConstraints: &admissionregistrationv1.MatchResources{
-			ResourceRules: slicesutils.Map(mp.Spec.MatchConstraints.ResourceRules, func(rule admissionregistrationv1.NamedRuleWithOperations) admissionregistrationv1.NamedRuleWithOperations {
+			ResourceRules: slicesutils.Map(spec.MatchConstraints.ResourceRules, func(rule admissionregistrationv1.NamedRuleWithOperations) admissionregistrationv1.NamedRuleWithOperations {
 				return admissionregistrationv1.NamedRuleWithOperations{
 					ResourceNames:      rule.ResourceNames,
 					RuleWithOperations: rule.RuleWithOperations,
@@ -353,7 +385,7 @@ func BuildMutatingAdmissionPolicyV1(
 			}),
 		},
 		MatchConditions: matchConditions,
-		Mutations: slicesutils.Map(mp.Spec.Mutations, func(m admissionregistrationv1alpha1.Mutation) admissionregistrationv1.Mutation {
+		Mutations: slicesutils.Map(spec.Mutations, func(m admissionregistrationv1alpha1.Mutation) admissionregistrationv1.Mutation {
 			mut := admissionregistrationv1.Mutation{PatchType: admissionregistrationv1.PatchType(m.PatchType)}
 			if m.ApplyConfiguration != nil {
 				mut.ApplyConfiguration = &admissionregistrationv1.ApplyConfiguration{Expression: m.ApplyConfiguration.Expression}
@@ -363,11 +395,11 @@ func BuildMutatingAdmissionPolicyV1(
 			}
 			return mut
 		}),
-		Variables: slicesutils.Map(mp.Spec.Variables, func(v admissionregistrationv1.Variable) admissionregistrationv1.Variable {
+		Variables: slicesutils.Map(spec.Variables, func(v admissionregistrationv1.Variable) admissionregistrationv1.Variable {
 			return v
 		}),
 		FailurePolicy:      fpt,
-		ReinvocationPolicy: mp.Spec.GetReinvocationPolicy(),
+		ReinvocationPolicy: spec.GetReinvocationPolicy(),
 	}
 	controllerutils.SetManagedByKyvernoLabel(mapol)
 	policyLabels := mp.GetLabels()
@@ -376,34 +408,43 @@ func BuildMutatingAdmissionPolicyV1(
 	}
 }
 
-// BuildMutatingAdmissionPolicyBindingV1 is used to build a Kubernetes MutatingAdmissionPolicyBinding (v1) from a MutatingPolicy.
+// BuildMutatingAdmissionPolicyBindingV1 is used to build a Kubernetes MutatingAdmissionPolicyBinding
+// (v1) from a MutatingPolicy. mapName is the name of the MutatingAdmissionPolicy this binding targets -
+// see BuildValidatingAdmissionPolicyBinding's vapName parameter for why it's taken explicitly.
 func BuildMutatingAdmissionPolicyBindingV1(
 	mapbinding *admissionregistrationv1.MutatingAdmissionPolicyBinding,
 	mp *policiesv1beta1.MutatingPolicy,
+	mapName string,
 ) {
 	mapbinding.OwnerReferences = mutatingPolicyOwnerRef(mp)
 	mapbinding.Spec = admissionregistrationv1.MutatingAdmissionPolicyBindingSpec{
-		PolicyName: "mpol-" + mp.GetName(),
+		PolicyName: mapName,
 	}
 	controllerutils.SetManagedByKyvernoLabel(mapbinding)
 }
 
-// BuildMutatingAdmissionPolicyBeta is used to build a Kubernetes MutatingAdmissionPolicy (v1beta1) from a MutatingPolicy
+// BuildMutatingAdmissionPolicyBeta is used to build a Kubernetes MutatingAdmissionPolicy (v1beta1) from
+// a MutatingPolicy. specOverride mirrors BuildMutatingAdmissionPolicy's parameter of the same name.
 func BuildMutatingAdmissionPolicyBeta(
 	mapol *admissionregistrationv1beta1.MutatingAdmissionPolicy,
 	mp *policiesv1beta1.MutatingPolicy,
 	exceptions []policiesv1beta1.PolicyException,
+	specOverride *policiesv1beta1.MutatingPolicySpec,
 ) {
+	spec := mp.Spec
+	if specOverride != nil {
+		spec = *specOverride
+	}
 	matchConditions := slicesutils.Map(negateExceptionMatchConditions(exceptions), func(mc admissionregistrationv1.MatchCondition) admissionregistrationv1beta1.MatchCondition {
 		return admissionregistrationv1beta1.MatchCondition(mc)
 	})
-	for _, mc := range mp.Spec.MatchConditions {
+	for _, mc := range spec.MatchConditions {
 		matchConditions = append(matchConditions, admissionregistrationv1beta1.MatchCondition(mc))
 	}
 
 	var fpt *admissionregistrationv1beta1.FailurePolicyType
-	if mp.Spec.FailurePolicy != nil {
-		conv := admissionregistrationv1beta1.FailurePolicyType(*mp.Spec.FailurePolicy)
+	if spec.FailurePolicy != nil {
+		conv := admissionregistrationv1beta1.FailurePolicyType(*spec.FailurePolicy)
 		fpt = &conv
 	}
 
@@ -412,7 +453,7 @@ func BuildMutatingAdmissionPolicyBeta(
 	// set policy spec
 	mapol.Spec = admissionregistrationv1beta1.MutatingAdmissionPolicySpec{
 		MatchConstraints: &admissionregistrationv1beta1.MatchResources{
-			ResourceRules: slicesutils.Map(mp.Spec.MatchConstraints.ResourceRules, func(rule admissionregistrationv1.NamedRuleWithOperations) admissionregistrationv1beta1.NamedRuleWithOperations {
+			ResourceRules: slicesutils.Map(spec.MatchConstraints.ResourceRules, func(rule admissionregistrationv1.NamedRuleWithOperations) admissionregistrationv1beta1.NamedRuleWithOperations {
 				return admissionregistrationv1beta1.NamedRuleWithOperations{
 					ResourceNames:      rule.ResourceNames,
 					RuleWithOperations: rule.RuleWithOperations,
@@ -420,7 +461,7 @@ func BuildMutatingAdmissionPolicyBeta(
 			}),
 		},
 		MatchConditions: matchConditions,
-		Mutations: slicesutils.Map(mp.Spec.Mutations, func(m admissionregistrationv1alpha1.Mutation) admissionregistrationv1beta1.Mutation {
+		Mutations: slicesutils.Map(spec.Mutations, func(m admissionregistrationv1alpha1.Mutation) admissionregistrationv1beta1.Mutation {
 			mut := admissionregistrationv1beta1.Mutation{
 				PatchType: admissionregistrationv1beta1.PatchType(m.PatchType),
 			}
@@ -436,11 +477,11 @@ func BuildMutatingAdmissionPolicyBeta(
 			}
 			return mut
 		}),
-		Variables: slicesutils.Map(mp.Spec.Variables, func(v admissionregistrationv1.Variable) admissionregistrationv1beta1.Variable {
+		Variables: slicesutils.Map(spec.Variables, func(v admissionregistrationv1.Variable) admissionregistrationv1beta1.Variable {
 			return admissionregistrationv1beta1.Variable(v)
 		}),
 		FailurePolicy:      fpt,
-		ReinvocationPolicy: mp.Spec.GetReinvocationPolicy(),
+		ReinvocationPolicy: spec.GetReinvocationPolicy(),
 	}
 	// set labels
 	controllerutils.SetManagedByKyvernoLabel(mapol)
@@ -450,14 +491,17 @@ func BuildMutatingAdmissionPolicyBeta(
 	}
 }
 
-// BuildMutatingAdmissionPolicyBindingBeta is used to build a Kubernetes MutatingAdmissionPolicyBinding (v1beta1) from a MutatingPolicy
+// BuildMutatingAdmissionPolicyBindingBeta is used to build a Kubernetes MutatingAdmissionPolicyBinding
+// (v1beta1) from a MutatingPolicy. mapName is the name of the MutatingAdmissionPolicy this binding
+// targets - see BuildValidatingAdmissionPolicyBinding's vapName parameter for why it's taken explicitly.
 func BuildMutatingAdmissionPolicyBindingBeta(
 	mapbinding *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding,
 	mp *policiesv1beta1.MutatingPolicy,
+	mapName string,
 ) {
 	mapbinding.OwnerReferences = mutatingPolicyOwnerRef(mp)
 	mapbinding.Spec = admissionregistrationv1beta1.MutatingAdmissionPolicyBindingSpec{
-		PolicyName: "mpol-" + mp.GetName(),
+		PolicyName: mapName,
 	}
 	controllerutils.SetManagedByKyvernoLabel(mapbinding)
 }

--- a/pkg/admissionpolicy/builder_test.go
+++ b/pkg/admissionpolicy/builder_test.go
@@ -81,7 +81,7 @@ func TestBuildMutatingAdmissionPolicyBeta(t *testing.T) {
 		},
 	}
 
-	BuildMutatingAdmissionPolicyBeta(mapol, mp, exceptions)
+	BuildMutatingAdmissionPolicyBeta(mapol, mp, exceptions, nil)
 
 	// Verify owner reference
 	assert.Len(t, mapol.OwnerReferences, 1)
@@ -147,7 +147,7 @@ func TestBuildMutatingAdmissionPolicyV1(t *testing.T) {
 
 	mapol := &admissionregistrationv1.MutatingAdmissionPolicy{ObjectMeta: metav1.ObjectMeta{Name: "mpol-test-mpol"}}
 
-	BuildMutatingAdmissionPolicyV1(mapol, mp, nil)
+	BuildMutatingAdmissionPolicyV1(mapol, mp, nil, nil)
 
 	assert.Len(t, mapol.OwnerReferences, 1)
 	assert.Equal(t, mp.GetName(), mapol.OwnerReferences[0].Name)
@@ -167,7 +167,7 @@ func TestBuildMutatingAdmissionPolicyBindingV1(t *testing.T) {
 	mp := &policiesv1beta1.MutatingPolicy{ObjectMeta: metav1.ObjectMeta{Name: "test-mpol", UID: "test-uid"}}
 	mapbinding := &admissionregistrationv1.MutatingAdmissionPolicyBinding{ObjectMeta: metav1.ObjectMeta{Name: "mpol-test-mpol-binding"}}
 
-	BuildMutatingAdmissionPolicyBindingV1(mapbinding, mp)
+	BuildMutatingAdmissionPolicyBindingV1(mapbinding, mp, "mpol-test-mpol")
 
 	assert.Len(t, mapbinding.OwnerReferences, 1)
 	assert.Equal(t, mp.GetName(), mapbinding.OwnerReferences[0].Name)
@@ -189,7 +189,7 @@ func TestBuildMutatingAdmissionPolicyBindingBeta(t *testing.T) {
 		},
 	}
 
-	BuildMutatingAdmissionPolicyBindingBeta(mapbinding, mp)
+	BuildMutatingAdmissionPolicyBindingBeta(mapbinding, mp, "mpol-test-mpol")
 
 	// Verify owner reference
 	assert.Len(t, mapbinding.OwnerReferences, 1)
@@ -235,7 +235,7 @@ func TestBuildMutatingAdmissionPolicyBeta_WithFailurePolicy(t *testing.T) {
 		},
 	}
 
-	BuildMutatingAdmissionPolicyBeta(mapol, mp, nil)
+	BuildMutatingAdmissionPolicyBeta(mapol, mp, nil, nil)
 
 	// Verify failure policy
 	assert.NotNil(t, mapol.Spec.FailurePolicy)
@@ -276,7 +276,7 @@ func TestBuildMutatingAdmissionPolicyBeta_MutationTypeConversion(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test"},
 	}
 
-	BuildMutatingAdmissionPolicyBeta(mapol, mp, nil)
+	BuildMutatingAdmissionPolicyBeta(mapol, mp, nil, nil)
 
 	assert.Len(t, mapol.Spec.Mutations, 1)
 	assert.Equal(t, admissionregistrationv1beta1.PatchTypeApplyConfiguration, mapol.Spec.Mutations[0].PatchType)
@@ -316,7 +316,7 @@ func TestBuildMutatingAdmissionPolicyBeta_MutationTypeConversion(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test2"},
 	}
 
-	BuildMutatingAdmissionPolicyBeta(mapol2, mp2, nil)
+	BuildMutatingAdmissionPolicyBeta(mapol2, mp2, nil, nil)
 
 	assert.Len(t, mapol2.Spec.Mutations, 1)
 	assert.Equal(t, admissionregistrationv1beta1.PatchTypeJSONPatch, mapol2.Spec.Mutations[0].PatchType)

--- a/pkg/admissionpolicy/builder_test.go
+++ b/pkg/admissionpolicy/builder_test.go
@@ -4,12 +4,81 @@ import (
 	"testing"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// TestBuildValidatingAdmissionPolicy_RewritesExceptionForAutogenGroup guards against a real bug
+// found in code review of the autogen fan-out (#17423): a PolicyException's match condition is
+// written against the Pod-shaped base object (e.g. object.spec.containers...). Embedded verbatim
+// into an autogen-group VAP - where object is actually a Deployment/CronJob - it would silently
+// never match, or error, exactly like the policy's own validations would without the same
+// rewrite. The exception's negated match condition must get the identical
+// autogen.ReplacementsMap rewrite as the group's own Validations.
+func TestBuildValidatingAdmissionPolicy_RewritesExceptionForAutogenGroup(t *testing.T) {
+	vpol := &policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-vpol", UID: "test-uid"},
+		Spec: policiesv1beta1.ValidatingPolicySpec{
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+					RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+						Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"pods"}},
+					},
+				}},
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{Expression: "object.spec.containers.all(c, !c.image.endsWith(':latest'))"},
+			},
+		},
+	}
+	policy := engineapi.NewValidatingPolicy(vpol)
+
+	celpolex := &policiesv1beta1.PolicyException{
+		Spec: policiesv1beta1.PolicyExceptionSpec{
+			MatchConditions: []admissionregistrationv1.MatchCondition{
+				{Name: "skip-sidecars", Expression: "object.spec.containers.exists(c, c.name == 'sidecar')"},
+			},
+		},
+	}
+	exceptions := []engineapi.GenericException{engineapi.NewCELPolicyException(celpolex)}
+
+	// The "defaults" group's rewritten spec, as pkg/cel/autogen would actually produce it.
+	groupSpec := &policiesv1beta1.ValidatingPolicySpec{
+		MatchConstraints: &admissionregistrationv1.MatchResources{
+			ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+				RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+					Rule:       admissionregistrationv1.Rule{APIGroups: []string{"apps"}, APIVersions: []string{"v1"}, Resources: []string{"deployments"}},
+				},
+			}},
+		},
+		Validations: []admissionregistrationv1.Validation{
+			{Expression: "object.spec.template.spec.containers.all(c, !c.image.endsWith(':latest'))"},
+		},
+	}
+
+	vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+	err := BuildValidatingAdmissionPolicy(nil, vap, policy, exceptions, "defaults", groupSpec)
+	assert.NoError(t, err)
+
+	assert.Len(t, vap.Spec.MatchConditions, 1)
+	assert.Equal(t,
+		"!(object.spec.template.spec.containers.exists(c, c.name == 'sidecar'))",
+		vap.Spec.MatchConditions[0].Expression,
+		"exception match condition must get the same pod-template rewrite as the group's own validations",
+	)
+
+	// Sanity check: the base (non-autogen) variant must NOT be rewritten.
+	baseVAP := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+	err = BuildValidatingAdmissionPolicy(nil, baseVAP, policy, exceptions, "", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "!(object.spec.containers.exists(c, c.name == 'sidecar'))", baseVAP.Spec.MatchConditions[0].Expression)
+}
 
 func TestBuildMutatingAdmissionPolicyBeta(t *testing.T) {
 	mp := &policiesv1beta1.MutatingPolicy{
@@ -81,7 +150,7 @@ func TestBuildMutatingAdmissionPolicyBeta(t *testing.T) {
 		},
 	}
 
-	BuildMutatingAdmissionPolicyBeta(mapol, mp, exceptions, nil)
+	BuildMutatingAdmissionPolicyBeta(mapol, mp, exceptions, "", nil)
 
 	// Verify owner reference
 	assert.Len(t, mapol.OwnerReferences, 1)
@@ -147,7 +216,7 @@ func TestBuildMutatingAdmissionPolicyV1(t *testing.T) {
 
 	mapol := &admissionregistrationv1.MutatingAdmissionPolicy{ObjectMeta: metav1.ObjectMeta{Name: "mpol-test-mpol"}}
 
-	BuildMutatingAdmissionPolicyV1(mapol, mp, nil, nil)
+	BuildMutatingAdmissionPolicyV1(mapol, mp, nil, "", nil)
 
 	assert.Len(t, mapol.OwnerReferences, 1)
 	assert.Equal(t, mp.GetName(), mapol.OwnerReferences[0].Name)
@@ -235,7 +304,7 @@ func TestBuildMutatingAdmissionPolicyBeta_WithFailurePolicy(t *testing.T) {
 		},
 	}
 
-	BuildMutatingAdmissionPolicyBeta(mapol, mp, nil, nil)
+	BuildMutatingAdmissionPolicyBeta(mapol, mp, nil, "", nil)
 
 	// Verify failure policy
 	assert.NotNil(t, mapol.Spec.FailurePolicy)
@@ -276,7 +345,7 @@ func TestBuildMutatingAdmissionPolicyBeta_MutationTypeConversion(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test"},
 	}
 
-	BuildMutatingAdmissionPolicyBeta(mapol, mp, nil, nil)
+	BuildMutatingAdmissionPolicyBeta(mapol, mp, nil, "", nil)
 
 	assert.Len(t, mapol.Spec.Mutations, 1)
 	assert.Equal(t, admissionregistrationv1beta1.PatchTypeApplyConfiguration, mapol.Spec.Mutations[0].PatchType)
@@ -316,7 +385,7 @@ func TestBuildMutatingAdmissionPolicyBeta_MutationTypeConversion(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test2"},
 	}
 
-	BuildMutatingAdmissionPolicyBeta(mapol2, mp2, nil, nil)
+	BuildMutatingAdmissionPolicyBeta(mapol2, mp2, nil, "", nil)
 
 	assert.Len(t, mapol2.Spec.Mutations, 1)
 	assert.Equal(t, admissionregistrationv1beta1.PatchTypeJSONPatch, mapol2.Spec.Mutations[0].PatchType)

--- a/pkg/cel/policies/mpol/autogen/autogen.go
+++ b/pkg/cel/policies/mpol/autogen/autogen.go
@@ -62,21 +62,21 @@ func generateRuleForControllers(spec *policiesv1beta1.MutatingPolicySpec, config
 		// Extraction-mode targets (custom workload CRDs) have no fixed
 		// "spec.template"-style path to rewrite expressions to - their pod
 		// template is discovered at evaluation time instead - so
-		// convertPodToTemplateExpression must not run for them. Without this
+		// ConvertPodToTemplateExpression must not run for them. Without this
 		// guard it would fall into its "default" case and rewrite these
 		// expressions to the built-in flat shape, which is wrong for
 		// whatever custom CRD this config actually targets.
 		if config != autogen.ExtractionReplacementsRef {
 			for i := range spec.MatchConditions {
 				if spec.MatchConditions[i].Expression != "" {
-					convertedExpr := convertPodToTemplateExpression(spec.MatchConditions[i].Expression, config)
+					convertedExpr := ConvertPodToTemplateExpression(spec.MatchConditions[i].Expression, config)
 					spec.MatchConditions[i].Expression = convertedExpr
 				}
 			}
 
 			for i := range spec.Mutations {
 				if spec.Mutations[i].ApplyConfiguration != nil && spec.Mutations[i].ApplyConfiguration.Expression != "" {
-					convertedExpr := convertPodToTemplateExpression(spec.Mutations[i].ApplyConfiguration.Expression, config)
+					convertedExpr := ConvertPodToTemplateExpression(spec.Mutations[i].ApplyConfiguration.Expression, config)
 					spec.Mutations[i].ApplyConfiguration.Expression = convertedExpr
 				}
 			}
@@ -106,8 +106,8 @@ func generateRuleForControllers(spec *policiesv1beta1.MutatingPolicySpec, config
 	return rules, nil
 }
 
-// convertPodToTemplateExpression converts pod mutation expressions to template expressions
-func convertPodToTemplateExpression(expression string, config string) string {
+// ConvertPodToTemplateExpression converts pod mutation expressions to template expressions
+func ConvertPodToTemplateExpression(expression string, config string) string {
 	var specReplacement string
 	var metadataReplacement string
 

--- a/pkg/cel/policies/mpol/autogen/autogen_test.go
+++ b/pkg/cel/policies/mpol/autogen/autogen_test.go
@@ -163,7 +163,7 @@ func TestConvertPodToTemplateExpression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := convertPodToTemplateExpression(tt.input, tt.config)
+			result := ConvertPodToTemplateExpression(tt.input, tt.config)
 			assert.Equal(t, normalize(tt.expected), normalize(result))
 		})
 	}
@@ -676,7 +676,7 @@ func TestMutationConversionEdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := convertPodToTemplateExpression(tt.input, tt.config)
+			result := ConvertPodToTemplateExpression(tt.input, tt.config)
 			assert.Equal(t, normalize(tt.expected), normalize(result))
 		})
 	}

--- a/pkg/controllers/admissionpolicygenerator/controller.go
+++ b/pkg/controllers/admissionpolicygenerator/controller.go
@@ -31,6 +31,7 @@ import (
 	admissionregistrationv1listers "k8s.io/client-go/listers/admissionregistration/v1"
 	admissionregistrationv1alpha1listers "k8s.io/client-go/listers/admissionregistration/v1alpha1"
 	admissionregistrationv1beta1listers "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -284,42 +285,74 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 	return nil
 }
 
+// updatePolicyStatus writes generated/msg to the policy's status, retrying on write conflicts.
+// A conflict here is expected, not exceptional: the policystatus controller (pkg/controllers/
+// policystatus) independently recomputes and persists this same policy's Autogen.Configs on the
+// same spec-change event this controller reacts to, so the two controllers routinely race to
+// UpdateStatus the same object. Without a retry, a lost race silently drops this status write with
+// no requeue (the reconcile still returns nil), leaving status.generated/the status message stale
+// indefinitely - exactly the kind of staleness that matters here now that generated/msg reflect a
+// real, user-visible distinction (fully native vs. partially webhook-covered autogen fan-out) and
+// not just a boolean toggle. Refetching via the lister on each attempt (rather than reusing the
+// first DeepCopy) is required for RetryOnConflict to make forward progress.
 func (c *controller) updatePolicyStatus(ctx context.Context, policy engineapi.GenericPolicy, generated bool, msg string) {
 	if pol := policy.AsKyvernoPolicy(); pol != nil {
 		cpol := pol.(*kyvernov1.ClusterPolicy)
-		latest := cpol.DeepCopy()
-		latest.Status.ValidatingAdmissionPolicy.Generated = generated
-		latest.Status.ValidatingAdmissionPolicy.Message = msg
-
-		new, err := c.kyvernoClient.KyvernoV1().ClusterPolicies().UpdateStatus(ctx, latest, metav1.UpdateOptions{})
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest, err := c.cpolLister.Get(cpol.GetName())
+			if err != nil {
+				return err
+			}
+			latest = latest.DeepCopy()
+			latest.Status.ValidatingAdmissionPolicy.Generated = generated
+			latest.Status.ValidatingAdmissionPolicy.Message = msg
+			_, err = c.kyvernoClient.KyvernoV1().ClusterPolicies().UpdateStatus(ctx, latest, metav1.UpdateOptions{})
+			return err
+		})
 		if err != nil {
-			logging.Error(err, "failed to update cluster policy status", "name", cpol.GetName(), "status", latest.Status)
+			if !apierrors.IsNotFound(err) {
+				logging.Error(err, "failed to update cluster policy status", "name", cpol.GetName())
+			}
 			return
 		}
-		logging.V(3).Info("updated cluster policy status", "name", cpol.GetName(), "status", new.Status)
+		logging.V(3).Info("updated cluster policy status", "name", cpol.GetName(), "generated", generated, "message", msg)
 	} else if vpol := policy.AsValidatingPolicy(); vpol != nil {
-		latest := vpol.DeepCopy()
-		latest.Status.Generated = generated
-		latest.Status.GetConditionStatus().Message = msg
-
-		new, err := c.kyvernoClient.PoliciesV1beta1().ValidatingPolicies().UpdateStatus(ctx, latest, metav1.UpdateOptions{})
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest, err := c.vpolLister.Get(vpol.GetName())
+			if err != nil {
+				return err
+			}
+			latest = latest.DeepCopy()
+			latest.Status.Generated = generated
+			latest.Status.GetConditionStatus().Message = msg
+			_, err = c.kyvernoClient.PoliciesV1beta1().ValidatingPolicies().UpdateStatus(ctx, latest, metav1.UpdateOptions{})
+			return err
+		})
 		if err != nil {
-			logging.Error(err, "failed to update validating policy status", "name", vpol.GetName(), "status", latest.Status)
+			if !apierrors.IsNotFound(err) {
+				logging.Error(err, "failed to update validating policy status", "name", vpol.GetName())
+			}
 			return
 		}
-
-		logging.V(3).Info("updated validating policy status", "name", vpol.GetName(), "status", new.Status)
+		logging.V(3).Info("updated validating policy status", "name", vpol.GetName(), "generated", generated, "message", msg)
 	} else if mpol := policy.AsMutatingPolicy(); mpol != nil {
-		latest := mpol.DeepCopy()
-		latest.Status.Generated = generated
-		latest.Status.GetConditionStatus().Message = msg
-
-		new, err := c.kyvernoClient.PoliciesV1beta1().MutatingPolicies().UpdateStatus(ctx, latest, metav1.UpdateOptions{})
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest, err := c.mpolLister.Get(mpol.GetName())
+			if err != nil {
+				return err
+			}
+			latest = latest.DeepCopy()
+			latest.Status.Generated = generated
+			latest.Status.GetConditionStatus().Message = msg
+			_, err = c.kyvernoClient.PoliciesV1beta1().MutatingPolicies().UpdateStatus(ctx, latest, metav1.UpdateOptions{})
+			return err
+		})
 		if err != nil {
-			logging.Error(err, "failed to update mutating policy status", "name", mpol.GetName(), "status", latest.Status)
+			if !apierrors.IsNotFound(err) {
+				logging.Error(err, "failed to update mutating policy status", "name", mpol.GetName())
+			}
 			return
 		}
-
-		logging.V(3).Info("updated mutating policy status", "name", mpol.GetName(), "status", new.Status)
+		logging.V(3).Info("updated mutating policy status", "name", mpol.GetName(), "generated", generated, "message", msg)
 	}
 }

--- a/pkg/controllers/admissionpolicygenerator/controller.go
+++ b/pkg/controllers/admissionpolicygenerator/controller.go
@@ -293,17 +293,18 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 // no requeue (the reconcile still returns nil), leaving status.generated/the status message stale
 // indefinitely - exactly the kind of staleness that matters here now that generated/msg reflect a
 // real, user-visible distinction (fully native vs. partially webhook-covered autogen fan-out) and
-// not just a boolean toggle. Refetching via the lister on each attempt (rather than reusing the
-// first DeepCopy) is required for RetryOnConflict to make forward progress.
+// not just a boolean toggle. Each retry attempt re-fetches with a live client Get (not the
+// informer-backed lister): the lister's cache may not have observed the concurrent write that
+// caused the conflict yet, so refetching from the lister would just return the same stale
+// ResourceVersion on every attempt and fail identically each time, defeating the retry entirely.
 func (c *controller) updatePolicyStatus(ctx context.Context, policy engineapi.GenericPolicy, generated bool, msg string) {
 	if pol := policy.AsKyvernoPolicy(); pol != nil {
 		cpol := pol.(*kyvernov1.ClusterPolicy)
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			latest, err := c.cpolLister.Get(cpol.GetName())
+			latest, err := c.kyvernoClient.KyvernoV1().ClusterPolicies().Get(ctx, cpol.GetName(), metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
-			latest = latest.DeepCopy()
 			latest.Status.ValidatingAdmissionPolicy.Generated = generated
 			latest.Status.ValidatingAdmissionPolicy.Message = msg
 			_, err = c.kyvernoClient.KyvernoV1().ClusterPolicies().UpdateStatus(ctx, latest, metav1.UpdateOptions{})
@@ -318,11 +319,10 @@ func (c *controller) updatePolicyStatus(ctx context.Context, policy engineapi.Ge
 		logging.V(3).Info("updated cluster policy status", "name", cpol.GetName(), "generated", generated, "message", msg)
 	} else if vpol := policy.AsValidatingPolicy(); vpol != nil {
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			latest, err := c.vpolLister.Get(vpol.GetName())
+			latest, err := c.kyvernoClient.PoliciesV1beta1().ValidatingPolicies().Get(ctx, vpol.GetName(), metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
-			latest = latest.DeepCopy()
 			latest.Status.Generated = generated
 			latest.Status.GetConditionStatus().Message = msg
 			_, err = c.kyvernoClient.PoliciesV1beta1().ValidatingPolicies().UpdateStatus(ctx, latest, metav1.UpdateOptions{})
@@ -337,11 +337,10 @@ func (c *controller) updatePolicyStatus(ctx context.Context, policy engineapi.Ge
 		logging.V(3).Info("updated validating policy status", "name", vpol.GetName(), "generated", generated, "message", msg)
 	} else if mpol := policy.AsMutatingPolicy(); mpol != nil {
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			latest, err := c.mpolLister.Get(mpol.GetName())
+			latest, err := c.kyvernoClient.PoliciesV1beta1().MutatingPolicies().Get(ctx, mpol.GetName(), metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
-			latest = latest.DeepCopy()
 			latest.Status.Generated = generated
 			latest.Status.GetConditionStatus().Message = msg
 			_, err = c.kyvernoClient.PoliciesV1beta1().MutatingPolicies().UpdateStatus(ctx, latest, metav1.UpdateOptions{})

--- a/pkg/controllers/admissionpolicygenerator/generate-map.go
+++ b/pkg/controllers/admissionpolicygenerator/generate-map.go
@@ -22,9 +22,12 @@ import (
 
 // mapVariant is one desired MutatingAdmissionPolicy for a policy: either the base (unmodified)
 // policy, or the rewritten rule for one autogen group (e.g. "defaults", "cronjobs").
-// specOverride is nil for the base variant.
+// group/specOverride are "" / nil for the base variant. group is also needed (independent of
+// specOverride) to correctly rewrite any PolicyException embedded into this variant - see
+// BuildMutatingAdmissionPolicy's group parameter.
 type mapVariant struct {
 	name         string
+	group        string
 	specOverride *policiesv1beta1.MutatingPolicySpec
 }
 
@@ -39,7 +42,7 @@ func desiredMAPVariants(mpol *policiesv1beta1.MutatingPolicy, baseName string) (
 			skippedGroups = append(skippedGroups, group)
 			continue
 		}
-		variants = append(variants, mapVariant{name: baseName + "-" + group, specOverride: configs[group].Spec})
+		variants = append(variants, mapVariant{name: baseName + "-" + group, group: group, specOverride: configs[group].Spec})
 	}
 	return variants, skippedGroups
 }
@@ -184,13 +187,13 @@ func (c *controller) applyMAPV1(ctx context.Context, variant mapVariant, mpol *p
 	}
 
 	if observedMAP.ResourceVersion == "" {
-		admissionpolicy.BuildMutatingAdmissionPolicyV1(observedMAP, mpol, celexceptions, variant.specOverride)
+		admissionpolicy.BuildMutatingAdmissionPolicyV1(observedMAP, mpol, celexceptions, variant.group, variant.specOverride)
 		if _, err := c.client.AdmissionregistrationV1().MutatingAdmissionPolicies().Create(ctx, observedMAP, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create mutatingadmissionpolicy %s: %v", variant.name, err)
 		}
 	} else {
 		if _, err := controllerutils.Update(ctx, observedMAP, c.client.AdmissionregistrationV1().MutatingAdmissionPolicies(), func(observed *admissionregistrationv1.MutatingAdmissionPolicy) error {
-			admissionpolicy.BuildMutatingAdmissionPolicyV1(observed, mpol, celexceptions, variant.specOverride)
+			admissionpolicy.BuildMutatingAdmissionPolicyV1(observed, mpol, celexceptions, variant.group, variant.specOverride)
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to update mutatingadmissionpolicy %s: %v", variant.name, err)
@@ -232,14 +235,14 @@ func (c *controller) applyMAPAlpha(ctx context.Context, variant mapVariant, mpol
 	}
 
 	if observedMAP.ResourceVersion == "" {
-		admissionpolicy.BuildMutatingAdmissionPolicy(observedMAP, mpol, celexceptions, variant.specOverride)
+		admissionpolicy.BuildMutatingAdmissionPolicy(observedMAP, mpol, celexceptions, variant.group, variant.specOverride)
 		if _, err := c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().Create(ctx, observedMAP, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create mutatingadmissionpolicy %s: %v", variant.name, err)
 		}
 	} else {
 		if _, err := controllerutils.Update(ctx, observedMAP, c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies(),
 			func(observed *admissionregistrationv1alpha1.MutatingAdmissionPolicy) error {
-				admissionpolicy.BuildMutatingAdmissionPolicy(observed, mpol, celexceptions, variant.specOverride)
+				admissionpolicy.BuildMutatingAdmissionPolicy(observed, mpol, celexceptions, variant.group, variant.specOverride)
 				return nil
 			}); err != nil {
 			return fmt.Errorf("failed to update mutatingadmissionpolicy %s: %v", variant.name, err)
@@ -282,14 +285,14 @@ func (c *controller) applyMAPBeta(ctx context.Context, variant mapVariant, mpol 
 	}
 
 	if observedMAP.ResourceVersion == "" {
-		admissionpolicy.BuildMutatingAdmissionPolicyBeta(observedMAP, mpol, celexceptions, variant.specOverride)
+		admissionpolicy.BuildMutatingAdmissionPolicyBeta(observedMAP, mpol, celexceptions, variant.group, variant.specOverride)
 		if _, err := c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicies().Create(ctx, observedMAP, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create mutatingadmissionpolicy %s: %v", variant.name, err)
 		}
 	} else {
 		if _, err := controllerutils.Update(ctx, observedMAP, c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicies(),
 			func(observed *admissionregistrationv1beta1.MutatingAdmissionPolicy) error {
-				admissionpolicy.BuildMutatingAdmissionPolicyBeta(observed, mpol, celexceptions, variant.specOverride)
+				admissionpolicy.BuildMutatingAdmissionPolicyBeta(observed, mpol, celexceptions, variant.group, variant.specOverride)
 				return nil
 			}); err != nil {
 			return fmt.Errorf("failed to update mutatingadmissionpolicy %s: %v", variant.name, err)

--- a/pkg/controllers/admissionpolicygenerator/generate-map.go
+++ b/pkg/controllers/admissionpolicygenerator/generate-map.go
@@ -3,9 +3,13 @@ package admissionpolicygenerator
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/admissionpolicy"
+	mpolautogen "github.com/kyverno/kyverno/pkg/cel/policies/mpol/autogen"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -13,7 +17,32 @@ import (
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
+
+// mapVariant is one desired MutatingAdmissionPolicy for a policy: either the base (unmodified)
+// policy, or the rewritten rule for one autogen group (e.g. "defaults", "cronjobs").
+// specOverride is nil for the base variant.
+type mapVariant struct {
+	name         string
+	specOverride *policiesv1beta1.MutatingPolicySpec
+}
+
+// desiredMAPVariants mirrors desiredVAPVariants (generate-vap.go) for MutatingPolicy: the base
+// policy plus one per translatable autogen group, with extraction-mode (custom-CRD) groups
+// excluded and reported back separately - see desiredVAPVariants' doc comment for why.
+func desiredMAPVariants(mpol *policiesv1beta1.MutatingPolicy, baseName string) (variants []mapVariant, skippedGroups []string) {
+	variants = append(variants, mapVariant{name: baseName})
+	configs := mpol.GetStatus().Autogen.Configs
+	for _, group := range slices.Sorted(maps.Keys(configs)) {
+		if group == mpolautogen.ExtractionReplacementsRef {
+			skippedGroups = append(skippedGroups, group)
+			continue
+		}
+		variants = append(variants, mapVariant{name: baseName + "-" + group, specOverride: configs[group].Spec})
+	}
+	return variants, skippedGroups
+}
 
 // preferredMAPVersion returns the API version to use based on which listers are initialised.
 // Both the policy and binding listers must be set for a version to be considered available.
@@ -44,6 +73,22 @@ func (c *controller) handleMAPGeneration(ctx context.Context, mpol *policiesv1be
 	return c.handleMAPGenerationWithVersion(ctx, mpol, version)
 }
 
+// mapFullSkipReason returns a non-empty reason when a MutatingAdmissionPolicy must not be
+// generated at all for the policy (any previously generated variant is deleted). Unlike pod
+// controller autogen (handled per-group by the fan-out below), these are whole-policy blockers:
+// useServerSideApply mutates atomic fields that a native MutatingAdmissionPolicy rejects, so a
+// generated MAP (which becomes the sole admission path once status.generated is set) would drop
+// the mutation.
+func mapFullSkipReason(mpol *policiesv1beta1.MutatingPolicy) string {
+	if !mpol.GetSpec().GenerateMutatingAdmissionPolicyEnabled() {
+		return "skip generating MutatingAdmissionPolicy: not enabled."
+	}
+	if ec := mpol.GetSpec().EvaluationConfiguration; ec != nil && ec.UseServerSideApply {
+		return "skip generating MutatingAdmissionPolicy: useServerSideApply is enabled, which mutates atomic fields that a native MutatingAdmissionPolicy rejects."
+	}
+	return ""
+}
+
 func (c *controller) handleMAPGenerationWithVersion(ctx context.Context, mpol *policiesv1beta1.MutatingPolicy, version admissionpolicy.MutatingAdmissionPolicyVersion) error {
 	genericPolicy := engineapi.NewMutatingPolicy(mpol)
 	if !admissionpolicy.HasMutatingAdmissionPolicyPermissionForVersion(version, c.checker) {
@@ -58,260 +103,335 @@ func (c *controller) handleMAPGenerationWithVersion(ctx context.Context, mpol *p
 	}
 
 	mapName := "mpol-" + mpol.GetName()
-	mapBindingName := constructBindingName(mapName)
 
-	reason := mapGenerationSkipReason(mpol)
-	shouldDelete := reason != ""
+	if reason := mapFullSkipReason(mpol); reason != "" {
+		if err := c.deleteMAPVariants(ctx, nil, genericPolicy, mapName, version); err != nil {
+			return err
+		}
+		c.updatePolicyStatus(ctx, genericPolicy, false, reason)
+		return nil
+	}
 
+	celexceptions, err := c.getCELExceptions(mpol.GetName())
+	if err != nil {
+		return fmt.Errorf("failed to get celexceptions by name %s: %v", mpol.GetName(), err)
+	}
+
+	variants, skippedGroups := desiredMAPVariants(mpol, mapName)
+
+	var generateErrs []string
+	for _, variant := range variants {
+		if err := c.applyMAPVariant(ctx, version, variant, mpol, celexceptions); err != nil {
+			generateErrs = append(generateErrs, fmt.Sprintf("%s: %v", variant.name, err))
+			continue
+		}
+	}
+	if err := c.deleteMAPVariants(ctx, variants, genericPolicy, mapName, version); err != nil {
+		generateErrs = append(generateErrs, err.Error())
+	}
+
+	if len(generateErrs) > 0 {
+		err := fmt.Errorf("failed to generate MutatingAdmissionPolicy: %s", strings.Join(generateErrs, "; "))
+		c.updatePolicyStatus(ctx, genericPolicy, false, err.Error())
+		return err
+	}
+
+	// See the identical comment in handleVAPGenerationForValidatingPolicy (generate-vap.go): a
+	// custom-CRD autogen target can never become a native MAP, so status.generated must stay
+	// false whenever one is present, or Kyverno's own webhook/background-scan would stop
+	// evaluating this policy for that target entirely.
+	if len(skippedGroups) > 0 {
+		msg := fmt.Sprintf("MutatingAdmissionPolicy generated for the pod-controller autogen target(s); custom-CRD autogen target(s) (%s) cannot be translated to a native MutatingAdmissionPolicy and remain enforced via Kyverno's webhook only.", strings.Join(skippedGroups, ", "))
+		c.updatePolicyStatus(ctx, genericPolicy, false, msg)
+		return nil
+	}
+
+	c.updatePolicyStatus(ctx, genericPolicy, true, "")
+	return nil
+}
+
+// applyMAPVariant creates or updates a single MutatingAdmissionPolicy + binding, for whichever
+// API version is preferred in this cluster.
+func (c *controller) applyMAPVariant(ctx context.Context, version admissionpolicy.MutatingAdmissionPolicyVersion, variant mapVariant, mpol *policiesv1beta1.MutatingPolicy, celexceptions []policiesv1beta1.PolicyException) error {
 	switch version {
 	case admissionpolicy.MutatingAdmissionPolicyVersionV1:
-		return c.handleMAPV1(ctx, mpol, mapName, mapBindingName, shouldDelete, reason, genericPolicy)
+		return c.applyMAPV1(ctx, variant, mpol, celexceptions)
 	case admissionpolicy.MutatingAdmissionPolicyVersionV1beta1:
-		return c.handleMAPV1Beta1(ctx, mpol, mapName, mapBindingName, shouldDelete, reason, genericPolicy)
+		return c.applyMAPBeta(ctx, variant, mpol, celexceptions)
 	case admissionpolicy.MutatingAdmissionPolicyVersionV1alpha1:
-		return c.handleMAPV1Alpha1(ctx, mpol, mapName, mapBindingName, shouldDelete, reason, genericPolicy)
+		return c.applyMAPAlpha(ctx, variant, mpol, celexceptions)
 	default:
 		return fmt.Errorf("unsupported MutatingAdmissionPolicy version: %s", version)
 	}
 }
 
-func (c *controller) handleMAPV1(ctx context.Context, mpol *policiesv1beta1.MutatingPolicy, mapName, mapBindingName string, shouldDelete bool, reason string, genericPolicy engineapi.GenericPolicy) error {
-	observedMAP, mapErr := c.getMutatingAdmissionPolicyV1(mapName)
+func (c *controller) applyMAPV1(ctx context.Context, variant mapVariant, mpol *policiesv1beta1.MutatingPolicy, celexceptions []policiesv1beta1.PolicyException) error {
+	mapBindingName := constructBindingName(variant.name)
+	observedMAP, mapErr := c.getMutatingAdmissionPolicyV1(variant.name)
 	observedMAPbinding, mapBindingErr := c.getMutatingAdmissionPolicyBindingV1(mapBindingName)
-
-	if shouldDelete {
-		if mapErr == nil {
-			if err := c.client.AdmissionregistrationV1().MutatingAdmissionPolicies().Delete(ctx, mapName, metav1.DeleteOptions{}); err != nil {
-				return err
-			}
-		}
-		if mapBindingErr == nil {
-			if err := c.client.AdmissionregistrationV1().MutatingAdmissionPolicyBindings().Delete(ctx, mapBindingName, metav1.DeleteOptions{}); err != nil {
-				return err
-			}
-		}
-		c.updatePolicyStatus(ctx, genericPolicy, false, reason)
-		return nil
-	}
-
-	celexceptions, err := c.getCELExceptions(mpol.GetName())
-	if err != nil {
-		return fmt.Errorf("failed to get celexceptions by name %s: %v", mpol.GetName(), err)
-	}
 
 	if mapErr != nil {
 		if !apierrors.IsNotFound(mapErr) {
-			return fmt.Errorf("failed to get mutatingadmissionpolicy %s: %v", mapName, mapErr)
+			return fmt.Errorf("failed to get mutatingadmissionpolicy %s: %v", variant.name, mapErr)
 		}
-		observedMAP = &admissionregistrationv1.MutatingAdmissionPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: mapName},
-		}
+		observedMAP = &admissionregistrationv1.MutatingAdmissionPolicy{ObjectMeta: metav1.ObjectMeta{Name: variant.name}}
 	}
 	if mapBindingErr != nil {
 		if !apierrors.IsNotFound(mapBindingErr) {
 			return fmt.Errorf("failed to get mutatingadmissionpolicybinding %s: %v", mapBindingName, mapBindingErr)
 		}
-		observedMAPbinding = &admissionregistrationv1.MutatingAdmissionPolicyBinding{
-			ObjectMeta: metav1.ObjectMeta{Name: mapBindingName},
-		}
+		observedMAPbinding = &admissionregistrationv1.MutatingAdmissionPolicyBinding{ObjectMeta: metav1.ObjectMeta{Name: mapBindingName}}
 	}
 
 	if observedMAP.ResourceVersion == "" {
-		admissionpolicy.BuildMutatingAdmissionPolicyV1(observedMAP, mpol, celexceptions)
+		admissionpolicy.BuildMutatingAdmissionPolicyV1(observedMAP, mpol, celexceptions, variant.specOverride)
 		if _, err := c.client.AdmissionregistrationV1().MutatingAdmissionPolicies().Create(ctx, observedMAP, metav1.CreateOptions{}); err != nil {
-			return fmt.Errorf("failed to create mutatingadmissionpolicy %s: %v", observedMAP.GetName(), err)
+			return fmt.Errorf("failed to create mutatingadmissionpolicy %s: %v", variant.name, err)
 		}
 	} else {
 		if _, err := controllerutils.Update(ctx, observedMAP, c.client.AdmissionregistrationV1().MutatingAdmissionPolicies(), func(observed *admissionregistrationv1.MutatingAdmissionPolicy) error {
-			admissionpolicy.BuildMutatingAdmissionPolicyV1(observed, mpol, celexceptions)
+			admissionpolicy.BuildMutatingAdmissionPolicyV1(observed, mpol, celexceptions, variant.specOverride)
 			return nil
 		}); err != nil {
-			return fmt.Errorf("failed to update mutatingadmissionpolicy %s: %v", observedMAP.GetName(), err)
+			return fmt.Errorf("failed to update mutatingadmissionpolicy %s: %v", variant.name, err)
 		}
 	}
 
 	if observedMAPbinding.ResourceVersion == "" {
-		admissionpolicy.BuildMutatingAdmissionPolicyBindingV1(observedMAPbinding, mpol)
+		admissionpolicy.BuildMutatingAdmissionPolicyBindingV1(observedMAPbinding, mpol, variant.name)
 		if _, err := c.client.AdmissionregistrationV1().MutatingAdmissionPolicyBindings().Create(ctx, observedMAPbinding, metav1.CreateOptions{}); err != nil {
-			return fmt.Errorf("failed to create mutatingadmissionpolicybinding %s: %v", observedMAPbinding.GetName(), err)
+			return fmt.Errorf("failed to create mutatingadmissionpolicybinding %s: %v", mapBindingName, err)
 		}
 	} else {
 		if _, err := controllerutils.Update(ctx, observedMAPbinding, c.client.AdmissionregistrationV1().MutatingAdmissionPolicyBindings(), func(observed *admissionregistrationv1.MutatingAdmissionPolicyBinding) error {
-			admissionpolicy.BuildMutatingAdmissionPolicyBindingV1(observed, mpol)
+			admissionpolicy.BuildMutatingAdmissionPolicyBindingV1(observed, mpol, variant.name)
 			return nil
 		}); err != nil {
-			return fmt.Errorf("failed to update mutatingadmissionpolicybinding %s: %v", observedMAPbinding.GetName(), err)
+			return fmt.Errorf("failed to update mutatingadmissionpolicybinding %s: %v", mapBindingName, err)
 		}
 	}
-
-	c.updatePolicyStatus(ctx, genericPolicy, true, "")
 	return nil
 }
 
-// mapGenerationSkipReason returns a non-empty reason when a MutatingAdmissionPolicy must not be
-// generated for the policy, in which case any previously generated policy is deleted instead.
-// useServerSideApply mutates atomic fields that a native MutatingAdmissionPolicy rejects, so a
-// generated MAP (which becomes the sole admission path once status.generated is set) would drop the
-// mutation. Pod-controller autogen is likewise incompatible with MAP generation.
-func mapGenerationSkipReason(mpol *policiesv1beta1.MutatingPolicy) string {
-	if !mpol.GetSpec().GenerateMutatingAdmissionPolicyEnabled() {
-		return "skip generating MutatingAdmissionPolicy: not enabled."
-	}
-	if ec := mpol.GetSpec().EvaluationConfiguration; ec != nil && ec.UseServerSideApply {
-		return "skip generating MutatingAdmissionPolicy: useServerSideApply is enabled, which mutates atomic fields that a native MutatingAdmissionPolicy rejects."
-	}
-	if len(mpol.GetStatus().Autogen.Configs) > 0 {
-		return "skip generating MutatingAdmissionPolicy: pod controllers autogen is enabled."
-	}
-	return ""
-}
-
-func (c *controller) handleMAPV1Alpha1(ctx context.Context, mpol *policiesv1beta1.MutatingPolicy, mapName, mapBindingName string, shouldDelete bool, reason string, genericPolicy engineapi.GenericPolicy) error {
-	observedMAP, mapErr := c.getMutatingAdmissionPolicy(mapName)
+func (c *controller) applyMAPAlpha(ctx context.Context, variant mapVariant, mpol *policiesv1beta1.MutatingPolicy, celexceptions []policiesv1beta1.PolicyException) error {
+	mapBindingName := constructBindingName(variant.name)
+	observedMAP, mapErr := c.getMutatingAdmissionPolicy(variant.name)
 	observedMAPbinding, mapBindingErr := c.getMutatingAdmissionPolicyBinding(mapBindingName)
-
-	if shouldDelete {
-		if mapErr == nil {
-			if err := c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().Delete(ctx, mapName, metav1.DeleteOptions{}); err != nil {
-				return err
-			}
-		}
-		if mapBindingErr == nil {
-			if err := c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings().Delete(ctx, mapBindingName, metav1.DeleteOptions{}); err != nil {
-				return err
-			}
-		}
-		c.updatePolicyStatus(ctx, genericPolicy, false, reason)
-		return nil
-	}
-
-	celexceptions, err := c.getCELExceptions(mpol.GetName())
-	if err != nil {
-		return fmt.Errorf("failed to get celexceptions by name %s: %v", mpol.GetName(), err)
-	}
 
 	if mapErr != nil {
 		if !apierrors.IsNotFound(mapErr) {
-			return fmt.Errorf("failed to get mutatingadmissionpolicy %s: %v", mapName, mapErr)
+			return fmt.Errorf("failed to get mutatingadmissionpolicy %s: %v", variant.name, mapErr)
 		}
-		observedMAP = &admissionregistrationv1alpha1.MutatingAdmissionPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: mapName},
-		}
+		observedMAP = &admissionregistrationv1alpha1.MutatingAdmissionPolicy{ObjectMeta: metav1.ObjectMeta{Name: variant.name}}
 	}
 	if mapBindingErr != nil {
 		if !apierrors.IsNotFound(mapBindingErr) {
 			return fmt.Errorf("failed to get mutatingadmissionpolicybinding %s: %v", mapBindingName, mapBindingErr)
 		}
-		observedMAPbinding = &admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{
-			ObjectMeta: metav1.ObjectMeta{Name: mapBindingName},
-		}
+		observedMAPbinding = &admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{ObjectMeta: metav1.ObjectMeta{Name: mapBindingName}}
 	}
 
 	if observedMAP.ResourceVersion == "" {
-		admissionpolicy.BuildMutatingAdmissionPolicy(observedMAP, mpol, celexceptions)
+		admissionpolicy.BuildMutatingAdmissionPolicy(observedMAP, mpol, celexceptions, variant.specOverride)
 		if _, err := c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().Create(ctx, observedMAP, metav1.CreateOptions{}); err != nil {
-			return fmt.Errorf("failed to create mutatingadmissionpolicy %s: %v", observedMAP.GetName(), err)
+			return fmt.Errorf("failed to create mutatingadmissionpolicy %s: %v", variant.name, err)
 		}
 	} else {
 		if _, err := controllerutils.Update(ctx, observedMAP, c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies(),
 			func(observed *admissionregistrationv1alpha1.MutatingAdmissionPolicy) error {
-				admissionpolicy.BuildMutatingAdmissionPolicy(observed, mpol, celexceptions)
+				admissionpolicy.BuildMutatingAdmissionPolicy(observed, mpol, celexceptions, variant.specOverride)
 				return nil
 			}); err != nil {
-			return fmt.Errorf("failed to update mutatingadmissionpolicy %s: %v", observedMAP.GetName(), err)
+			return fmt.Errorf("failed to update mutatingadmissionpolicy %s: %v", variant.name, err)
 		}
 	}
 
 	if observedMAPbinding.ResourceVersion == "" {
-		admissionpolicy.BuildMutatingAdmissionPolicyBinding(observedMAPbinding, mpol)
+		admissionpolicy.BuildMutatingAdmissionPolicyBinding(observedMAPbinding, mpol, variant.name)
 		if _, err := c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings().Create(ctx, observedMAPbinding, metav1.CreateOptions{}); err != nil {
-			return fmt.Errorf("failed to create mutatingadmissionpolicybinding %s: %v", observedMAPbinding.GetName(), err)
+			return fmt.Errorf("failed to create mutatingadmissionpolicybinding %s: %v", mapBindingName, err)
 		}
 	} else {
 		if _, err := controllerutils.Update(ctx, observedMAPbinding, c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings(),
 			func(observed *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding) error {
-				admissionpolicy.BuildMutatingAdmissionPolicyBinding(observed, mpol)
+				admissionpolicy.BuildMutatingAdmissionPolicyBinding(observed, mpol, variant.name)
 				return nil
 			}); err != nil {
-			return fmt.Errorf("failed to update mutatingadmissionpolicybinding %s: %v", observedMAPbinding.GetName(), err)
+			return fmt.Errorf("failed to update mutatingadmissionpolicybinding %s: %v", mapBindingName, err)
 		}
 	}
-
-	c.updatePolicyStatus(ctx, genericPolicy, true, "")
 	return nil
 }
 
-func (c *controller) handleMAPV1Beta1(ctx context.Context, mpol *policiesv1beta1.MutatingPolicy, mapName, mapBindingName string, shouldDelete bool, reason string, genericPolicy engineapi.GenericPolicy) error {
-	observedMAP, mapErr := c.getMutatingAdmissionPolicyBeta(mapName)
+func (c *controller) applyMAPBeta(ctx context.Context, variant mapVariant, mpol *policiesv1beta1.MutatingPolicy, celexceptions []policiesv1beta1.PolicyException) error {
+	mapBindingName := constructBindingName(variant.name)
+	observedMAP, mapErr := c.getMutatingAdmissionPolicyBeta(variant.name)
 	observedMAPbinding, mapBindingErr := c.getMutatingAdmissionPolicyBindingBeta(mapBindingName)
-
-	if shouldDelete {
-		if mapErr == nil {
-			if err := c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicies().Delete(ctx, mapName, metav1.DeleteOptions{}); err != nil {
-				return err
-			}
-		}
-		if mapBindingErr == nil {
-			if err := c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicyBindings().Delete(ctx, mapBindingName, metav1.DeleteOptions{}); err != nil {
-				return err
-			}
-		}
-		c.updatePolicyStatus(ctx, genericPolicy, false, reason)
-		return nil
-	}
-
-	celexceptions, err := c.getCELExceptions(mpol.GetName())
-	if err != nil {
-		return fmt.Errorf("failed to get celexceptions by name %s: %v", mpol.GetName(), err)
-	}
 
 	if mapErr != nil {
 		if !apierrors.IsNotFound(mapErr) {
-			return fmt.Errorf("failed to get mutatingadmissionpolicy %s: %v", mapName, mapErr)
+			return fmt.Errorf("failed to get mutatingadmissionpolicy %s: %v", variant.name, mapErr)
 		}
-		observedMAP = &admissionregistrationv1beta1.MutatingAdmissionPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: mapName},
-		}
+		observedMAP = &admissionregistrationv1beta1.MutatingAdmissionPolicy{ObjectMeta: metav1.ObjectMeta{Name: variant.name}}
 	}
 	if mapBindingErr != nil {
 		if !apierrors.IsNotFound(mapBindingErr) {
 			return fmt.Errorf("failed to get mutatingadmissionpolicybinding %s: %v", mapBindingName, mapBindingErr)
 		}
-		observedMAPbinding = &admissionregistrationv1beta1.MutatingAdmissionPolicyBinding{
-			ObjectMeta: metav1.ObjectMeta{Name: mapBindingName},
-		}
+		observedMAPbinding = &admissionregistrationv1beta1.MutatingAdmissionPolicyBinding{ObjectMeta: metav1.ObjectMeta{Name: mapBindingName}}
 	}
 
 	if observedMAP.ResourceVersion == "" {
-		admissionpolicy.BuildMutatingAdmissionPolicyBeta(observedMAP, mpol, celexceptions)
+		admissionpolicy.BuildMutatingAdmissionPolicyBeta(observedMAP, mpol, celexceptions, variant.specOverride)
 		if _, err := c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicies().Create(ctx, observedMAP, metav1.CreateOptions{}); err != nil {
-			return fmt.Errorf("failed to create mutatingadmissionpolicy %s: %v", observedMAP.GetName(), err)
+			return fmt.Errorf("failed to create mutatingadmissionpolicy %s: %v", variant.name, err)
 		}
 	} else {
 		if _, err := controllerutils.Update(ctx, observedMAP, c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicies(),
 			func(observed *admissionregistrationv1beta1.MutatingAdmissionPolicy) error {
-				admissionpolicy.BuildMutatingAdmissionPolicyBeta(observed, mpol, celexceptions)
+				admissionpolicy.BuildMutatingAdmissionPolicyBeta(observed, mpol, celexceptions, variant.specOverride)
 				return nil
 			}); err != nil {
-			return fmt.Errorf("failed to update mutatingadmissionpolicy %s: %v", observedMAP.GetName(), err)
+			return fmt.Errorf("failed to update mutatingadmissionpolicy %s: %v", variant.name, err)
 		}
 	}
 
 	if observedMAPbinding.ResourceVersion == "" {
-		admissionpolicy.BuildMutatingAdmissionPolicyBindingBeta(observedMAPbinding, mpol)
+		admissionpolicy.BuildMutatingAdmissionPolicyBindingBeta(observedMAPbinding, mpol, variant.name)
 		if _, err := c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicyBindings().Create(ctx, observedMAPbinding, metav1.CreateOptions{}); err != nil {
-			return fmt.Errorf("failed to create mutatingadmissionpolicybinding %s: %v", observedMAPbinding.GetName(), err)
+			return fmt.Errorf("failed to create mutatingadmissionpolicybinding %s: %v", mapBindingName, err)
 		}
 	} else {
 		if _, err := controllerutils.Update(ctx, observedMAPbinding, c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicyBindings(),
 			func(observed *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding) error {
-				admissionpolicy.BuildMutatingAdmissionPolicyBindingBeta(observed, mpol)
+				admissionpolicy.BuildMutatingAdmissionPolicyBindingBeta(observed, mpol, variant.name)
 				return nil
 			}); err != nil {
-			return fmt.Errorf("failed to update mutatingadmissionpolicybinding %s: %v", observedMAPbinding.GetName(), err)
+			return fmt.Errorf("failed to update mutatingadmissionpolicybinding %s: %v", mapBindingName, err)
 		}
 	}
-
-	c.updatePolicyStatus(ctx, genericPolicy, true, "")
 	return nil
+}
+
+// deleteMAPVariants removes any MutatingAdmissionPolicy (+ binding) previously generated for this
+// policy that isn't in the current desired set - mirrors deleteVAPVariants (generate-vap.go); see
+// its doc comment for why ownership is checked by UID rather than the name prefix alone.
+func (c *controller) deleteMAPVariants(ctx context.Context, desired []mapVariant, policy engineapi.GenericPolicy, baseName string, version admissionpolicy.MutatingAdmissionPolicyVersion) error {
+	desiredNames := make(map[string]bool, len(desired))
+	for _, v := range desired {
+		desiredNames[v.name] = true
+	}
+
+	owned, err := c.listOwnedMAPNames(policy, baseName, version)
+	if err != nil {
+		return err
+	}
+	for _, name := range owned {
+		if desiredNames[name] {
+			continue
+		}
+		if err := c.deleteMAPByVersion(ctx, version, name, constructBindingName(name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *controller) deleteMAPByVersion(ctx context.Context, version admissionpolicy.MutatingAdmissionPolicyVersion, name, bindingName string) error {
+	switch version {
+	case admissionpolicy.MutatingAdmissionPolicyVersionV1:
+		if err := c.client.AdmissionregistrationV1().MutatingAdmissionPolicies().Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete stale mutatingadmissionpolicy %s: %v", name, err)
+		}
+		if err := c.client.AdmissionregistrationV1().MutatingAdmissionPolicyBindings().Delete(ctx, bindingName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete stale mutatingadmissionpolicybinding %s: %v", bindingName, err)
+		}
+	case admissionpolicy.MutatingAdmissionPolicyVersionV1beta1:
+		if err := c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicies().Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete stale mutatingadmissionpolicy %s: %v", name, err)
+		}
+		if err := c.client.AdmissionregistrationV1beta1().MutatingAdmissionPolicyBindings().Delete(ctx, bindingName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete stale mutatingadmissionpolicybinding %s: %v", bindingName, err)
+		}
+	case admissionpolicy.MutatingAdmissionPolicyVersionV1alpha1:
+		if err := c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicies().Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete stale mutatingadmissionpolicy %s: %v", name, err)
+		}
+		if err := c.client.AdmissionregistrationV1alpha1().MutatingAdmissionPolicyBindings().Delete(ctx, bindingName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete stale mutatingadmissionpolicybinding %s: %v", bindingName, err)
+		}
+	default:
+		return fmt.Errorf("unsupported MutatingAdmissionPolicy version: %s", version)
+	}
+	return nil
+}
+
+// listOwnedMAPNames mirrors listOwnedVAPNames (generate-vap.go) for whichever MutatingAdmissionPolicy
+// API version is in use.
+func (c *controller) listOwnedMAPNames(policy engineapi.GenericPolicy, baseName string, version admissionpolicy.MutatingAdmissionPolicyVersion) ([]string, error) {
+	uid := policy.GetUID()
+	prefix := baseName + "-"
+	matches := func(name string) bool { return name == baseName || strings.HasPrefix(name, prefix) }
+
+	var names []string
+	switch version {
+	case admissionpolicy.MutatingAdmissionPolicyVersionV1:
+		if c.mapV1Lister == nil {
+			return nil, nil
+		}
+		all, err := c.mapV1Lister.List(labels.Everything())
+		if err != nil {
+			return nil, fmt.Errorf("failed to list mutatingadmissionpolicies: %v", err)
+		}
+		for _, m := range all {
+			if !matches(m.Name) {
+				continue
+			}
+			for _, ref := range m.OwnerReferences {
+				if ref.UID == uid {
+					names = append(names, m.Name)
+					break
+				}
+			}
+		}
+	case admissionpolicy.MutatingAdmissionPolicyVersionV1beta1:
+		if c.mapBetaLister == nil {
+			return nil, nil
+		}
+		all, err := c.mapBetaLister.List(labels.Everything())
+		if err != nil {
+			return nil, fmt.Errorf("failed to list mutatingadmissionpolicies: %v", err)
+		}
+		for _, m := range all {
+			if !matches(m.Name) {
+				continue
+			}
+			for _, ref := range m.OwnerReferences {
+				if ref.UID == uid {
+					names = append(names, m.Name)
+					break
+				}
+			}
+		}
+	case admissionpolicy.MutatingAdmissionPolicyVersionV1alpha1:
+		if c.mapAlphaLister == nil {
+			return nil, nil
+		}
+		all, err := c.mapAlphaLister.List(labels.Everything())
+		if err != nil {
+			return nil, fmt.Errorf("failed to list mutatingadmissionpolicies: %v", err)
+		}
+		for _, m := range all {
+			if !matches(m.Name) {
+				continue
+			}
+			for _, ref := range m.OwnerReferences {
+				if ref.UID == uid {
+					names = append(names, m.Name)
+					break
+				}
+			}
+		}
+	}
+	return names, nil
 }

--- a/pkg/controllers/admissionpolicygenerator/generate-vap.go
+++ b/pkg/controllers/admissionpolicygenerator/generate-vap.go
@@ -21,9 +21,12 @@ import (
 
 // vapVariant is one desired ValidatingAdmissionPolicy for a policy: either the base
 // (unmodified) policy, or the rewritten rule for one autogen group (e.g. "defaults",
-// "cronjobs"). specOverride is nil for the base variant.
+// "cronjobs"). group/specOverride are "" / nil for the base variant. group is also needed
+// (independent of specOverride) to correctly rewrite any PolicyException embedded into this
+// variant - see BuildValidatingAdmissionPolicy's group parameter.
 type vapVariant struct {
 	name         string
+	group        string
 	specOverride *policiesv1beta1.ValidatingPolicySpec
 }
 
@@ -41,7 +44,7 @@ func desiredVAPVariants(vpol *policiesv1beta1.ValidatingPolicy, baseName string)
 			skippedGroups = append(skippedGroups, group)
 			continue
 		}
-		variants = append(variants, vapVariant{name: baseName + "-" + group, specOverride: configs[group].Spec})
+		variants = append(variants, vapVariant{name: baseName + "-" + group, group: group, specOverride: configs[group].Spec})
 	}
 	return variants, skippedGroups
 }
@@ -209,7 +212,7 @@ func (c *controller) applyVAP(
 	}
 
 	if observedVAP.ResourceVersion == "" {
-		if err := admissionpolicy.BuildValidatingAdmissionPolicy(c.discoveryClient, observedVAP, policy, genericExceptions, variant.specOverride); err != nil {
+		if err := admissionpolicy.BuildValidatingAdmissionPolicy(c.discoveryClient, observedVAP, policy, genericExceptions, variant.group, variant.specOverride); err != nil {
 			return fmt.Errorf("failed to build validatingadmissionpolicy %s: %v", variant.name, err)
 		}
 		if _, err := c.client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Create(ctx, observedVAP, metav1.CreateOptions{}); err != nil {
@@ -221,7 +224,7 @@ func (c *controller) applyVAP(
 			observedVAP,
 			c.client.AdmissionregistrationV1().ValidatingAdmissionPolicies(),
 			func(observed *admissionregistrationv1.ValidatingAdmissionPolicy) error {
-				return admissionpolicy.BuildValidatingAdmissionPolicy(c.discoveryClient, observed, policy, genericExceptions, variant.specOverride)
+				return admissionpolicy.BuildValidatingAdmissionPolicy(c.discoveryClient, observed, policy, genericExceptions, variant.group, variant.specOverride)
 			}); err != nil {
 			return fmt.Errorf("failed to update validatingadmissionpolicy %s: %v", variant.name, err)
 		}

--- a/pkg/controllers/admissionpolicygenerator/generate-vap.go
+++ b/pkg/controllers/admissionpolicygenerator/generate-vap.go
@@ -3,15 +3,48 @@ package admissionpolicygenerator
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/admissionpolicy"
+	vpolautogen "github.com/kyverno/kyverno/pkg/cel/policies/vpol/autogen"
 	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
 	"github.com/kyverno/kyverno/pkg/event"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
+
+// vapVariant is one desired ValidatingAdmissionPolicy for a policy: either the base
+// (unmodified) policy, or the rewritten rule for one autogen group (e.g. "defaults",
+// "cronjobs"). specOverride is nil for the base variant.
+type vapVariant struct {
+	name         string
+	specOverride *policiesv1beta1.ValidatingPolicySpec
+}
+
+// desiredVAPVariants returns the ValidatingAdmissionPolicies that should exist for a
+// ValidatingPolicy: the base policy plus one per translatable autogen group. Extraction-mode
+// (custom-CRD) groups are excluded and returned separately as skippedGroups - they have no
+// fixed field path a native VAP's CEL could address, since their pod template is only ever
+// located by Kyverno's own Go code at evaluation time (see pkg/cel/autogen/extract), which a
+// native VAP has no equivalent of.
+func desiredVAPVariants(vpol *policiesv1beta1.ValidatingPolicy, baseName string) (variants []vapVariant, skippedGroups []string) {
+	variants = append(variants, vapVariant{name: baseName})
+	configs := vpol.GetStatus().Autogen.Configs
+	for _, group := range slices.Sorted(maps.Keys(configs)) {
+		if group == vpolautogen.ExtractionReplacementsRef {
+			skippedGroups = append(skippedGroups, group)
+			continue
+		}
+		variants = append(variants, vapVariant{name: baseName + "-" + group, specOverride: configs[group].Spec})
+	}
+	return variants, skippedGroups
+}
 
 func (c *controller) handleVAPGeneration(ctx context.Context, polType string, policy engineapi.GenericPolicy) error {
 	// check if the controller has the required permissions to generate ValidatingAdmissionPolicies.
@@ -27,99 +60,143 @@ func (c *controller) handleVAPGeneration(ctx context.Context, polType string, po
 		return nil
 	}
 
-	var vapName string
 	if polType == "ClusterPolicy" {
-		vapName = "cpol-" + policy.GetName()
-	} else {
-		vapName = "vpol-" + policy.GetName()
+		return c.handleVAPGenerationForClusterPolicy(ctx, policy)
 	}
+	return c.handleVAPGenerationForValidatingPolicy(ctx, policy)
+}
+
+// handleVAPGenerationForClusterPolicy generates a single ValidatingAdmissionPolicy from a legacy
+// ClusterPolicy. Unchanged from before the autogen fan-out work - ClusterPolicy's own (legacy,
+// annotation-based) autogen mechanism is a structurally different problem, out of scope here.
+func (c *controller) handleVAPGenerationForClusterPolicy(ctx context.Context, policy engineapi.GenericPolicy) error {
+	vapName := "cpol-" + policy.GetName()
 	vapBindingName := constructBindingName(vapName)
-	// get the ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding if exists.
 	observedVAP, vapErr := c.getValidatingAdmissionPolicy(vapName)
 	observedVAPbinding, vapBindingErr := c.getValidatingAdmissionPolicyBinding(vapBindingName)
 
-	genericExceptions := make([]engineapi.GenericException, 0)
-	// in case of clusterpolicies, check if we can generate a VAP from it.
-	if polType == "ClusterPolicy" {
-		spec := policy.AsKyvernoPolicy().GetSpec()
-		exceptions, err := c.getExceptions(policy.GetName(), spec.Rules[0].Name)
-		if err != nil {
-			return err
-		}
-
-		if ok, msg := admissionpolicy.CanGenerateVAP(spec, exceptions, false); !ok {
-			// delete the ValidatingAdmissionPolicy if exist
-			if vapErr == nil {
-				err = c.client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete(ctx, vapName, metav1.DeleteOptions{})
-				if err != nil {
-					return err
-				}
-			}
-			// delete the ValidatingAdmissionPolicyBinding if exist
-			if vapBindingErr == nil {
-				err = c.client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, vapBindingName, metav1.DeleteOptions{})
-				if err != nil {
-					return err
-				}
-			}
-
-			if msg == "" {
-				msg = "skip generating ValidatingAdmissionPolicy: a policy exception is configured."
-			}
-			c.updatePolicyStatus(ctx, policy, false, msg)
-			return nil
-		}
-		for _, exception := range exceptions {
-			genericExceptions = append(genericExceptions, engineapi.NewPolicyException(&exception))
-		}
-	} else {
-		pol := policy.AsValidatingPolicy()
-		wantVap := pol.GetSpec().GenerateValidatingAdmissionPolicyEnabled()
-		shouldDelete := !wantVap
-
-		var reason string
-		if wantVap {
-			isAutogen := len(pol.GetStatus().Autogen.Configs) > 0
-			if isAutogen {
-				shouldDelete = true
-				reason = "skip generating ValidatingAdmissionPolicy: pod controllers autogen is enabled."
-			}
-		} else {
-			reason = "skip generating ValidatingAdmissionPolicy: not enabled."
-		}
-		if shouldDelete {
-			// delete the ValidatingAdmissionPolicy if exist
-			if vapErr == nil {
-				if err := c.client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete(ctx, vapName, metav1.DeleteOptions{}); err != nil {
-					return err
-				}
-			}
-			// delete the ValidatingAdmissionPolicyBinding if exist
-			if vapBindingErr == nil {
-				if err := c.client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, vapBindingName, metav1.DeleteOptions{}); err != nil {
-					return err
-				}
-			}
-			c.updatePolicyStatus(ctx, policy, false, reason)
-			return nil
-		}
-		celexceptions, err := c.getCELExceptions(policy.GetName())
-		if err != nil {
-			return fmt.Errorf("failed to get celexceptions by name %s: %v", policy.GetName(), err)
-		}
-		for _, exception := range celexceptions {
-			genericExceptions = append(genericExceptions, engineapi.NewCELPolicyException(&exception))
-		}
+	spec := policy.AsKyvernoPolicy().GetSpec()
+	exceptions, err := c.getExceptions(policy.GetName(), spec.Rules[0].Name)
+	if err != nil {
+		return err
 	}
 
+	if ok, msg := admissionpolicy.CanGenerateVAP(spec, exceptions, false); !ok {
+		if vapErr == nil {
+			if err := c.client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete(ctx, vapName, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+		}
+		if vapBindingErr == nil {
+			if err := c.client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, vapBindingName, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+		}
+		if msg == "" {
+			msg = "skip generating ValidatingAdmissionPolicy: a policy exception is configured."
+		}
+		c.updatePolicyStatus(ctx, policy, false, msg)
+		return nil
+	}
+
+	genericExceptions := make([]engineapi.GenericException, 0, len(exceptions))
+	for _, exception := range exceptions {
+		genericExceptions = append(genericExceptions, engineapi.NewPolicyException(&exception))
+	}
+
+	if err := c.applyVAP(ctx, vapVariant{name: vapName}, vapBindingName, observedVAP, vapErr, observedVAPbinding, vapBindingErr, policy, genericExceptions); err != nil {
+		return err
+	}
+
+	c.updatePolicyStatus(ctx, policy, true, "")
+	c.eventGen.Add(event.NewValidatingAdmissionPolicyEvent(policy, vapName, vapBindingName)...)
+	return nil
+}
+
+// handleVAPGenerationForValidatingPolicy generates one ValidatingAdmissionPolicy per autogen
+// group (the "fan-out" fix for #17423) instead of the old all-or-nothing behavior that skipped
+// VAP generation entirely whenever pod-controller autogen was configured.
+func (c *controller) handleVAPGenerationForValidatingPolicy(ctx context.Context, policy engineapi.GenericPolicy) error {
+	pol := policy.AsValidatingPolicy()
+	vapName := "vpol-" + policy.GetName()
+
+	if !pol.GetSpec().GenerateValidatingAdmissionPolicyEnabled() {
+		if err := c.deleteVAPVariants(ctx, nil, policy, vapName); err != nil {
+			return err
+		}
+		c.updatePolicyStatus(ctx, policy, false, "skip generating ValidatingAdmissionPolicy: not enabled.")
+		return nil
+	}
+
+	celexceptions, err := c.getCELExceptions(policy.GetName())
+	if err != nil {
+		return fmt.Errorf("failed to get celexceptions by name %s: %v", policy.GetName(), err)
+	}
+	genericExceptions := make([]engineapi.GenericException, 0, len(celexceptions))
+	for _, exception := range celexceptions {
+		genericExceptions = append(genericExceptions, engineapi.NewCELPolicyException(&exception))
+	}
+
+	variants, skippedGroups := desiredVAPVariants(pol, vapName)
+
+	var generateErrs []string
+	for _, variant := range variants {
+		vapBindingName := constructBindingName(variant.name)
+		observedVAP, vapErr := c.getValidatingAdmissionPolicy(variant.name)
+		observedVAPbinding, vapBindingErr := c.getValidatingAdmissionPolicyBinding(vapBindingName)
+		if err := c.applyVAP(ctx, variant, vapBindingName, observedVAP, vapErr, observedVAPbinding, vapBindingErr, policy, genericExceptions); err != nil {
+			generateErrs = append(generateErrs, fmt.Sprintf("%s: %v", variant.name, err))
+			continue
+		}
+		c.eventGen.Add(event.NewValidatingAdmissionPolicyEvent(policy, variant.name, vapBindingName)...)
+	}
+
+	if err := c.deleteVAPVariants(ctx, variants, policy, vapName); err != nil {
+		generateErrs = append(generateErrs, err.Error())
+	}
+
+	if len(generateErrs) > 0 {
+		err := fmt.Errorf("failed to generate ValidatingAdmissionPolicy: %s", strings.Join(generateErrs, "; "))
+		c.updatePolicyStatus(ctx, policy, false, err.Error())
+		return err
+	}
+
+	// A generated VAP only replaces Kyverno's own webhook/background-scan evaluation when every
+	// autogen target was actually translated - if a custom-CRD (extraction-mode) group was
+	// skipped, that group is only ever enforced by Kyverno's webhook (see pkg/cel/autogen/extract),
+	// so status.generated must stay false to keep Kyverno's own engine evaluating this policy too.
+	// This does mean the built-in-controller groups end up double-covered (both a generated VAP
+	// and Kyverno's webhook) whenever a custom CRD is also autogen'd on the same policy - a real,
+	// accepted inefficiency traded for correctness in that mixed case.
+	if len(skippedGroups) > 0 {
+		msg := fmt.Sprintf("ValidatingAdmissionPolicy generated for the pod-controller autogen target(s); custom-CRD autogen target(s) (%s) cannot be translated to a native ValidatingAdmissionPolicy and remain enforced via Kyverno's webhook only.", strings.Join(skippedGroups, ", "))
+		c.updatePolicyStatus(ctx, policy, false, msg)
+		return nil
+	}
+
+	c.updatePolicyStatus(ctx, policy, true, "")
+	return nil
+}
+
+// applyVAP creates or updates a single ValidatingAdmissionPolicy + binding for one variant
+// (the base policy or one autogen group).
+func (c *controller) applyVAP(
+	ctx context.Context,
+	variant vapVariant,
+	vapBindingName string,
+	observedVAP *admissionregistrationv1.ValidatingAdmissionPolicy,
+	vapErr error,
+	observedVAPbinding *admissionregistrationv1.ValidatingAdmissionPolicyBinding,
+	vapBindingErr error,
+	policy engineapi.GenericPolicy,
+	genericExceptions []engineapi.GenericException,
+) error {
 	if vapErr != nil {
 		if !apierrors.IsNotFound(vapErr) {
-			return fmt.Errorf("failed to get validatingadmissionpolicy %s: %v", vapName, vapErr)
+			return fmt.Errorf("failed to get validatingadmissionpolicy %s: %v", variant.name, vapErr)
 		}
 		observedVAP = &admissionregistrationv1.ValidatingAdmissionPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: vapName,
-			},
+			ObjectMeta: metav1.ObjectMeta{Name: variant.name},
 		}
 	}
 	if vapBindingErr != nil {
@@ -127,58 +204,106 @@ func (c *controller) handleVAPGeneration(ctx context.Context, polType string, po
 			return fmt.Errorf("failed to get validatingadmissionpolicybinding %s: %v", vapBindingName, vapBindingErr)
 		}
 		observedVAPbinding = &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: vapBindingName,
-			},
+			ObjectMeta: metav1.ObjectMeta{Name: vapBindingName},
 		}
 	}
 
 	if observedVAP.ResourceVersion == "" {
-		err := admissionpolicy.BuildValidatingAdmissionPolicy(c.discoveryClient, observedVAP, policy, genericExceptions)
-		if err != nil {
-			return fmt.Errorf("failed to build validatingadmissionpolicy %s: %v", observedVAP.GetName(), err)
+		if err := admissionpolicy.BuildValidatingAdmissionPolicy(c.discoveryClient, observedVAP, policy, genericExceptions, variant.specOverride); err != nil {
+			return fmt.Errorf("failed to build validatingadmissionpolicy %s: %v", variant.name, err)
 		}
-		_, err = c.client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Create(ctx, observedVAP, metav1.CreateOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to create validatingadmissionpolicy %s: %v", observedVAP.GetName(), err)
+		if _, err := c.client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Create(ctx, observedVAP, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("failed to create validatingadmissionpolicy %s: %v", variant.name, err)
 		}
 	} else {
-		_, err := controllerutils.Update(
+		if _, err := controllerutils.Update(
 			ctx,
 			observedVAP,
 			c.client.AdmissionregistrationV1().ValidatingAdmissionPolicies(),
 			func(observed *admissionregistrationv1.ValidatingAdmissionPolicy) error {
-				return admissionpolicy.BuildValidatingAdmissionPolicy(c.discoveryClient, observed, policy, genericExceptions)
-			})
-		if err != nil {
-			return fmt.Errorf("failed to update validatingadmissionpolicy %s: %v", observedVAP.GetName(), err)
+				return admissionpolicy.BuildValidatingAdmissionPolicy(c.discoveryClient, observed, policy, genericExceptions, variant.specOverride)
+			}); err != nil {
+			return fmt.Errorf("failed to update validatingadmissionpolicy %s: %v", variant.name, err)
 		}
 	}
 
 	if observedVAPbinding.ResourceVersion == "" {
-		err := admissionpolicy.BuildValidatingAdmissionPolicyBinding(observedVAPbinding, policy)
-		if err != nil {
-			return fmt.Errorf("failed to build validatingadmissionpolicybinding %s: %v", observedVAPbinding.GetName(), err)
+		if err := admissionpolicy.BuildValidatingAdmissionPolicyBinding(observedVAPbinding, policy, variant.name, variant.specOverride); err != nil {
+			return fmt.Errorf("failed to build validatingadmissionpolicybinding %s: %v", vapBindingName, err)
 		}
-		_, err = c.client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Create(ctx, observedVAPbinding, metav1.CreateOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to create validatingadmissionpolicybinding %s: %v", observedVAPbinding.GetName(), err)
+		if _, err := c.client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Create(ctx, observedVAPbinding, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("failed to create validatingadmissionpolicybinding %s: %v", vapBindingName, err)
 		}
 	} else {
-		_, err := controllerutils.Update(
+		if _, err := controllerutils.Update(
 			ctx,
 			observedVAPbinding,
 			c.client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings(),
 			func(observed *admissionregistrationv1.ValidatingAdmissionPolicyBinding) error {
-				return admissionpolicy.BuildValidatingAdmissionPolicyBinding(observed, policy)
-			})
-		if err != nil {
-			return fmt.Errorf("failed to update validatingadmissionpolicybinding %s: %v", observedVAPbinding.GetName(), err)
+				return admissionpolicy.BuildValidatingAdmissionPolicyBinding(observed, policy, variant.name, variant.specOverride)
+			}); err != nil {
+			return fmt.Errorf("failed to update validatingadmissionpolicybinding %s: %v", vapBindingName, err)
 		}
 	}
-
-	c.updatePolicyStatus(ctx, policy, true, "")
-	c.eventGen.Add(event.NewValidatingAdmissionPolicyEvent(policy, observedVAP.Name, observedVAPbinding.Name)...)
-
 	return nil
+}
+
+// deleteVAPVariants removes any ValidatingAdmissionPolicy (+ binding) previously generated for
+// this policy that isn't in the current desired set - e.g. an autogen group was removed from
+// spec.autogen.podControllers.controllers, or VAP generation was disabled entirely (desired ==
+// nil). Ownership is checked via OwnerReferences UID, not just the baseName prefix, so this can
+// never touch another policy's generated objects even if names happen to share a prefix (e.g.
+// policy "foo" vs. policy "foo-defaults").
+func (c *controller) deleteVAPVariants(ctx context.Context, desired []vapVariant, policy engineapi.GenericPolicy, baseName string) error {
+	desiredNames := make(map[string]bool, len(desired))
+	for _, v := range desired {
+		desiredNames[v.name] = true
+	}
+
+	owned, err := c.listOwnedVAPNames(policy, baseName)
+	if err != nil {
+		return err
+	}
+	for _, name := range owned {
+		if desiredNames[name] {
+			continue
+		}
+		bindingName := constructBindingName(name)
+		if err := c.client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete stale validatingadmissionpolicy %s: %v", name, err)
+		}
+		if err := c.client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, bindingName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete stale validatingadmissionpolicybinding %s: %v", bindingName, err)
+		}
+	}
+	return nil
+}
+
+// listOwnedVAPNames returns the names of every ValidatingAdmissionPolicy owned by policy (by
+// OwnerReferences UID) whose name is either baseName ("vpol-<name>"/"cpol-<name>", the base
+// variant) or "<baseName>-<group>" (an autogen-group variant). The name check is just a cheap
+// pre-filter; UID is what actually decides ownership.
+func (c *controller) listOwnedVAPNames(policy engineapi.GenericPolicy, baseName string) ([]string, error) {
+	if c.vapLister == nil {
+		return nil, nil
+	}
+	all, err := c.vapLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list validatingadmissionpolicies: %v", err)
+	}
+	uid := policy.GetUID()
+	prefix := baseName + "-"
+	var names []string
+	for _, vap := range all {
+		if vap.Name != baseName && !strings.HasPrefix(vap.Name, prefix) {
+			continue
+		}
+		for _, ref := range vap.OwnerReferences {
+			if ref.UID == uid {
+				names = append(names, vap.Name)
+				break
+			}
+		}
+	}
+	return names, nil
 }

--- a/pkg/controllers/admissionpolicygenerator/generate_map_test.go
+++ b/pkg/controllers/admissionpolicygenerator/generate_map_test.go
@@ -6,6 +6,7 @@ import (
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/pkg/admissionpolicy"
+	mpolautogen "github.com/kyverno/kyverno/pkg/cel/policies/mpol/autogen"
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -13,6 +14,72 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
 )
+
+// TestDesiredMAPVariants mirrors TestDesiredVAPVariants (generate_vap_test.go) for
+// MutatingPolicy - see its doc comment for the scenario this covers.
+func TestDesiredMAPVariants(t *testing.T) {
+	baseSpec := &policiesv1beta1.MutatingPolicySpec{}
+
+	tests := []struct {
+		name        string
+		configs     map[string]policiesv1beta1.MutatingPolicyAutogen
+		wantNames   []string
+		wantSkipped []string
+	}{
+		{
+			name:      "no autogen: base variant only",
+			wantNames: []string{"mpol-test"},
+		},
+		{
+			name: "one translatable group",
+			configs: map[string]policiesv1beta1.MutatingPolicyAutogen{
+				"defaults": {Spec: baseSpec},
+			},
+			wantNames: []string{"mpol-test", "mpol-test-defaults"},
+		},
+		{
+			name: "extraction-mode group only: no group variant, reported as skipped",
+			configs: map[string]policiesv1beta1.MutatingPolicyAutogen{
+				mpolautogen.ExtractionReplacementsRef: {Spec: baseSpec},
+			},
+			wantNames:   []string{"mpol-test"},
+			wantSkipped: []string{mpolautogen.ExtractionReplacementsRef},
+		},
+		{
+			name: "mixed: translatable group still generates even though a custom CRD is also autogen'd",
+			configs: map[string]policiesv1beta1.MutatingPolicyAutogen{
+				"cronjobs":                            {Spec: baseSpec},
+				mpolautogen.ExtractionReplacementsRef: {Spec: baseSpec},
+			},
+			wantNames:   []string{"mpol-test", "mpol-test-cronjobs"},
+			wantSkipped: []string{mpolautogen.ExtractionReplacementsRef},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mpol := &policiesv1beta1.MutatingPolicy{
+				Status: policiesv1beta1.MutatingPolicyStatus{
+					Autogen: policiesv1beta1.MutatingPolicyAutogenStatus{Configs: tt.configs},
+				},
+			}
+
+			variants, skipped := desiredMAPVariants(mpol, "mpol-test")
+
+			var gotNames []string
+			for _, v := range variants {
+				gotNames = append(gotNames, v.name)
+				if v.name == "mpol-test" {
+					assert.Nil(t, v.specOverride)
+				} else {
+					assert.NotNil(t, v.specOverride)
+				}
+			}
+			assert.ElementsMatch(t, tt.wantNames, gotNames)
+			assert.ElementsMatch(t, tt.wantSkipped, skipped)
+		})
+	}
+}
 
 // TestPreferredMAPVersion tests that the controller selects the right API version
 // based on which listers are initialised, with v1beta1 taking precedence.
@@ -93,11 +160,14 @@ func mapGenEnabled() *policiesv1beta1.MutatingPolicyAutogenConfiguration {
 	}
 }
 
-// TestMapGenerationSkipReason covers the decision of whether a MutatingAdmissionPolicy may be
-// generated for a MutatingPolicy. A policy using useServerSideApply mutates atomic fields that a
-// native MutatingAdmissionPolicy rejects, so generation must be skipped, otherwise the generated MAP
-// becomes the sole admission path and the mutation breaks.
-func TestMapGenerationSkipReason(t *testing.T) {
+// TestMapFullSkipReason covers the decision of whether a MutatingAdmissionPolicy must not be
+// generated at all for a MutatingPolicy. A policy using useServerSideApply mutates atomic fields
+// that a native MutatingAdmissionPolicy rejects, so generation must be skipped, otherwise the
+// generated MAP becomes the sole admission path and the mutation breaks. Pod-controller autogen is
+// no longer a full-skip reason (see TestDesiredMAPVariants) - it's now handled per-group by the
+// fan-out generation in generate-map.go, which generates a MAP for every translatable group and
+// only leaves out ones that genuinely can't be translated (custom-CRD/extraction-mode targets).
+func TestMapFullSkipReason(t *testing.T) {
 	tests := []struct {
 		name       string
 		policy     *policiesv1beta1.MutatingPolicy
@@ -135,25 +205,26 @@ func TestMapGenerationSkipReason(t *testing.T) {
 			wantReason: "skip generating MutatingAdmissionPolicy: useServerSideApply is enabled, which mutates atomic fields that a native MutatingAdmissionPolicy rejects.",
 		},
 		{
-			name: "generation enabled with pod controllers autogen",
+			// Previously this forced a full skip; now the fan-out in generate-map.go handles
+			// autogen'd groups individually, so mapFullSkipReason no longer blocks on it.
+			name: "generation enabled with pod controllers autogen is no longer a full-skip reason",
 			policy: &policiesv1beta1.MutatingPolicy{
 				Spec: policiesv1beta1.MutatingPolicySpec{
 					AutogenConfiguration: mapGenEnabled(),
 				},
 				Status: policiesv1beta1.MutatingPolicyStatus{
 					Autogen: policiesv1beta1.MutatingPolicyAutogenStatus{
-						Configs: map[string]policiesv1beta1.MutatingPolicyAutogen{"deployments": {}},
+						Configs: map[string]policiesv1beta1.MutatingPolicyAutogen{"defaults": {}},
 					},
 				},
 			},
-			wantSkip:   true,
-			wantReason: "skip generating MutatingAdmissionPolicy: pod controllers autogen is enabled.",
+			wantSkip: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reason := mapGenerationSkipReason(tt.policy)
+			reason := mapFullSkipReason(tt.policy)
 			assert.Equal(t, tt.wantSkip, reason != "")
 			if tt.wantReason != "" {
 				assert.Equal(t, tt.wantReason, reason)

--- a/pkg/controllers/admissionpolicygenerator/generate_vap_test.go
+++ b/pkg/controllers/admissionpolicygenerator/generate_vap_test.go
@@ -1,0 +1,154 @@
+package admissionpolicygenerator
+
+import (
+	"testing"
+
+	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
+	vpolautogen "github.com/kyverno/kyverno/pkg/cel/policies/vpol/autogen"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	"github.com/stretchr/testify/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestDesiredVAPVariants covers the core fan-out decision for issue #17423: one VAP for the base
+// policy, one more per translatable autogen group, and extraction-mode (custom-CRD) groups
+// excluded from generation but still reported so status can note they stay webhook-only.
+func TestDesiredVAPVariants(t *testing.T) {
+	baseSpec := &policiesv1beta1.ValidatingPolicySpec{}
+
+	tests := []struct {
+		name        string
+		configs     map[string]policiesv1beta1.ValidatingPolicyAutogen
+		wantNames   []string
+		wantSkipped []string
+	}{
+		{
+			name:      "no autogen: base variant only",
+			wantNames: []string{"vpol-test"},
+		},
+		{
+			name: "one translatable group",
+			configs: map[string]policiesv1beta1.ValidatingPolicyAutogen{
+				"defaults": {Spec: baseSpec},
+			},
+			wantNames: []string{"vpol-test", "vpol-test-defaults"},
+		},
+		{
+			name: "two translatable groups",
+			configs: map[string]policiesv1beta1.ValidatingPolicyAutogen{
+				"defaults": {Spec: baseSpec},
+				"cronjobs": {Spec: baseSpec},
+			},
+			wantNames: []string{"vpol-test", "vpol-test-cronjobs", "vpol-test-defaults"},
+		},
+		{
+			name: "extraction-mode group only: no group variant, reported as skipped",
+			configs: map[string]policiesv1beta1.ValidatingPolicyAutogen{
+				vpolautogen.ExtractionReplacementsRef: {Spec: baseSpec},
+			},
+			wantNames:   []string{"vpol-test"},
+			wantSkipped: []string{vpolautogen.ExtractionReplacementsRef},
+		},
+		{
+			name: "mixed: translatable group still generates even though a custom CRD is also autogen'd",
+			configs: map[string]policiesv1beta1.ValidatingPolicyAutogen{
+				"defaults":                            {Spec: baseSpec},
+				vpolautogen.ExtractionReplacementsRef: {Spec: baseSpec},
+			},
+			wantNames:   []string{"vpol-test", "vpol-test-defaults"},
+			wantSkipped: []string{vpolautogen.ExtractionReplacementsRef},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vpol := &policiesv1beta1.ValidatingPolicy{
+				Status: policiesv1beta1.ValidatingPolicyStatus{
+					Autogen: policiesv1beta1.ValidatingPolicyAutogenStatus{Configs: tt.configs},
+				},
+			}
+
+			variants, skipped := desiredVAPVariants(vpol, "vpol-test")
+
+			var gotNames []string
+			for _, v := range variants {
+				gotNames = append(gotNames, v.name)
+				if v.name == "vpol-test" {
+					assert.Nil(t, v.specOverride, "base variant must use the policy's own spec, not an override")
+				} else {
+					assert.NotNil(t, v.specOverride, "group variant must carry the autogen'd spec")
+				}
+			}
+			assert.ElementsMatch(t, tt.wantNames, gotNames)
+			assert.ElementsMatch(t, tt.wantSkipped, skipped)
+		})
+	}
+}
+
+// mockVAPLister is a minimal in-memory ValidatingAdmissionPolicyLister for testing GC logic
+// without a full fake clientset.
+type mockVAPLister struct {
+	items []*admissionregistrationv1.ValidatingAdmissionPolicy
+}
+
+func (m *mockVAPLister) List(selector labels.Selector) ([]*admissionregistrationv1.ValidatingAdmissionPolicy, error) {
+	return m.items, nil
+}
+
+func (m *mockVAPLister) Get(name string) (*admissionregistrationv1.ValidatingAdmissionPolicy, error) {
+	for _, v := range m.items {
+		if v.Name == name {
+			return v, nil
+		}
+	}
+	return nil, nil
+}
+
+// TestListOwnedVAPNames_DoesNotCollideAcrossPolicies guards against a real hazard in the GC
+// design: generated VAP names share a "<baseName>-<group>" pattern, so a naive name-prefix match
+// (without also checking ownership) would let policy "foo"'s GC pass accidentally delete a VAP
+// that actually belongs to an unrelated policy literally named "foo-defaults". Ownership must be
+// decided by OwnerReferences UID, with the name check only ever a cheap pre-filter.
+func TestListOwnedVAPNames_DoesNotCollideAcrossPolicies(t *testing.T) {
+	fooUID := types.UID("foo-uid")
+	otherUID := types.UID("other-policy-uid")
+
+	c := &controller{
+		vapLister: &mockVAPLister{
+			items: []*admissionregistrationv1.ValidatingAdmissionPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "vpol-foo",
+						OwnerReferences: []metav1.OwnerReference{{UID: fooUID}},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "vpol-foo-defaults",
+						OwnerReferences: []metav1.OwnerReference{{UID: fooUID}},
+					},
+				},
+				{
+					// Name collides with policy "foo"'s naming pattern but is owned by a
+					// different policy (e.g. a real ValidatingPolicy literally named
+					// "foo-defaults") - must never be returned for policy "foo".
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "vpol-foo-defaults-extra",
+						OwnerReferences: []metav1.OwnerReference{{UID: otherUID}},
+					},
+				},
+			},
+		},
+	}
+
+	policy := engineapi.NewValidatingPolicy(&policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: fooUID},
+	})
+
+	names, err := c.listOwnedVAPNames(policy, "vpol-foo")
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"vpol-foo", "vpol-foo-defaults"}, names)
+}

--- a/pkg/controllers/admissionpolicygenerator/mpol.go
+++ b/pkg/controllers/admissionpolicygenerator/mpol.go
@@ -14,7 +14,12 @@ func (c *controller) addMP(obj policiesv1beta1.MutatingPolicyLike) {
 }
 
 func (c *controller) updateMP(old, obj policiesv1beta1.MutatingPolicyLike) {
-	if datautils.DeepEqual(old.GetSpec(), obj.GetSpec()) {
+	specChanged := !datautils.DeepEqual(old.GetSpec(), obj.GetSpec())
+	// See the identical comment in updateVP (vpol.go) - policystatus recomputes
+	// Autogen.Configs independently, often in a later reconcile than this one, so MAP
+	// fan-out needs a second chance to react once that status update lands.
+	autogenChanged := !datautils.DeepEqual(old.GetStatus().Autogen, obj.GetStatus().Autogen)
+	if !specChanged && !autogenChanged {
 		return
 	}
 	logger.V(2).Info("mutating policy updated", "uid", obj.GetUID(), "kind", obj.GetKind(), "name", obj.GetName())

--- a/pkg/controllers/admissionpolicygenerator/vpol.go
+++ b/pkg/controllers/admissionpolicygenerator/vpol.go
@@ -14,7 +14,15 @@ func (c *controller) addVP(obj *policiesv1beta1.ValidatingPolicy) {
 }
 
 func (c *controller) updateVP(old, obj *policiesv1beta1.ValidatingPolicy) {
-	if datautils.DeepEqual(old.GetSpec(), obj.GetSpec()) {
+	specChanged := !datautils.DeepEqual(old.GetSpec(), obj.GetSpec())
+	// Autogen.Configs is recomputed and persisted independently by the policystatus
+	// controller in reaction to the same spec change - often in a separate reconcile that
+	// lands after this one. Without also reacting to that status-only update, VAP fan-out
+	// (generate-vap.go) can compute its desired set from a stale Autogen.Configs and never
+	// get a second chance to reconcile once policystatus catches up, leaving orphaned
+	// per-group ValidatingAdmissionPolicies un-GC'd indefinitely.
+	autogenChanged := !datautils.DeepEqual(old.GetStatus().Autogen, obj.GetStatus().Autogen)
+	if !specChanged && !autogenChanged {
 		return
 	}
 	logger.V(2).Info("validating policy updated", "uid", obj.GetUID(), "kind", obj.GetKind(), "name", obj.GetName())

--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -485,7 +485,7 @@ func Validate(policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interf
 			},
 		}
 		genericPolicy := engineapi.NewKyvernoPolicy(policy)
-		err = admissionpolicy.BuildValidatingAdmissionPolicy(client.Discovery(), vap, genericPolicy, nil, nil)
+		err = admissionpolicy.BuildValidatingAdmissionPolicy(client.Discovery(), vap, genericPolicy, nil, "", nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -485,7 +485,7 @@ func Validate(policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interf
 			},
 		}
 		genericPolicy := engineapi.NewKyvernoPolicy(policy)
-		err = admissionpolicy.BuildValidatingAdmissionPolicy(client.Discovery(), vap, genericPolicy, nil)
+		err = admissionpolicy.BuildValidatingAdmissionPolicy(client.Discovery(), vap, genericPolicy, nil, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Explanation

`ValidatingPolicy`/`MutatingPolicy` support two independent conveniences: generating a native
`ValidatingAdmissionPolicy`/`MutatingAdmissionPolicy` (so the API server enforces the policy directly,
without a Kyverno webhook round-trip) and pod-controller autogen (applying a Pod-targeted rule to
Deployments, CronJobs, etc. automatically). Until now these were mutually exclusive: the moment autogen
was configured, native VAP/MAP generation was skipped entirely for the whole policy, so users had to
choose between native enforcement and controller coverage.

This PR generates one VAP/MAP per autogen group instead of skipping, so both features can be used
together. Custom-CRD (extraction-mode) autogen targets are the one case that structurally can't become a
native VAP/MAP - their pod template is only ever located by Kyverno's own Go code at evaluation time, and
the API server's native CEL evaluation has no equivalent step - so that group alone stays webhook-only,
with the policy's `status.generated` reflecting that accurately.

This is a fix to existing behavior, not new user-facing configuration - no new spec fields are added.

## Related issue

Closes #17423

## What type of PR is this

/kind bug

## Proposed Changes

- **Fan-out generation** (`pkg/controllers/admissionpolicygenerator/generate-vap.go`,
  `generate-map.go`): instead of skipping VAP/MAP generation whenever
  `policy.Status.Autogen.Configs` is non-empty, generate one object per autogen group, reusing the
  already-rewritten `Spec` each group carries (`vpol-<name>`, `vpol-<name>-defaults`,
  `vpol-<name>-cronjobs`, and the MAP equivalents). Built-in controllers collapse into at most two groups
  (`defaults`, `cronjobs`) per `pkg/cel/autogen`'s existing rewrite-path grouping.
- **Extraction-mode (custom-CRD) targets are excluded from generation, not the whole policy.** They're
  reported back so a status message can note they remain webhook-only, rather than blocking generation
  for the rest of the policy's targets.
- **`status.generated` semantics**: now `true` only when *every* autogen target was translated to a
  native object. If a custom-CRD target is present, it stays `false` so Kyverno's own
  webhook/background-scan/CEL engine keep evaluating the whole policy (including the now also
  natively-covered built-in targets - an accepted double-coverage cost in that mixed case, see
  Limitations).
- **Lifecycle/GC**: generated objects are tracked per policy via `OwnerReferences` (matched by UID, not
  just name prefix, to avoid a same-prefix collision between an autogen group's generated name and an
  unrelated policy literally named that way). Each reconcile diffs the desired set against what's owned
  and deletes anything no longer desired (an autogen target removed, or generation disabled entirely).
- **Builder functions** (`pkg/admissionpolicy/builder.go`): `BuildValidatingAdmissionPolicy[Binding]` and
  `BuildMutatingAdmissionPolicy[Binding]{,V1,Beta}` now accept an optional spec override (the autogen
  group's rewritten spec) and, for bindings, an explicit target object name, instead of always deriving
  both from the policy's own spec/name.
- **Two related fixes found while live-testing the fan-out**, both pre-existing but only clearly exposed
  once status/GC decisions became per-group instead of a single boolean:
  - `updatePolicyStatus` now retries on write conflicts (`retry.RetryOnConflict`). The `policystatus`
    controller independently recomputes and persists `Autogen.Configs` on the same spec-change event this
    controller reacts to, so the two routinely raced to `UpdateStatus`; without a retry, a lost race
    silently dropped the status write with no requeue, leaving `status.generated`/the status message
    stale indefinitely.
  - `updateVP`/`updateMP` now also react to a change in `Status.Autogen`, not just `Spec`. Previously,
    since `policystatus`'s recomputation is a status-only update, this controller had no way to know it
    should look again once that update landed - a `ValidatingAdmissionPolicy` generated for a
    since-removed autogen group could stay un-GC'd indefinitely.
- **Two more fixes from running `/code-review` against this PR before requesting a maintainer look**
  (both are real bugs, confirmed and fixed - see Proof Manifest 6 below for a live repro of the first):
  - **PolicyException match conditions are now rewritten per autogen group.** A
    `PolicyException`'s match condition is written against the Pod-shaped base object (e.g.
    `object.spec.containers...`). Embedded verbatim into an autogen-group VAP/MAP - where `object` is
    actually a Deployment/CronJob - it would silently never match (or error), exactly the class of bug
    the group's own `Validations` already guard against via the same pod-template rewrite. This was
    unreachable before this PR (an autogen'd policy never got a VAP/MAP at all). Fixed by threading the
    autogen group key through the builder functions and applying the identical rewrite
    (`autogen.Apply`/`autogen.ReplacementsMap` for VAP; the now-exported
    `mpolautogen.ConvertPodToTemplateExpression` for MAP) to the exception's negated match condition.
  - **`updatePolicyStatus`'s new retry re-fetched from the informer-backed lister**, which may not yet
    have observed the concurrent write that caused the conflict - every retry attempt could return the
    same stale `ResourceVersion` and fail identically, defeating the retry. Fixed by re-fetching via a
    live client `Get` inside each retry attempt instead.

## Limitations

- **Double coverage for mixed policies.** A policy autogen'd onto both a built-in controller and a
  custom CRD gets *both* a generated VAP for the built-in target *and* continued Kyverno-webhook
  evaluation of the entire policy (since `status.generated` must stay `false` for the custom-CRD target
  to keep working). This is correct but not maximally efficient - the built-in target is evaluated twice.
  Removing this would need a way to mark individual targets (not the whole policy) as
  webhook-vs-native, which is a larger change.
- **Legacy `ClusterPolicy` autogen is untouched.** `ClusterPolicy`'s VAP generation path has no
  autogen-skip check today and is a structurally different mechanism (annotation-based, not
  `Status.Autogen.Configs`-based); out of scope here.
- **Still only VAP/MAP for `ValidatingPolicy`/`MutatingPolicy` (`policies.kyverno.io`)**, matching the
  issue's scope - no change to `ImageValidatingPolicy`/`GeneratingPolicy`/`DeletingPolicy`.
- **Eventual consistency between two controllers remains** (`policystatus` computing
  `Autogen.Configs`, this controller consuming it) - the fix above closes the gap to "reacts on the next
  status update" rather than "never", but there's still no single atomic transaction; a brief window
  where `status.generated`/the generated-object set lags the true desired state is possible, as it always
  has been for this controller.
- **Background/audit scanning stops for a policy once `status.generated` is `true`** (pre-existing
  behavior of `pkg/controllers/report/background`, unchanged by this PR) - a native VAP/MAP only
  enforces admission going forward, so resources that predate it (or were never touched again) aren't
  retroactively caught by scans once this flag is set. This tradeoff already existed for any
  non-autogen'd policy with VAP/MAP generation enabled; this PR just makes it reachable for autogen'd
  policies too, since they could never reach `status.generated: true` before. Worth being aware of, not
  something this PR changes the fundamentals of.

### Proof Manifests

All tests below were run against a local `kind` cluster with this branch's `kyverno-admission-controller`
image loaded, using `require-run-as-nonroot` and `add-safety-label-mpol` as unrelated pre-existing
policies on the same cluster (their continued correct behavior throughout is itself evidence of no
regression).

**Policy under test** (autogen onto a built-in controller pair plus a custom CRD, VAP generation enabled):

```yaml
apiVersion: policies.kyverno.io/v1beta1
kind: ValidatingPolicy
metadata:
  name: vap-fanout-test
spec:
  autogen:
    podControllers:
      controllers:
        - deployments
        - cronjobs
        - jobsets.v1alpha2.jobset.x-k8s.io
    validatingAdmissionPolicy:
      enabled: true
  matchConstraints:
    resourceRules:
      - apiGroups: [""]
        apiVersions: ["v1"]
        operations: ["CREATE", "UPDATE"]
        resources: ["pods"]
  validations:
    - message: "Images must not use the 'latest' tag."
      expression: "object.spec.containers.all(c, !c.image.endsWith(':latest'))"
```

**1. Built-in-only autogen (`deployments`, `cronjobs`) generates one VAP per group:**

```
$ kubectl get validatingadmissionpolicies | grep vap-fanout-test
vpol-vap-fanout-test            1             <unset>     25s
vpol-vap-fanout-test-cronjobs   1             <unset>     25s
vpol-vap-fanout-test-defaults   1             <unset>     25s

$ kubectl get validatingadmissionpolicybindings | grep vap-fanout-test
vpol-vap-fanout-test-binding            vpol-vap-fanout-test            <unset>    25s
vpol-vap-fanout-test-cronjobs-binding   vpol-vap-fanout-test-cronjobs   <unset>    25s
vpol-vap-fanout-test-defaults-binding   vpol-vap-fanout-test-defaults   <unset>    25s

$ kubectl get vpol vap-fanout-test -o jsonpath='{.status.generated}'
true
```

Owner references correctly point at the source policy, and the binding's `policyName` correctly points
at its own generated VAP (not the base one):

```
$ kubectl get validatingadmissionpolicybindings vpol-vap-fanout-test-defaults-binding -o jsonpath='{.spec.policyName}'
vpol-vap-fanout-test-defaults
```

**2. The generated VAP is real native enforcement** - denies/allows a Deployment directly at the API
server, with the CEL correctly rewritten to the Deployment's pod-template path:

```
$ kubectl get validatingadmissionpolicies vpol-vap-fanout-test-defaults -o jsonpath='{.spec.validations[0].expression}'
object.spec.template.spec.containers.all(c, !c.image.endsWith(':latest'))

$ kubectl apply -f bad-deploy.yaml   # image: nginx:latest
The deployments "bad-deploy-fanout-test" is invalid: : ValidatingAdmissionPolicy 'vpol-vap-fanout-test-defaults' with binding 'vpol-vap-fanout-test-defaults-binding' denied request: Images must not use the 'latest' tag.

$ kubectl apply -f good-deploy.yaml  # image: nginx:1.25.3, non-root
deployment.apps/good-deploy-fanout-test created
```

**3. Mixed autogen (built-in + custom CRD `jobsets.v1alpha2.jobset.x-k8s.io`)**: no VAP is generated for
the JobSet target, `status.generated` correctly flips to `false` with an explanatory message, while the
built-in targets keep their native VAPs *and* the JobSet keeps working via Kyverno's webhook
(extraction-mode) - no coverage gap, no regression:

```
$ kubectl get validatingadmissionpolicies | grep vap-fanout-test
vpol-vap-fanout-test            1             <unset>     3m
vpol-vap-fanout-test-cronjobs   1             <unset>     3m
vpol-vap-fanout-test-defaults   1             <unset>     3m
# (no vap-fanout-test-jobsets / -extract object)

$ kubectl get vpol vap-fanout-test -o jsonpath='{.status.generated}{"\n"}{.status.conditionStatus.message}{"\n"}'
false
ValidatingAdmissionPolicy generated for the pod-controller autogen target(s); custom-CRD autogen target(s) (extract) cannot be translated to a native ValidatingAdmissionPolicy and remain enforced via Kyverno's webhook only.

$ kubectl apply -f bad-jobset.yaml   # container image: busybox:latest
Error from server: error when creating "bad-jobset.yaml": admission webhook "vpol.validate.kyverno.svc-fail" denied the request: Policy vap-fanout-test failed: Images must not use the 'latest' tag. (pod template at spec.replicatedJobs[0].template.spec.template)

$ kubectl apply -f good-jobset.yaml  # container image: busybox:1.36
jobset.jobset.x-k8s.io/good-jobset-fanout-test created

# built-in target still natively denied even in this mixed state (double coverage, as documented above)
$ kubectl apply -f bad-deploy.yaml
The deployments "bad-deploy-fanout-test" is invalid: : ValidatingAdmissionPolicy 'vpol-vap-fanout-test-defaults' with binding 'vpol-vap-fanout-test-defaults-binding' denied request: Images must not use the 'latest' tag.
```

**4. GC on shrink** - removing `cronjobs` (and the custom CRD) from the autogen list cleans up the
now-stale generated objects and `status.generated` returns to `true`:

```
$ kubectl get validatingadmissionpolicies | grep vap-fanout-test
vpol-vap-fanout-test            1             <unset>     13m
vpol-vap-fanout-test-defaults   1             <unset>     13m
# vpol-vap-fanout-test-cronjobs and its binding are gone

$ kubectl get vpol vap-fanout-test -o jsonpath='{.status.generated}{"\n"}{.status.conditionStatus.message}{"\n"}'
true
```

**5. GC on delete** - deleting the policy cleans up all generated objects via standard Kubernetes
owner-reference garbage collection (confirming owner references are set correctly on every generated
variant):

```
$ kubectl delete vpol vap-fanout-test
validatingpolicy.policies.kyverno.io "vap-fanout-test" deleted
$ kubectl get validatingadmissionpolicies,validatingadmissionpolicybindings | grep vap-fanout-test
(no output)
```

**6. PolicyException match conditions are correctly rewritten per autogen group** (the bug caught by
`/code-review`, see Proposed Changes above) - a policy with the same `latest`-tag rule, autogen'd onto
`deployments` only, plus a `PolicyException` matching on `object.spec.containers.exists(c, c.name ==
'exempt')` (a Pod-shaped expression):

```yaml
apiVersion: policies.kyverno.io/v1beta1
kind: PolicyException
metadata:
  name: skip-exempt-app
spec:
  policyRefs:
    - name: vap-fanout-exc-test
      kind: ValidatingPolicy
  matchConditions:
    - name: is-exempt
      expression: "object.spec.containers.exists(c, c.name == 'exempt')"
```

The generated `-defaults` VAP's match condition is correctly rewritten to the Deployment's pod-template
path, not embedded verbatim:

```
$ kubectl get validatingadmissionpolicies vpol-vap-fanout-exc-test-defaults -o jsonpath='{.spec.matchConditions}'
[{"expression":"!(object.spec.template.spec.containers.exists(c, c.name == 'exempt'))","name":"is-exempt"}]
```

And it actually works end-to-end: a Deployment with a container named `exempt` is allowed despite the
`latest` tag; one without is still denied:

```
$ kubectl apply -f exempt-deploy.yaml   # container name: exempt, image: nginx:latest
deployment.apps/exempt-deploy-fanout-test created

$ kubectl apply -f bad-deploy.yaml      # container name: nginx, image: nginx:latest
The deployments "bad-deploy-fanout-test" is invalid: : ValidatingAdmissionPolicy 'vpol-vap-fanout-exc-test-defaults' with binding 'vpol-vap-fanout-exc-test-defaults-binding' denied request: Images must not use the 'latest' tag.
```

**Unit tests**: `go test ./pkg/admissionpolicy/... ./pkg/controllers/admissionpolicygenerator/...
./pkg/cel/policies/mpol/autogen/...` pass, including new table tests for the fan-out decision
(`desiredVAPVariants`/`desiredMAPVariants`, covering no-autogen / built-in-only /
mixed-with-extraction-mode cases), a regression test for the owner-reference-vs-name-prefix GC collision
case described above, and a regression test for the PolicyException rewrite fix
(`TestBuildValidatingAdmissionPolicy_RewritesExceptionForAutogenGroup`).

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
