### PR TITLE
fix(helm): grant reports-controller RBAC on DeletingPolicy/NamespacedDeletingPolicy

### DIFF
--- a/charts/kyverno/templates/reports-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/reports-controller/clusterrole.yaml
@@ -67,6 +67,8 @@ rules:
       - namespacedgeneratingpolicies
       - mutatingpolicies
       - namespacedmutatingpolicies
+      - deletingpolicies
+      - namespaceddeletingpolicies
     verbs:
       - create
       - delete

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -87957,6 +87957,8 @@ rules:
       - namespacedgeneratingpolicies
       - mutatingpolicies
       - namespacedmutatingpolicies
+      - deletingpolicies
+      - namespaceddeletingpolicies
     verbs:
       - create
       - delete


### PR DESCRIPTION
## Explanation

The reports-controller's `:core` ClusterRole grants access to every `policies.kyverno.io` CEL policy type (`ValidatingPolicy`, `ImageValidatingPolicy`, `GeneratingPolicy`, `MutatingPolicy`, and their `Namespaced` variants) except `DeletingPolicy`/`NamespacedDeletingPolicy`. A `ValidatingPolicy` whose `matchConstraints` target those two resources with background scanning enabled therefore fails its `RBACPermissionsGranted` condition and never becomes `Ready`, since that check runs a `SubjectAccessReview` against the reports-controller service account. This is a fix to existing behavior (a missing RBAC grant), not new functionality.

## Related issue

Closes #17532

## Documentation (required for features)

Not applicable — this only adds two resources to an existing RBAC rule, no new user-facing values or behavior.

## What type of PR is this

/kind bug

## Proposed Changes

Add `deletingpolicies` and `namespaceddeletingpolicies` to the same `apiGroups`/`resources` list as `generatingpolicies`/`namespacedgeneratingpolicies`/`mutatingpolicies`/`namespacedmutatingpolicies` in `charts/kyverno/templates/reports-controller/clusterrole.yaml`, and regenerate `config/install-latest-testing.yaml` accordingly (`make codegen-manifest-install-latest`).

### Proof Manifests

Before the fix, with `reportsController.enabled: true` (default) and `cleanupController.enabled: false` (default):

```
$ kubectl auth can-i get deletingpolicies.policies.kyverno.io --as=system:serviceaccount:kyverno:kyverno-reports-controller
no
$ kubectl auth can-i get namespaceddeletingpolicies.policies.kyverno.io --as=system:serviceaccount:kyverno:kyverno-reports-controller
no
```

A `ValidatingPolicy` matching `CREATE`/`UPDATE` of those two resources with `spec.evaluation.background.enabled: true` reports:

```yaml
status:
  conditionStatus:
    conditions:
    - type: RBACPermissionsGranted
      status: "False"
      reason: Failed
      message: >-
        Policy is not ready for reporting, missing permissions:
        get policies.kyverno.io/v1, Resource=deletingpolicies: ;
        list policies.kyverno.io/v1, Resource=deletingpolicies: ;
        watch policies.kyverno.io/v1, Resource=deletingpolicies: ;
        get policies.kyverno.io/v1, Resource=namespaceddeletingpolicies: ;
        list policies.kyverno.io/v1, Resource=namespaceddeletingpolicies: ;
        watch policies.kyverno.io/v1, Resource=namespaceddeletingpolicies: .
    ready: false
```

After this change, `kubectl auth can-i` returns `yes` for both resources and the condition becomes `True`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Kubernetes RBAC permissions for `deletingpolicies` and `namespaceddeletingpolicies` resources in the policies API group.
  - Updated both the Helm chart and latest testing installation configuration to include these resources.
  - Reports-controller deployments can now access and manage the newly supported policy resource types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->