### PR TITLE
fix(ivpol): check cosign annotations against signature payload optional map

### DIFF
--- a/pkg/image/verifiers/ivpol/cosign/certs.go
+++ b/pkg/image/verifiers/ivpol/cosign/certs.go
@@ -5,11 +5,13 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 
 	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
 var signatureAlgorithmMap = map[string]crypto.Hash{
@@ -86,16 +88,28 @@ func decodePEM(raw []byte, signatureAlgorithm crypto.Hash) (signature.Verifier, 
 	return signature.LoadVerifier(pubKey, signatureAlgorithm)
 }
 
-// this is the equivalent of checkAnnotations in the cpol
+// checkSignatureAnnotations verifies the required annotations against the
+// optional annotations carried in the cosign signature payload. cosign
+// populates the payload's "optional" map via `cosign sign -a`, so this matches
+// the semantics of the ClusterPolicy cosign verifier's checkAnnotations. The
+// previous implementation compared against the signature's OCI descriptor
+// annotations (oci.Signature.Annotations()), which are a different concept and
+// are not populated by `cosign sign -a`.
 func checkSignatureAnnotations(sig oci.Signature, annotations map[string]string) error {
-	sigAnnotations, err := sig.Annotations()
+	pld, err := sig.Payload()
 	if err != nil {
-		return fmt.Errorf("failed to fetch annotation from signature")
+		return fmt.Errorf("failed to get signature payload: %w", err)
 	}
+
+	sci := payload.SimpleContainerImage{}
+	if err := json.Unmarshal(pld, &sci); err != nil {
+		return fmt.Errorf("failed to decode signature payload: %w", err)
+	}
+
 	for key, val := range annotations {
-		if val != sigAnnotations[key] {
+		if val != sci.Optional[key] {
 			return fmt.Errorf("annotations mismatch: %s does not match expected value %s for key %s",
-				sigAnnotations[key], val, key)
+				sci.Optional[key], val, key)
 		}
 	}
 	return nil

--- a/pkg/image/verifiers/ivpol/cosign/certs_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/certs_test.go
@@ -25,20 +25,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mockSignature is a test double for oci.Signature that carries a configurable
+// payload so tests can exercise annotation checks against the payload contents.
 type mockSignature struct {
 	payload    []byte
 	payloadErr error
 }
 
+// Annotations is a no-op that satisfies oci.Signature; the code under test
+// reads annotations from the signature payload rather than the descriptor.
 func (m *mockSignature) Annotations() (map[string]string, error) { return nil, nil }
 
 // Implement other oci.Signature interface methods as no-ops for testing
-func (m *mockSignature) Digest() (v1.Hash, error)                            { return v1.Hash{}, nil }
-func (m *mockSignature) DiffID() (v1.Hash, error)                            { return v1.Hash{}, nil }
-func (m *mockSignature) Compressed() (io.ReadCloser, error)                  { return nil, nil }
-func (m *mockSignature) Uncompressed() (io.ReadCloser, error)                { return nil, nil }
-func (m *mockSignature) Size() (int64, error)                                { return 0, nil }
-func (m *mockSignature) MediaType() (types.MediaType, error)                 { return "", nil }
+func (m *mockSignature) Digest() (v1.Hash, error)             { return v1.Hash{}, nil }
+func (m *mockSignature) DiffID() (v1.Hash, error)             { return v1.Hash{}, nil }
+func (m *mockSignature) Compressed() (io.ReadCloser, error)   { return nil, nil }
+func (m *mockSignature) Uncompressed() (io.ReadCloser, error) { return nil, nil }
+func (m *mockSignature) Size() (int64, error)                 { return 0, nil }
+func (m *mockSignature) MediaType() (types.MediaType, error)  { return "", nil }
+
+// Payload returns the mock signature's configured payload bytes and error,
+// letting tests simulate both successful payload fetches and fetch failures.
 func (m *mockSignature) Payload() ([]byte, error)                            { return m.payload, m.payloadErr }
 func (m *mockSignature) Signature() ([]byte, error)                          { return nil, nil }
 func (m *mockSignature) Base64Signature() (string, error)                    { return "", nil }
@@ -732,6 +739,9 @@ func TestCertificateProperties(t *testing.T) {
 	}
 }
 
+// TestCheckSignatureAnnotations verifies that required annotations are matched
+// against the "optional" map of the cosign signature payload, covering matching,
+// mismatched, missing, empty, and payload-fetch-error cases.
 func TestCheckSignatureAnnotations(t *testing.T) {
 	makePayload := func(optional map[string]string) []byte {
 		optionalAny := make(map[string]interface{}, len(optional))

--- a/pkg/image/verifiers/ivpol/cosign/certs_test.go
+++ b/pkg/image/verifiers/ivpol/cosign/certs_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"io"
@@ -19,21 +20,17 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
+	"github.com/sigstore/sigstore/pkg/signature/payload"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type mockSignature struct {
-	annotations map[string]string
-	annotErr    error
+	payload    []byte
+	payloadErr error
 }
 
-func (m *mockSignature) Annotations() (map[string]string, error) {
-	if m.annotErr != nil {
-		return nil, m.annotErr
-	}
-	return m.annotations, nil
-}
+func (m *mockSignature) Annotations() (map[string]string, error) { return nil, nil }
 
 // Implement other oci.Signature interface methods as no-ops for testing
 func (m *mockSignature) Digest() (v1.Hash, error)                            { return v1.Hash{}, nil }
@@ -42,7 +39,7 @@ func (m *mockSignature) Compressed() (io.ReadCloser, error)                  { r
 func (m *mockSignature) Uncompressed() (io.ReadCloser, error)                { return nil, nil }
 func (m *mockSignature) Size() (int64, error)                                { return 0, nil }
 func (m *mockSignature) MediaType() (types.MediaType, error)                 { return "", nil }
-func (m *mockSignature) Payload() ([]byte, error)                            { return nil, nil }
+func (m *mockSignature) Payload() ([]byte, error)                            { return m.payload, m.payloadErr }
 func (m *mockSignature) Signature() ([]byte, error)                          { return nil, nil }
 func (m *mockSignature) Base64Signature() (string, error)                    { return "", nil }
 func (m *mockSignature) Cert() (*x509.Certificate, error)                    { return nil, nil }
@@ -736,6 +733,16 @@ func TestCertificateProperties(t *testing.T) {
 }
 
 func TestCheckSignatureAnnotations(t *testing.T) {
+	makePayload := func(optional map[string]string) []byte {
+		optionalAny := make(map[string]interface{}, len(optional))
+		for k, v := range optional {
+			optionalAny[k] = v
+		}
+		b, err := json.Marshal(payload.SimpleContainerImage{Optional: optionalAny})
+		require.NoError(t, err)
+		return b
+	}
+
 	tests := []struct {
 		name        string
 		sig         *mockSignature
@@ -744,13 +751,13 @@ func TestCheckSignatureAnnotations(t *testing.T) {
 		errContains string
 	}{
 		{
-			name: "matching annotations",
+			name: "matching annotations from payload optional map",
 			sig: &mockSignature{
-				annotations: map[string]string{
+				payload: makePayload(map[string]string{
 					"key1": "value1",
 					"key2": "value2",
 					"key3": "value3",
-				},
+				}),
 			},
 			expected: map[string]string{
 				"key1": "value1",
@@ -761,10 +768,10 @@ func TestCheckSignatureAnnotations(t *testing.T) {
 		{
 			name: "all annotations match",
 			sig: &mockSignature{
-				annotations: map[string]string{
+				payload: makePayload(map[string]string{
 					"io.kyverno.image": "myimage:v1",
 					"builder":          "github-actions",
-				},
+				}),
 			},
 			expected: map[string]string{
 				"io.kyverno.image": "myimage:v1",
@@ -775,10 +782,10 @@ func TestCheckSignatureAnnotations(t *testing.T) {
 		{
 			name: "mismatched value",
 			sig: &mockSignature{
-				annotations: map[string]string{
+				payload: makePayload(map[string]string{
 					"key1": "value1",
 					"key2": "wrongvalue",
-				},
+				}),
 			},
 			expected: map[string]string{
 				"key1": "value1",
@@ -790,9 +797,9 @@ func TestCheckSignatureAnnotations(t *testing.T) {
 		{
 			name: "missing key",
 			sig: &mockSignature{
-				annotations: map[string]string{
+				payload: makePayload(map[string]string{
 					"key1": "value1",
-				},
+				}),
 			},
 			expected: map[string]string{
 				"key1":       "value1",
@@ -804,18 +811,18 @@ func TestCheckSignatureAnnotations(t *testing.T) {
 		{
 			name: "empty expected",
 			sig: &mockSignature{
-				annotations: map[string]string{
+				payload: makePayload(map[string]string{
 					"key1": "value1",
 					"key2": "value2",
-				},
+				}),
 			},
 			expected: map[string]string{},
 			wantErr:  false,
 		},
 		{
-			name: "empty signature",
+			name: "empty payload optional map",
 			sig: &mockSignature{
-				annotations: map[string]string{},
+				payload: makePayload(map[string]string{}),
 			},
 			expected: map[string]string{
 				"key1": "value1",
@@ -824,35 +831,22 @@ func TestCheckSignatureAnnotations(t *testing.T) {
 			errContains: "annotations mismatch",
 		},
 		{
-			name: "annotations fetch error",
+			name: "payload fetch error",
 			sig: &mockSignature{
-				annotErr: errors.New("failed to fetch annotations"),
+				payloadErr: errors.New("failed to fetch payload"),
 			},
 			expected: map[string]string{
 				"key1": "value1",
 			},
 			wantErr:     true,
-			errContains: "failed to fetch annotation from signature",
-		},
-		{
-			name: "cosign standard annotations",
-			sig: &mockSignature{
-				annotations: map[string]string{
-					"dev.cosignproject.cosign/signature": "MEUCIQDxUX...",
-					"dev.sigstore.cosign/bundle":         `{"SignedEntryTimestamp":"..."}`,
-				},
-			},
-			expected: map[string]string{
-				"dev.cosignproject.cosign/signature": "MEUCIQDxUX...",
-			},
-			wantErr: false,
+			errContains: "failed to get signature payload",
 		},
 		{
 			name: "case sensitivity",
 			sig: &mockSignature{
-				annotations: map[string]string{
+				payload: makePayload(map[string]string{
 					"Key1": "Value1",
-				},
+				}),
 			},
 			expected: map[string]string{
 				"key1": "Value1", // Different case in key
@@ -861,13 +855,13 @@ func TestCheckSignatureAnnotations(t *testing.T) {
 			errContains: "annotations mismatch",
 		},
 		{
-			name: "extra annotations in signature",
+			name: "extra annotations in payload optional map",
 			sig: &mockSignature{
-				annotations: map[string]string{
+				payload: makePayload(map[string]string{
 					"key1":  "value1",
 					"key2":  "value2",
 					"extra": "annotation",
-				},
+				}),
 			},
 			expected: map[string]string{
 				"key1": "value1",


### PR DESCRIPTION
## What this PR does

Fixes the ImageVerificationPolicy (IVP) cosign attestor's `annotations` field so it checks the annotations carried in the cosign signature payload, matching the semantics of the ClusterPolicy (CVP) verifier.

The IVP verifier compared the required annotations against the signature's OCI descriptor annotations (`oci.Signature.Annotations()`) rather than the optional annotations stored in the `SimpleContainerImage` payload. cosign populates the payload's `optional` map via `cosign sign -a`, which is exactly what the CVP verifier checks against (`checkAnnotations` on the decoded payload). As a result the same `annotations` field meant two different things between the two policy types, and IVP policies failed to match even when the annotation was present on the image.

## Changes

- `checkSignatureAnnotations` now decodes the `SimpleContainerImage` payload and compares the required annotations against its `optional` map instead of the OCI descriptor annotations.
- Updated the unit test to exercise the payload `optional` map (including a payload-fetch error case) rather than the descriptor annotations.

## Testing

- `go test ./pkg/image/verifiers/ivpol/cosign/` passes.
- `go vet` and `gofmt` are clean.

Fixes https://github.com/kyverno/kyverno/issues/17505


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Signature annotation verification now checks annotations embedded in the signed payload.
  - Mismatched or missing annotations are correctly rejected.
  - Payload retrieval failures and empty annotation data now produce verification failures.

- **Tests**
  - Expanded coverage for payload-based annotation validation, including retrieval errors, mismatches, and empty annotation sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->