### PR TITLE
fix(cli): resource.List returns empty list when no resources of the kind exist

### DIFF
--- a/pkg/cel/libs/fake_context.go
+++ b/pkg/cel/libs/fake_context.go
@@ -117,7 +117,12 @@ func (cp *FakeContextProvider) ListResources(apiVersion, resource, namespace str
 	gvr := gv.WithResource(resource)
 	resources := cp.resources[gvr.String()]
 	if resources == nil {
-		return nil, kerrors.NewBadRequest(fmt.Sprintf("%s resource not found", gvr.GroupResource()))
+		// No resource of this kind is registered in the context, so the list is
+		// simply empty rather than an error. This matches the behavior of a live
+		// cluster, where listing an existing (but empty) resource type yields an
+		// empty list, and lets CEL expressions such as
+		// `resource.List(...).items.orValue([])` evaluate successfully.
+		return &unstructured.UnstructuredList{}, nil
 	}
 	var out unstructured.UnstructuredList
 	for _, obj := range resources[namespace] {

--- a/pkg/cel/libs/fake_context_test.go
+++ b/pkg/cel/libs/fake_context_test.go
@@ -165,14 +165,44 @@ func TestFakeContextProvider_AddResource(t *testing.T) {
 	}
 	{
 		got, err := cp.ListResources("v1", "wrongs", "test-ns", nil)
-		assert.Error(t, err)
-		assert.Nil(t, got)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(got.Items))
 	}
 	{
 		got, err := cp.ListResources("wrong", "configmaps", "test-ns", nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(got.Items))
+	}
+	{
+		got, err := cp.ListResources("bad/group/version", "configmaps", "test-ns", nil)
 		assert.Error(t, err)
 		assert.Nil(t, got)
 	}
+}
+
+func TestFakeContextProvider_ListResources_UnregisteredKindReturnsEmptyList(t *testing.T) {
+	// A context that contains no resources of a given kind must yield an empty
+	// list, not an error, so CEL expressions like
+	// `resource.List("rbac.authorization.k8s.io/v1", "clusterroles", "").items.orValue([])`
+	// evaluate successfully in the CLI (kyverno apply/test). See #17517.
+	cp := NewFakeContextProvider()
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "example",
+		},
+	}
+	assert.NoError(t, cp.AddResource(
+		schema.GroupVersionResource{Version: "v1", Resource: "configmaps"},
+		cm,
+	))
+
+	// A kind with no resources registered in the context returns an empty list.
+	got, err := cp.ListResources("rbac.authorization.k8s.io/v1", "clusterroles", "", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Empty(t, got.Items)
 }
 
 func TestFakeContextProvider_Clone(t *testing.T) {


### PR DESCRIPTION
## What

Fix `resource.List` so that it returns an empty list (instead of a `BadRequest` error) when the CLI context contains no resources of the requested kind.

## Why

When evaluating a CEL expression like

```cel
resource.List("rbac.authorization.k8s.io/v1", "clusterroles", "").items.orValue([])
```

with `kyverno apply` or `kyverno test`, the `FakeContextProvider.ListResources` implementation returned a `BadRequest` error whenever no resource of that kind had been registered in the context. That turned a perfectly valid policy into an evaluation error (`error: 1`, exit code 1), even though the correct result is an empty list.

This matches the behavior of a live cluster, where listing an existing (but empty) resource type yields an empty list.

## How

`FakeContextProvider.ListResources` now returns an empty `UnstructuredList` when no entry exists for the requested `GroupVersionResource`, instead of a `BadRequest` error. A malformed `apiVersion` (e.g. `a/b/c`) still returns a parse error.

## Tests

- Updated `TestFakeContextProvider_AddResource` so the "unknown kind" and "unknown version" list cases assert an empty list rather than an error.
- Added `TestFakeContextProvider_ListResources_UnregisteredKindReturnsEmptyList` reproducing the exact scenario from the issue (a `ConfigMap` in context, listing `clusterroles`).

Fixes #17517


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resource listings for valid but unregistered kinds now return an empty list instead of an error.
  - CEL expressions using resource listings can now safely evaluate empty results in CLI workflows.
  - Invalid group/version formats continue to return errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->