### PR TITLE
fix: stop leaking the aggregate report cleanup goroutine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.46.0
 	go.opentelemetry.io/otel/trace v1.46.0
 	go.uber.org/automaxprocs v1.6.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/crypto v0.56.0

--- a/pkg/controllers/report/aggregate/controller.go
+++ b/pkg/controllers/report/aggregate/controller.go
@@ -106,6 +106,7 @@ type PolicyMapEntry struct {
 	Rules  sets.Set[string]
 }
 
+// NewController returns the controller that aggregates ephemeral reports into policy reports.
 func NewController(
 	client versioned.Interface,
 	orClient openreportsclient.OpenreportsV1alpha1Interface,
@@ -403,6 +404,7 @@ func NewController(
 	return &c
 }
 
+// Run starts the cache cleanup loop and the reconcile workers, and blocks until ctx is cancelled.
 func (c *controller) Run(ctx context.Context, workers int) {
 	var group wait.Group
 	group.StartWithContext(ctx, func(ctx context.Context) {

--- a/pkg/controllers/report/aggregate/controller.go
+++ b/pkg/controllers/report/aggregate/controller.go
@@ -53,7 +53,14 @@ const (
 	maxRetries     = 10
 	enqueueDelay   = 10 * time.Second
 	deletionGrace  = time.Minute * 2
+	// cacheCleanupInterval is how often stale entries are pruned from reportUUIDToPolicyCache
+	cacheCleanupInterval = 10 * time.Second
 )
+
+// managedByKyverno selects the reports owned by Kyverno.
+var managedByKyverno = labels.SelectorFromSet(labels.Set{
+	kyverno.LabelAppManagedBy: kyverno.ValueKyvernoApp,
+})
 
 type controller struct {
 	// clients
@@ -78,6 +85,8 @@ type controller struct {
 	mapAlphaLister admissionregistrationv1alpha1listers.MutatingAdmissionPolicyLister
 	ephrLister     cache.GenericLister
 	cephrLister    cache.GenericLister
+	polrLister     cache.GenericLister
+	cpolrLister    cache.GenericLister
 
 	// reportUUIDToPolicyCache maps report UUIDs to policies that affect them for targeted reconciliation.
 	// This avoids processing all reports when a single policy changes.
@@ -136,45 +145,6 @@ func NewController(
 	cacheMu := &sync.Mutex{}
 	// Initialize cache for mapping report UUIDs to their affecting policies.
 	reportUUIDToPolicyCache := make(map[string]sets.Set[string])
-	selector := labels.SelectorFromSet(labels.Set{
-		kyverno.LabelAppManagedBy: kyverno.ValueKyvernoApp,
-	})
-
-	// Background cleanup goroutine removes cache entries for deleted reports every 10 seconds.
-	go func() {
-		for {
-			time.Sleep(time.Second * 10)
-			// List all existing reports to identify which ones still exist
-			reports, err := polrInformer.Lister().List(selector)
-			if err != nil {
-				logger.Error(err, "failed to list reports to clear the policy cache")
-				continue
-			}
-			clusterReports, err := cpolrInformer.Lister().List(selector)
-			if err != nil {
-				logger.Error(err, "failed to list cluster reports to clear the policy cache")
-				continue
-			}
-			// Build set of existing report UUIDs
-			reportsMap := make(map[string]struct{})
-			for _, r := range reports {
-				reportMeta := r.(*metav1.PartialObjectMetadata)
-				reportsMap[string(reportMeta.GetUID())] = struct{}{}
-			}
-			for _, cr := range clusterReports {
-				reportMeta := cr.(*metav1.PartialObjectMetadata)
-				reportsMap[string(reportMeta.GetUID())] = struct{}{}
-			}
-			// Remove cache entries for deleted reports
-			cacheMu.Lock()
-			for reportUID := range reportUUIDToPolicyCache {
-				if _, ok := reportsMap[reportUID]; !ok {
-					delete(reportUUIDToPolicyCache, reportUID)
-				}
-			}
-			cacheMu.Unlock()
-		}
-	}()
 
 	c := controller{
 		client:                  client,
@@ -184,6 +154,8 @@ func NewController(
 		cpolLister:              cpolInformer.Lister(),
 		ephrLister:              ephrInformer.Lister(),
 		cephrLister:             cephrInformer.Lister(),
+		polrLister:              polrInformer.Lister(),
+		cpolrLister:             cpolrInformer.Lister(),
 		cacheMu:                 cacheMu,
 		reportUUIDToPolicyCache: reportUUIDToPolicyCache,
 		frontQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -209,7 +181,7 @@ func NewController(
 	}
 	// enqueueReportsForPolicy queues only reports affected by a specific policy change using the cache.
 	enqueueReportsForPolicy := func(o metav1.Object) {
-		if list, err := polrInformer.Lister().List(selector); err == nil {
+		if list, err := polrInformer.Lister().List(managedByKyverno); err == nil {
 			// the cache has not been built yet, enqueue all reports for reconciliation
 			cacheMu.Lock()
 			cacheLen := len(reportUUIDToPolicyCache)
@@ -250,7 +222,7 @@ func NewController(
 				}
 			}
 		}
-		if list, err := cpolrInformer.Lister().List(selector); err == nil {
+		if list, err := cpolrInformer.Lister().List(managedByKyverno); err == nil {
 			// the cache has not been built yet, enqueue all reports for reconciliation
 			cacheMu.Lock()
 			cacheLen := len(reportUUIDToPolicyCache)
@@ -434,12 +406,49 @@ func NewController(
 func (c *controller) Run(ctx context.Context, workers int) {
 	var group wait.Group
 	group.StartWithContext(ctx, func(ctx context.Context) {
+		wait.UntilWithContext(ctx, c.pruneCache, cacheCleanupInterval)
+	})
+	group.StartWithContext(ctx, func(ctx context.Context) {
 		controllerutils.Run(ctx, logger, ControllerName, time.Second, c.frontQueue, workers, maxRetries, c.frontReconcile)
 	})
 	group.StartWithContext(ctx, func(ctx context.Context) {
 		controllerutils.Run(ctx, logger, ControllerName, time.Second, c.backQueue, workers, maxRetries, c.backReconcile)
 	})
 	group.Wait()
+}
+
+// pruneCache removes cache entries for reports that no longer exist. It is
+// started by Run so it stops with the controller instead of outliving it.
+func (c *controller) pruneCache(ctx context.Context) {
+	// List all existing reports to identify which ones still exist
+	reports, err := c.polrLister.List(managedByKyverno)
+	if err != nil {
+		logger.Error(err, "failed to list reports to clear the policy cache")
+		return
+	}
+	clusterReports, err := c.cpolrLister.List(managedByKyverno)
+	if err != nil {
+		logger.Error(err, "failed to list cluster reports to clear the policy cache")
+		return
+	}
+	// Build set of existing report UUIDs
+	reportsMap := make(map[string]struct{})
+	for _, r := range reports {
+		reportMeta := r.(*metav1.PartialObjectMetadata)
+		reportsMap[string(reportMeta.GetUID())] = struct{}{}
+	}
+	for _, cr := range clusterReports {
+		reportMeta := cr.(*metav1.PartialObjectMetadata)
+		reportsMap[string(reportMeta.GetUID())] = struct{}{}
+	}
+	// Remove cache entries for deleted reports
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
+	for reportUID := range c.reportUUIDToPolicyCache {
+		if _, ok := reportsMap[reportUID]; !ok {
+			delete(c.reportUUIDToPolicyCache, reportUID)
+		}
+	}
 }
 
 func (c *controller) createPolicyMap() (map[string]PolicyMapEntry, error) {

--- a/pkg/controllers/report/aggregate/controller_test.go
+++ b/pkg/controllers/report/aggregate/controller_test.go
@@ -17,6 +17,7 @@ import (
 	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 	orfake "github.com/openreports/reports-api/pkg/client/clientset/versioned/fake"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -231,4 +232,38 @@ func TestControllerWithOpenreports(t *testing.T) {
 
 	list, _ := orClient.OpenreportsV1alpha1().Reports("default").List(context.TODO(), metav1.ListOptions{})
 	assert.Len(t, list.Items, 1)
+}
+
+// TestControllerRunReclaimsAllGoroutines asserts the report cache cleanup loop
+// is owned by Run and stops with the controller. NewController is invoked from
+// the leader election callback in cmd/reports-controller, so a goroutine started
+// in the constructor is never cancellable: every leadership acquisition leaks one
+// more immortal loop listing every report in the cluster every 10 seconds.
+func TestControllerRunReclaimsAllGoroutines(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	metaFactory, _, _ := newFakeMetaClient()
+	client := versionedfake.NewSimpleClientset()
+	kyvernoFactory := kyvernoinformer.NewSharedInformerFactory(client, 1*time.Second)
+
+	controller := aggregate.NewController(
+		client, nil, nil, metaFactory,
+		kyvernoFactory.Kyverno().V1().Policies(),
+		kyvernoFactory.Kyverno().V1().ClusterPolicies(),
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		controller.Run(ctx, 1)
+	}()
+	cancel()
+
+	select {
+	case <-stopped:
+	case <-time.After(30 * time.Second):
+		t.Fatal("controller did not stop after the context was cancelled")
+	}
 }


### PR DESCRIPTION
## Explanation

Fix. The aggregate report controller leaked a goroutine every time this replica acquired leadership. Each leaked loop keeps listing every PolicyReport and ClusterPolicyReport in the cluster forever, so API server load grows with every leadership change until the pod restarts.

## Related issue

Closes #17035

## What type of PR is this

/kind bug

## Proposed Changes

`NewController` started a bare `go func(){ for { time.Sleep(10s); ... } }()` with no context and no stop channel. It is called from the leader-election `OnStartedLeading` callback, so the loop outlives the controller and pins the discarded informer factory through its closure.

Moved into `Run` as a `wait.UntilWithContext` in the existing `wait.Group`. Listers hoisted onto the struct, label selector hoisted to a package var (it was rebuilt every tick and duplicated in `enqueueReportsForPolicy`).

Credit to @itsvishalyadav, whose #17036 had a similar diff and was closed with an offer to resubmit. Happy to step aside if they want to carry it.

### Proof Manifests

Not applicable, no user-facing behavior change. `TestControllerRunReclaimsAllGoroutines` fails without the fix, naming the leak (`aggregate.NewController.func1` in `time.Sleep`).

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md).
- [X] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

AI-assisted. I reviewed every line of this diff before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of stale report data during controller shutdown.
  * Added safeguards to ensure background cleanup processes terminate correctly when the application stops.

* **Tests**
  * Added regression coverage for cleanup behavior during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->