### PR TITLE
fix: honour the caller context in notary attestation verification

### DIFF
--- a/pkg/image/verifiers/cpol/notary/notary.go
+++ b/pkg/image/verifiers/cpol/notary/notary.go
@@ -248,7 +248,7 @@ func verifyAttestators(ctx context.Context, v *notaryVerifier, ref name.Referenc
 	}
 
 	logger.V(4).Info("verification started")
-	targetDesc, outcomes, err := notation.Verify(context.TODO(), notationVerifier, parsedRef.Repo, remoteVerifyOptions)
+	targetDesc, outcomes, err := notation.Verify(notationlog.WithLogger(ctx, notary.NotaryLoggerAdapter(logger.WithName("Notary Verifier Debug"))), notationVerifier, parsedRef.Repo, remoteVerifyOptions)
 	if err != nil {
 		logger.V(4).Info("failed to vefify attestator", "remoteVerifyOptions", remoteVerifyOptions, "repo", parsedRef.Repo)
 		return targetDesc, err

--- a/pkg/image/verifiers/cpol/notary/notary.go
+++ b/pkg/image/verifiers/cpol/notary/notary.go
@@ -204,6 +204,8 @@ func (v *notaryVerifier) verifyOutcomes(outcomes []*notation.VerificationOutcome
 	return multierr.Combine(errs...)
 }
 
+// verifyAttestators verifies the notary signature on an attestation referrer and
+// returns its descriptor. It is a no-op when no attestor certificate is configured.
 func verifyAttestators(ctx context.Context, v *notaryVerifier, ref name.Reference, opts verifiers.Options, desc v1.Descriptor) (ocispec.Descriptor, error) {
 	logger.V(2).Info("verifying attestations", "reference", opts.ImageRef, "opts", opts)
 	if opts.Cert == "" && opts.CertChain == "" {

--- a/pkg/image/verifiers/cpol/notary/notary_unit_test.go
+++ b/pkg/image/verifiers/cpol/notary/notary_unit_test.go
@@ -1,15 +1,26 @@
 package notary
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/kyverno/kyverno/pkg/image/verifiers"
 	"github.com/notaryproject/notation-core-go/signature"
 	notation "github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation-go/verifier/trustpolicy"
+	"gotest.tools/v3/assert"
 )
 
 func TestCombineCerts(t *testing.T) {
@@ -315,4 +326,60 @@ func TestVerifyOutcomesErrorMessages(t *testing.T) {
 	if len(errMsg) == 0 {
 		t.Error("verifyOutcomes() error message should not be empty")
 	}
+}
+
+// contextOnlyClient is a verifiers.Client that contributes nothing but the
+// caller's context, so a test registry needs no credentials or TLS plumbing.
+type contextOnlyClient struct{}
+
+// Options returns the caller's context and nothing else.
+func (contextOnlyClient) Options(ctx context.Context) ([]remote.Option, []name.Option, error) {
+	return []remote.Option{remote.WithContext(ctx)}, nil, nil
+}
+
+// NameOptions returns no name options, so references are parsed as written.
+func (contextOnlyClient) NameOptions() []name.Option { return nil }
+
+// TestVerifyAttestatorsHonoursCallContext asserts verifyAttestators hands its
+// own context to notation rather than a fresh one, so cancelling the admission
+// request stops the registry round trips notation makes on our behalf. The test
+// registry answers the manifest lookups, then cancels the context and never
+// answers the signature listing, so the call can only return by honouring it.
+func TestVerifyAttestatorsHonoursCallContext(t *testing.T) {
+	manifest := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2},"layers":[]}`)
+	sum := sha256.Sum256(manifest)
+	dgst := "sha256:" + hex.EncodeToString(sum[:])
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/referrers/"):
+			cancel()
+			select {
+			case <-r.Context().Done():
+			case <-time.After(10 * time.Second):
+			}
+		case strings.HasSuffix(r.URL.Path, "/manifests/"+dgst):
+			w.Header().Set("Content-Type", string(types.OCIManifestSchema1))
+			w.Header().Set("Docker-Content-Digest", dgst)
+			w.Header().Set("Content-Length", strconv.Itoa(len(manifest)))
+			_, _ = w.Write(manifest)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	// httptest listens on 127.0.0.1, which go-containerregistry resolves over
+	// plain http, so no TLS plumbing is needed here.
+	ref, err := name.ParseReference(strings.TrimPrefix(srv.URL, "http://") + "/test/image:signed")
+	assert.NilError(t, err)
+	hash, err := v1.NewHash(dgst)
+	assert.NilError(t, err)
+
+	opts := verifiers.Options{ImageRef: ref.Name(), Cert: cert, Client: contextOnlyClient{}}
+	_, err = verifyAttestators(ctx, &notaryVerifier{}, ref, opts, v1.Descriptor{Digest: hash})
+	assert.ErrorContains(t, err, context.Canceled.Error())
 }

--- a/pkg/image/verifiers/cpol/notary/repository.go
+++ b/pkg/image/verifiers/cpol/notary/repository.go
@@ -26,12 +26,20 @@ func newRepository(remoteOpts []remote.Option, ref name.Reference) notationregis
 	}
 }
 
+// options binds the per-call context to the registry options. notation calls
+// every Repository method with the verification context, so the request's
+// deadline and cancellation have to reach the registry round trips; the
+// options captured at construction time carry whichever context built them.
+func (c *repositoryClient) options(ctx context.Context) []remote.Option {
+	return append(append([]remote.Option{}, c.remoteOpts...), remote.WithContext(ctx))
+}
+
 func (c *repositoryClient) Resolve(ctx context.Context, reference string) (ocispec.Descriptor, error) {
 	nameRef, err := name.ParseReference(c.getReferenceFromDigest(reference))
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	head, err := remote.Head(nameRef, c.remoteOpts...)
+	head, err := remote.Head(nameRef, c.options(ctx)...)
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
@@ -40,7 +48,7 @@ func (c *repositoryClient) Resolve(ctx context.Context, reference string) (ocisp
 }
 
 func (c *repositoryClient) ListSignatures(ctx context.Context, desc ocispec.Descriptor, fn func(signatureManifests []ocispec.Descriptor) error) error {
-	referrers, err := remote.Referrers(c.ref.Context().Digest(desc.Digest.String()), c.remoteOpts...)
+	referrers, err := remote.Referrers(c.ref.Context().Digest(desc.Digest.String()), c.options(ctx)...)
 	if err != nil {
 		return err
 	}
@@ -71,7 +79,7 @@ func (c *repositoryClient) FetchSignatureBlob(ctx context.Context, desc ocispec.
 		return nil, ocispec.Descriptor{}, err
 	}
 
-	remoteDesc, err := remote.Get(manifestRef, c.remoteOpts...)
+	remoteDesc, err := remote.Get(manifestRef, c.options(ctx)...)
 	if err != nil {
 		return nil, ocispec.Descriptor{}, err
 	}
@@ -97,7 +105,7 @@ func (c *repositoryClient) FetchSignatureBlob(ctx context.Context, desc ocispec.
 	}
 
 	digest := signatureBlobRef.Identifier()
-	signatureBlobLayer, err := remote.Layer(signatureBlobRef.Context().Digest(digest), c.remoteOpts...)
+	signatureBlobLayer, err := remote.Layer(signatureBlobRef.Context().Digest(digest), c.options(ctx)...)
 	if err != nil {
 		return nil, ocispec.Descriptor{}, err
 	}

--- a/pkg/image/verifiers/cpol/notary/repository.go
+++ b/pkg/image/verifiers/cpol/notary/repository.go
@@ -34,6 +34,7 @@ func (c *repositoryClient) options(ctx context.Context) []remote.Option {
 	return append(append([]remote.Option{}, c.remoteOpts...), remote.WithContext(ctx))
 }
 
+// Resolve returns the descriptor of the manifest the reference points at.
 func (c *repositoryClient) Resolve(ctx context.Context, reference string) (ocispec.Descriptor, error) {
 	nameRef, err := name.ParseReference(c.getReferenceFromDigest(reference))
 	if err != nil {
@@ -47,6 +48,7 @@ func (c *repositoryClient) Resolve(ctx context.Context, reference string) (ocisp
 	return descriptor, nil
 }
 
+// ListSignatures passes the notation signature manifests attached to desc to fn.
 func (c *repositoryClient) ListSignatures(ctx context.Context, desc ocispec.Descriptor, fn func(signatureManifests []ocispec.Descriptor) error) error {
 	referrers, err := remote.Referrers(c.ref.Context().Digest(desc.Digest.String()), c.options(ctx)...)
 	if err != nil {
@@ -73,6 +75,7 @@ func (c *repositoryClient) ListSignatures(ctx context.Context, desc ocispec.Desc
 	return fn(descList)
 }
 
+// FetchSignatureBlob returns the signature envelope carried by the signature manifest desc.
 func (c *repositoryClient) FetchSignatureBlob(ctx context.Context, desc ocispec.Descriptor) ([]byte, ocispec.Descriptor, error) {
 	manifestRef, err := name.ParseReference(c.getReferenceFromDescriptor(desc))
 	if err != nil {

--- a/pkg/image/verifiers/cpol/notary/repository_test.go
+++ b/pkg/image/verifiers/cpol/notary/repository_test.go
@@ -2,11 +2,16 @@ package notary
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	notationregistry "github.com/notaryproject/notation-go/registry"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 )
@@ -79,5 +84,58 @@ func TestFetchSignatureBlob(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Equal(t, desc.MediaType, "application/jose+json")
 		}
+	}
+}
+
+// TestRepositoryClientHonoursCallContext asserts every registry round trip made
+// on notation's behalf is bound to the context notation passes into the
+// Repository method, not to whichever context happened to build the client's
+// remote options. Without that binding the admission webhook's deadline never
+// reaches the registry, so a registry that tarpits the connection holds a
+// webhook worker for as long as it likes.
+func TestRepositoryClientHonoursCallContext(t *testing.T) {
+	var contacted atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		contacted.Store(true)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	// httptest listens on 127.0.0.1, which go-containerregistry resolves over
+	// plain http, so no TLS plumbing is needed here.
+	ref, err := name.ParseReference(strings.TrimPrefix(srv.URL, "http://") + "/test/image:signed")
+	assert.NilError(t, err)
+
+	const dgst = "sha256:b31bfb4d0213f254d361e0079deaaebefa4f82ba7aa76ef82e90b4935ad5b105"
+	desc := ocispec.Descriptor{
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Digest:    digest.Digest(dgst),
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := newRepository(nil, ref)
+	calls := map[string]func(context.Context) error{
+		"Resolve": func(ctx context.Context) error {
+			_, err := client.Resolve(ctx, dgst)
+			return err
+		},
+		"ListSignatures": func(ctx context.Context) error {
+			return client.ListSignatures(ctx, desc, func([]ocispec.Descriptor) error { return nil })
+		},
+		"FetchSignatureBlob": func(ctx context.Context) error {
+			_, _, err := client.FetchSignatureBlob(ctx, desc)
+			return err
+		},
+	}
+
+	for label, call := range calls {
+		t.Run(label, func(t *testing.T) {
+			contacted.Store(false)
+			err := call(cancelled)
+			assert.ErrorContains(t, err, context.Canceled.Error())
+			assert.Assert(t, !contacted.Load(), "registry was contacted with an already cancelled context")
+		})
 	}
 }


### PR DESCRIPTION
## Explanation

Fix. Notary attestation verification ignored the caller's context, so registry calls could not be cancelled and kept running after the admission request was already gone.

## Related issue

Refs #17121

## What type of PR is this

/kind bug

## Proposed Changes

`verifyAttestators` passed `context.TODO()` into `notation.Verify` while the signature path in the same file passes `ctx`.

Propagating `ctx` alone is not enough. notation drives all registry I/O through `repositoryClient`, whose `Resolve`, `ListSignatures` and `FetchSignatureBlob` ignored the context notation handed them and reused construction-time options. Fixed in one shared `options(ctx)` helper rather than at the four call sites.

`Refs` not `Closes`: the issue also names a second site, which `main` marks `//nolint:gosec // background context is intentional`, so that one is left alone.

### Proof Manifests

Not applicable, no user-facing behavior change. `TestRepositoryClientHonoursCallContext` is hermetic (`httptest`) and proves the registry is still contacted after the context is cancelled without the fix.

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md).
- [X] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

AI-assisted. I reviewed every line of this diff before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Registry and attestation verification requests now honor the context provided for each operation.
  - Canceled operations stop promptly without contacting the registry, improving cancellation behavior and responsiveness.
  - Verification logging now uses the configured Notary logger context, providing more useful diagnostic details.

- **Tests**
  - Added coverage confirming context cancellation is consistently respected across registry interactions and attestation verification requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->