### PR TITLE
feat: block creates and spec-updates of legacy policy APIs (1.20)

### DIFF
--- a/.github/workflows/tests-conformance.yaml
+++ b/.github/workflows/tests-conformance.yaml
@@ -193,6 +193,21 @@ jobs:
           shard-index: ${{ matrix.shard-index }}
           shard-count: 6
 
+  deprecations:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [v1.33.7, v1.34.3, v1.35.1]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/tests/conformance/run
+        with:
+          k8s-version: ${{ matrix.k8s-version }}
+          kyverno-configs: standard
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tests-path: deprecations
+
   events:
     runs-on: ubuntu-latest
     strategy:

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -366,7 +366,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | features.deferredLoading.enabled | bool | `true` | Enables the feature |
 | features.dumpPayload.enabled | bool | `false` | Enables the feature |
 | features.forceFailurePolicyIgnore.enabled | bool | `false` | Enables the feature |
-| features.blockLegacyPolicyAPIs.enabled | bool | `true` | Blocks creates and spec-changing updates of legacy kyverno.io policy APIs (ClusterPolicy, Policy, CleanupPolicy, ClusterCleanupPolicy, legacy PolicyException) in favor of the CEL-based policies.kyverno.io types. Existing legacy policies keep being read, enforced, and reconciled by GitOps tooling. Temporary migration escape hatch for 1.20, removed in 1.21. |
+| features.blockLegacyPolicyAPIs.enabled | bool | `true` | Blocks creates and spec-changing updates of legacy kyverno.io policy APIs (ClusterPolicy, Policy, CleanupPolicy, ClusterCleanupPolicy, legacy PolicyException) in favor of the CEL-based policies.kyverno.io types. Existing legacy policies remain readable and enforced; no-op, metadata-only, and status-subresource updates remain allowed. Temporary migration escape hatch for 1.20, removed in 1.21. |
 | features.generateValidatingAdmissionPolicy.enabled | bool | `true` | Enables the feature |
 | features.generateMutatingAdmissionPolicy.enabled | bool | `false` | Enables the feature |
 | features.dumpPatches.enabled | bool | `false` | Enables the feature |

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -366,6 +366,7 @@ The default audience is Kyverno-specific so leaked tokens are not accepted by th
 | features.deferredLoading.enabled | bool | `true` | Enables the feature |
 | features.dumpPayload.enabled | bool | `false` | Enables the feature |
 | features.forceFailurePolicyIgnore.enabled | bool | `false` | Enables the feature |
+| features.blockLegacyPolicyAPIs.enabled | bool | `true` | Blocks creates and spec-changing updates of legacy kyverno.io policy APIs (ClusterPolicy, Policy, CleanupPolicy, ClusterCleanupPolicy, legacy PolicyException) in favor of the CEL-based policies.kyverno.io types. Existing legacy policies keep being read, enforced, and reconciled by GitOps tooling. Temporary migration escape hatch for 1.20, removed in 1.21. |
 | features.generateValidatingAdmissionPolicy.enabled | bool | `true` | Enables the feature |
 | features.generateMutatingAdmissionPolicy.enabled | bool | `false` | Enables the feature |
 | features.dumpPatches.enabled | bool | `false` | Enables the feature |

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -62,6 +62,9 @@
 {{- with .forceFailurePolicyIgnore -}}
   {{- $flags = append $flags (print "--forceFailurePolicyIgnore=" .enabled) -}}
 {{- end -}}
+{{- with .blockLegacyPolicyAPIs -}}
+  {{- $flags = append $flags (print "--blockLegacyPolicyAPIs=" .enabled) -}}
+{{- end -}}
 {{- with .generateValidatingAdmissionPolicy -}}
   {{- $flags = append $flags (print "--generateValidatingAdmissionPolicy=" .enabled) -}}
 {{- end -}}

--- a/charts/kyverno/templates/admission-controller/deployment.yaml
+++ b/charts/kyverno/templates/admission-controller/deployment.yaml
@@ -202,6 +202,7 @@ spec:
             {{- include "kyverno.features.flags" (pick (mergeOverwrite (deepCopy .Values.features) .Values.admissionController.featuresOverride)
               "admissionReports"
               "autoUpdateWebhooks"
+              "blockLegacyPolicyAPIs"
               "configMapCaching"
               "controllerRuntimeMetrics"
               "deferredLoading"

--- a/charts/kyverno/templates/cleanup-controller/deployment.yaml
+++ b/charts/kyverno/templates/cleanup-controller/deployment.yaml
@@ -143,6 +143,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- include "kyverno.features.flags" (pick (mergeOverwrite (deepCopy .Values.features) .Values.cleanupController.featuresOverride)
+              "blockLegacyPolicyAPIs"
               "deferredLoading"
               "dumpPayload"
               "globalContext"

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -884,6 +884,9 @@ features:
   forceFailurePolicyIgnore:
     # -- Enables the feature
     enabled: false
+  blockLegacyPolicyAPIs:
+    # -- Blocks creates and spec-changing updates of legacy kyverno.io policy APIs (ClusterPolicy, Policy, CleanupPolicy, ClusterCleanupPolicy, legacy PolicyException) in favor of the CEL-based policies.kyverno.io types. Existing legacy policies keep being read, enforced, and reconciled by GitOps tooling. Temporary migration escape hatch for 1.20, removed in 1.21.
+    enabled: true
   generateValidatingAdmissionPolicy:
     # -- Enables the feature
     enabled: true

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -885,7 +885,7 @@ features:
     # -- Enables the feature
     enabled: false
   blockLegacyPolicyAPIs:
-    # -- Blocks creates and spec-changing updates of legacy kyverno.io policy APIs (ClusterPolicy, Policy, CleanupPolicy, ClusterCleanupPolicy, legacy PolicyException) in favor of the CEL-based policies.kyverno.io types. Existing legacy policies keep being read, enforced, and reconciled by GitOps tooling. Temporary migration escape hatch for 1.20, removed in 1.21.
+    # -- Blocks creates and spec-changing updates of legacy kyverno.io policy APIs (ClusterPolicy, Policy, CleanupPolicy, ClusterCleanupPolicy, legacy PolicyException) in favor of the CEL-based policies.kyverno.io types. Existing legacy policies remain readable and enforced; no-op, metadata-only, and status-subresource updates remain allowed. Temporary migration escape hatch for 1.20, removed in 1.21.
     enabled: true
   generateValidatingAdmissionPolicy:
     # -- Enables the feature

--- a/cmd/cleanup-controller/handlers/admission/policy/handlers.go
+++ b/cmd/cleanup-controller/handlers/admission/policy/handlers.go
@@ -25,6 +25,15 @@ func New(client dclient.Interface) *validationHandlers {
 }
 
 func (h *validationHandlers) Validate(ctx context.Context, logger logr.Logger, request handlers.AdmissionRequest, _ time.Time) handlers.AdmissionResponse {
+	// Subresource requests (e.g. /status, written by this controller's own reconcile loop)
+	// never touch spec, so there is nothing here to validate or warn about; short-circuit
+	// before policy validation and deprecation warnings, not just the legacy-policy block.
+	// Kubernetes guarantees a status-subresource write cannot change spec, see:
+	// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource
+	if request.SubResource != "" {
+		return admissionutils.ResponseSuccess(request.UID)
+	}
+
 	policy, oldPolicy, err := admissionutils.GetCleanupPolicies(request.AdmissionRequest)
 	if err != nil {
 		logger.Error(err, "failed to unmarshal policies from admission request")

--- a/cmd/cleanup-controller/handlers/admission/policy/handlers.go
+++ b/cmd/cleanup-controller/handlers/admission/policy/handlers.go
@@ -11,6 +11,7 @@ import (
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	validation "github.com/kyverno/kyverno/pkg/validation/cleanuppolicy"
 	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 )
 
 type validationHandlers struct {
@@ -24,9 +25,18 @@ func New(client dclient.Interface) *validationHandlers {
 }
 
 func (h *validationHandlers) Validate(ctx context.Context, logger logr.Logger, request handlers.AdmissionRequest, _ time.Time) handlers.AdmissionResponse {
-	policy, _, err := admissionutils.GetCleanupPolicies(request.AdmissionRequest)
+	policy, oldPolicy, err := admissionutils.GetCleanupPolicies(request.AdmissionRequest)
 	if err != nil {
 		logger.Error(err, "failed to unmarshal policies from admission request")
+		return admissionutils.Response(request.UID, err)
+	}
+	if err, blocked := deprecations.ShouldBlock(ctx, request.AdmissionRequest, func() bool {
+		return oldPolicy != nil && apiequality.Semantic.DeepEqual(oldPolicy.GetSpec(), policy.GetSpec())
+	}); blocked {
+		logger.Error(err, "legacy policy write blocked", "kind", request.Kind.Kind, "namespace", request.Namespace, "name", request.Name)
+		if deprecatedMetric := metrics.GetDeprecatedAPIRequestMetrics(); deprecatedMetric != nil {
+			deprecatedMetric.Record(ctx, request.Namespace, request.Kind.Group, request.Kind.Version, request.Kind.Kind, "")
+		}
 		return admissionutils.Response(request.UID, err)
 	}
 	if err := validation.Validate(ctx, logger, h.client, policy); err != nil {

--- a/cmd/cleanup-controller/handlers/admission/policy/handlers_test.go
+++ b/cmd/cleanup-controller/handlers/admission/policy/handlers_test.go
@@ -109,10 +109,11 @@ func TestValidateBlocksLegacyWrites(t *testing.T) {
 	metadataOnlyChange.ObjectMeta.Labels = map[string]string{"foo": "bar"}
 
 	tests := []struct {
-		name      string
-		toggleOff bool
-		request   handlers.AdmissionRequest
-		allowed   bool
+		name       string
+		toggleOff  bool
+		request    handlers.AdmissionRequest
+		allowed    bool
+		wantSilent bool // if true, assert resp.Warnings is empty too, not just Allowed
 	}{
 		{
 			name:    "create is blocked",
@@ -135,9 +136,15 @@ func TestValidateBlocksLegacyWrites(t *testing.T) {
 			allowed: true,
 		},
 		{
-			name:    "status subresource update is allowed (cleanup controller's own status writes)",
-			request: newCleanupPolicyRequest(t, admissionv1.Update, changedPolicy, policy, "status"),
-			allowed: true,
+			// This is the case that matters most for this controller: it short-circuits
+			// before validation.Validate/BuildKindWarning entirely, so the cleanup
+			// controller's own UpdateStatus calls never re-run full policy validation (auth
+			// checks, schedule/match validation) on every reconcile, and never emit a
+			// deprecation warning for its own housekeeping writes.
+			name:       "status subresource update is allowed and silent (cleanup controller's own status writes)",
+			request:    newCleanupPolicyRequest(t, admissionv1.Update, changedPolicy, policy, "status"),
+			allowed:    true,
+			wantSilent: true,
 		},
 		{
 			name:      "toggle disabled allows create",
@@ -159,6 +166,9 @@ func TestValidateBlocksLegacyWrites(t *testing.T) {
 			h := New(newFakeClient())
 			resp := h.Validate(context.Background(), logr.Discard(), tt.request, time.Now())
 			assert.Equal(t, tt.allowed, resp.Allowed, "message: %v", resp.Result)
+			if tt.wantSilent {
+				assert.Empty(t, resp.Warnings)
+			}
 		})
 	}
 }

--- a/cmd/cleanup-controller/handlers/admission/policy/handlers_test.go
+++ b/cmd/cleanup-controller/handlers/admission/policy/handlers_test.go
@@ -1,0 +1,164 @@
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	"github.com/kyverno/kyverno/pkg/toggle"
+	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+// cachedFakeDiscovery adapts a plain discoveryfake.FakeDiscovery into a
+// discovery.CachedDiscoveryInterface (adding no-op Fresh/Invalidate), so
+// validation.Validate's discovery.ServerPreferredResources(client.Discovery().CachedDiscoveryInterface())
+// call has a real, non-nil, non-aggregated discovery interface to walk instead of the dclient
+// test fake's CachedDiscoveryInterface(), which stubs to nil and panics deeper in client-go.
+type cachedFakeDiscovery struct {
+	*discoveryfake.FakeDiscovery
+}
+
+func (cachedFakeDiscovery) Fresh() bool { return true }
+func (cachedFakeDiscovery) Invalidate() {}
+
+// discoveryWithCache overrides only CachedDiscoveryInterface() on top of
+// dclient.NewFakeDiscoveryClient, which the rest of the fake dclient.Interface still needs for
+// GetGVRFromGVK/FindResources/etc.
+type discoveryWithCache struct {
+	dclient.IDiscovery
+	cached discovery.CachedDiscoveryInterface
+}
+
+func (d discoveryWithCache) CachedDiscoveryInterface() discovery.CachedDiscoveryInterface {
+	return d.cached
+}
+
+func newFakeClient() dclient.Interface {
+	fakeDisco := &discoveryfake.FakeDiscovery{Fake: &kubetesting.Fake{}}
+	disco := discoveryWithCache{
+		IDiscovery: dclient.NewFakeDiscoveryClient(nil),
+		cached:     cachedFakeDiscovery{fakeDisco},
+	}
+	return dclient.NewFakeClientWithDisco(dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()), kubefake.NewSimpleClientset(), disco)
+}
+
+// validCleanupPolicy passes validation.Validate against an empty fake client: an empty
+// MatchResources has no resource filters, so no delete/list SubjectAccessReview is required, and
+// the schedule is a well-formed cron expression.
+func validCleanupPolicy(name string) *kyvernov2.ClusterCleanupPolicy {
+	return &kyvernov2.ClusterCleanupPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: kyvernov2.CleanupPolicySpec{
+			Schedule: "0 0 * * *",
+		},
+	}
+}
+
+func legacyCleanupPolicyKind() metav1.GroupVersionKind {
+	return metav1.GroupVersionKind{Group: "kyverno.io", Version: "v2", Kind: "ClusterCleanupPolicy"}
+}
+
+func newCleanupPolicyRequest(t *testing.T, operation admissionv1.Operation, obj, oldObj *kyvernov2.ClusterCleanupPolicy, subResource string) handlers.AdmissionRequest {
+	t.Helper()
+	raw, err := json.Marshal(obj)
+	require.NoError(t, err)
+	request := handlers.AdmissionRequest{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID:         types.UID("test-uid"),
+			Kind:        legacyCleanupPolicyKind(),
+			Operation:   operation,
+			SubResource: subResource,
+			Object:      runtime.RawExtension{Raw: raw},
+		},
+	}
+	if oldObj != nil {
+		oldRaw, err := json.Marshal(oldObj)
+		require.NoError(t, err)
+		request.OldObject = runtime.RawExtension{Raw: oldRaw}
+	}
+	return request
+}
+
+// TestValidateBlocksLegacyWrites covers the 1.20 write-time hard block on legacy
+// ClusterCleanupPolicy/CleanupPolicy (see #17483/#17484/#17486). It specifically exercises the
+// status-subresource case: Kyverno's own cleanup controller writes ClusterCleanupPolicy/status
+// (pkg/controllers/cleanup/controller.go), and the cleanup-controller's webhook rule matches
+// "clustercleanuppolicies/*" including subresources — if the block didn't exempt subresources it
+// would deadlock the cleanup controller against its own status updates.
+func TestValidateBlocksLegacyWrites(t *testing.T) {
+	policy := validCleanupPolicy("test-policy")
+	changedPolicy := policy.DeepCopy()
+	changedPolicy.Spec.Schedule = "0 12 * * *"
+	metadataOnlyChange := policy.DeepCopy()
+	metadataOnlyChange.ObjectMeta.ResourceVersion = "123"
+	metadataOnlyChange.ObjectMeta.Labels = map[string]string{"foo": "bar"}
+
+	tests := []struct {
+		name      string
+		toggleOff bool
+		request   handlers.AdmissionRequest
+		allowed   bool
+	}{
+		{
+			name:    "create is blocked",
+			request: newCleanupPolicyRequest(t, admissionv1.Create, policy, nil, ""),
+			allowed: false,
+		},
+		{
+			name:    "spec-changing update is blocked",
+			request: newCleanupPolicyRequest(t, admissionv1.Update, changedPolicy, policy, ""),
+			allowed: false,
+		},
+		{
+			name:    "no-op GitOps re-apply is allowed",
+			request: newCleanupPolicyRequest(t, admissionv1.Update, policy, policy, ""),
+			allowed: true,
+		},
+		{
+			name:    "metadata-only update is allowed",
+			request: newCleanupPolicyRequest(t, admissionv1.Update, metadataOnlyChange, policy, ""),
+			allowed: true,
+		},
+		{
+			name:    "status subresource update is allowed (cleanup controller's own status writes)",
+			request: newCleanupPolicyRequest(t, admissionv1.Update, changedPolicy, policy, "status"),
+			allowed: true,
+		},
+		{
+			name:      "toggle disabled allows create",
+			toggleOff: true,
+			request:   newCleanupPolicyRequest(t, admissionv1.Create, policy, nil, ""),
+			allowed:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				require.NoError(t, toggle.BlockLegacyPolicyAPIs.Parse(""))
+			})
+			if tt.toggleOff {
+				require.NoError(t, toggle.BlockLegacyPolicyAPIs.Parse("false"))
+			}
+
+			h := New(newFakeClient())
+			resp := h.Validate(context.Background(), logr.Discard(), tt.request, time.Now())
+			assert.Equal(t, tt.allowed, resp.Allowed, "message: %v", resp.Result)
+		})
+	}
+}

--- a/cmd/cleanup-controller/main.go
+++ b/cmd/cleanup-controller/main.go
@@ -106,6 +106,7 @@ func main() {
 	flagset.Func(toggle.AllowHTTPInNamespacedPoliciesFlagName, toggle.AllowHTTPInNamespacedPoliciesDescription, toggle.AllowHTTPInNamespacedPolicies.Parse)
 	flagset.Func(toggle.HTTPBlocklistFlagName, toggle.HTTPBlocklistDescription, toggle.HTTPBlocklist.Parse)
 	flagset.Func(toggle.HTTPAllowlistFlagName, toggle.HTTPAllowlistDescription, toggle.HTTPAllowlist.Parse)
+	flagset.Func(toggle.BlockLegacyPolicyAPIsFlagName, toggle.BlockLegacyPolicyAPIsDescription, toggle.BlockLegacyPolicyAPIs.Parse)
 	flagset.StringVar(&caSecretName, "caSecretName", "", "Name of the secret containing CA.")
 	flagset.StringVar(&tlsSecretName, "tlsSecretName", "", "Name of the secret containing TLS pair.")
 	flagset.DurationVar(&renewBefore, "renewBefore", 15*24*time.Hour, "The certificate renewal time before expiration")
@@ -305,8 +306,11 @@ func main() {
 						[]admissionregistrationv1.RuleWithOperations{
 							{
 								Rule: admissionregistrationv1.Rule{
-									APIGroups:   []string{"kyverno.io"},
-									APIVersions: []string{"v2beta1"},
+									APIGroups: []string{"kyverno.io"},
+									// v2 is the storage version for cleanuppolicies/clustercleanuppolicies.kyverno.io.
+									// Without it, a "kyverno.io/v2" CleanupPolicy (the version most manifests
+									// actually use) never reaches this webhook at all.
+									APIVersions: []string{"v2", "v2beta1"},
 									Resources: []string{
 										"cleanuppolicies/*",
 										"clustercleanuppolicies/*",

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -209,8 +209,12 @@ func createrLeaderControllers(
 		nil,
 		[]admissionregistrationv1.RuleWithOperations{{
 			Rule: admissionregistrationv1.Rule{
-				APIGroups:   []string{"kyverno.io"},
-				APIVersions: []string{"v2alpha1", "v2beta1"},
+				APIGroups: []string{"kyverno.io"},
+				// v2 is the storage version for policyexceptions.kyverno.io; v2alpha1 is kept
+				// here for backwards compatibility even though no v2alpha1 PolicyException type
+				// has ever existed. Without v2, a "kyverno.io/v2" PolicyException (the version
+				// most manifests actually use) never reaches this webhook at all.
+				APIVersions: []string{"v2", "v2alpha1", "v2beta1"},
 				Resources:   []string{"policyexceptions"},
 			},
 			Operations: []admissionregistrationv1.OperationType{
@@ -407,6 +411,7 @@ func main() {
 	flagset.Func(toggle.AllowHTTPInNamespacedPoliciesFlagName, toggle.AllowHTTPInNamespacedPoliciesDescription, toggle.AllowHTTPInNamespacedPolicies.Parse)
 	flagset.Func(toggle.HTTPBlocklistFlagName, toggle.HTTPBlocklistDescription, toggle.HTTPBlocklist.Parse)
 	flagset.Func(toggle.HTTPAllowlistFlagName, toggle.HTTPAllowlistDescription, toggle.HTTPAllowlist.Parse)
+	flagset.Func(toggle.BlockLegacyPolicyAPIsFlagName, toggle.BlockLegacyPolicyAPIsDescription, toggle.BlockLegacyPolicyAPIs.Parse)
 	flagset.BoolVar(&admissionReports, "admissionReports", true, "Enable or disable admission reports.")
 	flagset.IntVar(&servicePort, "servicePort", 443, "Port used by the Kyverno Service resource and for webhook configurations.")
 	flagset.StringVar(&webhookServerHost, "webhookServerHost", "", "Host used by the webhook server. If not set, it will default to [::] for IPv6 or 0.0.0.0 for IPv4.")

--- a/config/install-latest-testing.yaml
+++ b/config/install-latest-testing.yaml
@@ -88746,6 +88746,7 @@ spec:
             - --enableDeferredLoading=true
             - --dumpPayload=false
             - --forceFailurePolicyIgnore=false
+            - --blockLegacyPolicyAPIs=true
             - --generateValidatingAdmissionPolicy=true
             - --generateMutatingAdmissionPolicy=false
             - --dumpPatches=false
@@ -89059,6 +89060,7 @@ spec:
             - --metricsPort=8000
             - --enableDeferredLoading=true
             - --dumpPayload=false
+            - --blockLegacyPolicyAPIs=true
             - --maxAPICallResponseLength=2000000
             - --apiCallTimeout=30s
             - --maxGlobalContextEntries=0

--- a/pkg/deprecations/block.go
+++ b/pkg/deprecations/block.go
@@ -1,0 +1,45 @@
+package deprecations
+
+import (
+	"context"
+
+	"github.com/kyverno/kyverno/pkg/toggle"
+	admissionv1 "k8s.io/api/admission/v1"
+)
+
+// ShouldBlock decides whether an admission request for a legacy kyverno.io policy kind must be
+// hard-denied under the 1.20 write-time block on legacy policy APIs (see
+// https://github.com/kyverno/kyverno/issues/17483). Only genuine creates and spec-changing
+// updates are blocked:
+//   - the toggle.BlockLegacyPolicyAPIs escape hatch, when disabled, allows everything through
+//     (temporary 1.20 migration-grace opt-out, removed in 1.21)
+//   - subresource requests (e.g. "status") are always allowed, so Kyverno's own controllers can
+//     keep writing status on legacy policies they manage
+//   - Delete/Connect operations, and any kind outside the legacy kyverno.io policy kinds, are
+//     always allowed
+//   - on Update, specsEqual is consulted to allow no-op re-applies (GitOps/Helm reconciliation
+//     re-submitting an unchanged manifest, or a metadata/status-only change) through silently;
+//     specsEqual is a thunk so callers only decode/compare the old and new specs when the
+//     request could otherwise be blocked
+//
+// specsEqual is only invoked for Update requests on a legacy policy kind, once every cheaper
+// check has already passed.
+func ShouldBlock(ctx context.Context, request admissionv1.AdmissionRequest, specsEqual func() bool) (error, bool) {
+	if !toggle.FromContext(ctx).BlockLegacyPolicyAPIs() {
+		return nil, false
+	}
+	if request.SubResource != "" {
+		return nil, false
+	}
+	if request.Operation != admissionv1.Create && request.Operation != admissionv1.Update {
+		return nil, false
+	}
+	if !IsLegacyPolicyKind(request.Kind.Group, request.Kind.Kind) {
+		return nil, false
+	}
+	if request.Operation == admissionv1.Update && specsEqual() {
+		return nil, false
+	}
+	err, _ := BuildKindError(request.Kind.Group, request.Kind.Version, request.Kind.Kind)
+	return err, true
+}

--- a/pkg/deprecations/block_test.go
+++ b/pkg/deprecations/block_test.go
@@ -106,7 +106,7 @@ func TestShouldBlock(t *testing.T) {
 			assert.Equal(t, tt.wantBlock, blocked)
 			if tt.wantBlock {
 				require.Error(t, err)
-				assert.True(t, strings.Contains(err.Error(), "no longer accepted for create or update"))
+				assert.True(t, strings.Contains(err.Error(), "no longer accepted for create, or for an update that changes spec"))
 			} else {
 				assert.NoError(t, err)
 			}

--- a/pkg/deprecations/block_test.go
+++ b/pkg/deprecations/block_test.go
@@ -1,0 +1,115 @@
+package deprecations
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kyverno/kyverno/pkg/toggle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// resetBlockLegacyPolicyAPIs returns the shared BlockLegacyPolicyAPIs toggle to its unset state
+// (default: enabled) once the test finishes, so tests that flip it don't leak into others.
+func resetBlockLegacyPolicyAPIs(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		require.NoError(t, toggle.BlockLegacyPolicyAPIs.Parse(""))
+	})
+}
+
+func neverCalled(t *testing.T) func() bool {
+	t.Helper()
+	return func() bool {
+		t.Fatal("specsEqual should not have been invoked")
+		return false
+	}
+}
+
+func TestShouldBlock(t *testing.T) {
+	clusterPolicyKind := metav1.GroupVersionKind{Group: "kyverno.io", Version: "v1", Kind: "ClusterPolicy"}
+	celPolicyExceptionKind := metav1.GroupVersionKind{Group: "policies.kyverno.io", Version: "v1", Kind: "PolicyException"}
+	validatingPolicyKind := metav1.GroupVersionKind{Group: "policies.kyverno.io", Version: "v1beta1", Kind: "ValidatingPolicy"}
+
+	tests := []struct {
+		name       string
+		toggleOff  bool
+		request    admissionv1.AdmissionRequest
+		specsEqual func() bool
+		wantBlock  bool
+	}{
+		{
+			name:      "toggle disabled allows create of a legacy kind",
+			toggleOff: true,
+			request:   admissionv1.AdmissionRequest{Kind: clusterPolicyKind, Operation: admissionv1.Create},
+			wantBlock: false,
+		},
+		{
+			name:      "status subresource is never blocked",
+			request:   admissionv1.AdmissionRequest{Kind: clusterPolicyKind, Operation: admissionv1.Update, SubResource: "status"},
+			wantBlock: false,
+		},
+		{
+			name:      "delete is never blocked",
+			request:   admissionv1.AdmissionRequest{Kind: clusterPolicyKind, Operation: admissionv1.Delete},
+			wantBlock: false,
+		},
+		{
+			name:      "connect is never blocked",
+			request:   admissionv1.AdmissionRequest{Kind: clusterPolicyKind, Operation: admissionv1.Connect},
+			wantBlock: false,
+		},
+		{
+			name:      "CEL PolicyException (policies.kyverno.io) is never blocked",
+			request:   admissionv1.AdmissionRequest{Kind: celPolicyExceptionKind, Operation: admissionv1.Create},
+			wantBlock: false,
+		},
+		{
+			name:      "non-legacy kind is never blocked",
+			request:   admissionv1.AdmissionRequest{Kind: validatingPolicyKind, Operation: admissionv1.Create},
+			wantBlock: false,
+		},
+		{
+			name:      "create of a legacy kind is blocked",
+			request:   admissionv1.AdmissionRequest{Kind: clusterPolicyKind, Operation: admissionv1.Create},
+			wantBlock: true,
+		},
+		{
+			name:       "no-op update (identical spec) is allowed",
+			request:    admissionv1.AdmissionRequest{Kind: clusterPolicyKind, Operation: admissionv1.Update},
+			specsEqual: func() bool { return true },
+			wantBlock:  false,
+		},
+		{
+			name:       "spec-changing update is blocked",
+			request:    admissionv1.AdmissionRequest{Kind: clusterPolicyKind, Operation: admissionv1.Update},
+			specsEqual: func() bool { return false },
+			wantBlock:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetBlockLegacyPolicyAPIs(t)
+			if tt.toggleOff {
+				require.NoError(t, toggle.BlockLegacyPolicyAPIs.Parse("false"))
+			}
+			specsEqual := tt.specsEqual
+			if specsEqual == nil {
+				specsEqual = neverCalled(t)
+			}
+
+			err, blocked := ShouldBlock(context.Background(), tt.request, specsEqual)
+			assert.Equal(t, tt.wantBlock, blocked)
+			if tt.wantBlock {
+				require.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), "no longer accepted for create or update"))
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/deprecations/deprecations.go
+++ b/pkg/deprecations/deprecations.go
@@ -67,6 +67,37 @@ func BuildKindWarning(group, version, kind string) (DeprecationWarning, bool) {
 	}, true
 }
 
+// IsLegacyPolicyKind reports whether kind (in the given group) is one of the legacy
+// kyverno.io policy kinds subject to the 1.20 write-time block on creates/spec-updates.
+func IsLegacyPolicyKind(group, kind string) bool {
+	if group != "kyverno.io" {
+		return false
+	}
+	_, ok := replacements[kind]
+	return ok
+}
+
+// BuildKindError returns a hard error rejecting a create or spec-changing update of a legacy
+// kyverno.io policy kind, or false if the kind is not a legacy policy type. It reuses the same
+// replacements table and migration URL as BuildKindWarning so the two messages stay consistent.
+func BuildKindError(group, version, kind string) (error, bool) {
+	if group != "kyverno.io" {
+		return nil, false
+	}
+	replacement, ok := replacements[kind]
+	if !ok {
+		return nil, false
+	}
+	apiVersion := group
+	if version != "" {
+		apiVersion = fmt.Sprintf("%s/%s", group, version)
+	}
+	return fmt.Errorf(
+		"%s %s is no longer accepted for create or update; migrate to %s (policies.kyverno.io), see %s",
+		apiVersion, kind, replacement, MigrationGuideURL,
+	), true
+}
+
 // PolicyFieldWarnings returns field-level deprecation warnings for legacy policy fields.
 func PolicyFieldWarnings(policy kyvernov1.PolicyInterface) []DeprecationWarning {
 	var warnings []DeprecationWarning

--- a/pkg/deprecations/deprecations.go
+++ b/pkg/deprecations/deprecations.go
@@ -93,7 +93,7 @@ func BuildKindError(group, version, kind string) (error, bool) {
 		apiVersion = fmt.Sprintf("%s/%s", group, version)
 	}
 	return fmt.Errorf(
-		"%s %s is no longer accepted for create or update; migrate to %s (policies.kyverno.io), see %s",
+		"%s %s is no longer accepted for create, or for an update that changes spec; migrate to %s (policies.kyverno.io), see %s",
 		apiVersion, kind, replacement, MigrationGuideURL,
 	), true
 }

--- a/pkg/deprecations/deprecations_test.go
+++ b/pkg/deprecations/deprecations_test.go
@@ -149,7 +149,7 @@ func TestBuildKindError(t *testing.T) {
 			t.Fatalf("BuildKindError(%q) returned a nil error", tt.kind)
 		}
 		msg := err.Error()
-		if !strings.Contains(msg, "kyverno.io/v1 "+tt.kind+" is no longer accepted for create or update") {
+		if !strings.Contains(msg, "kyverno.io/v1 "+tt.kind+" is no longer accepted for create, or for an update that changes spec") {
 			t.Errorf("BuildKindError(%q) = %q, expected a rejection notice for the kind", tt.kind, msg)
 		}
 		if !strings.Contains(msg, tt.replacement) {

--- a/pkg/deprecations/deprecations_test.go
+++ b/pkg/deprecations/deprecations_test.go
@@ -109,6 +109,74 @@ func TestBuildKindWarningIgnoresNonKyvernoGroup(t *testing.T) {
 	}
 }
 
+func TestIsLegacyPolicyKind(t *testing.T) {
+	t.Parallel()
+	for kind := range replacements {
+		if !IsLegacyPolicyKind("kyverno.io", kind) {
+			t.Errorf("IsLegacyPolicyKind(%q, %q) = false, want true", "kyverno.io", kind)
+		}
+	}
+	for _, tt := range []struct{ group, kind string }{
+		{"policies.kyverno.io", "PolicyException"},
+		{"policies.kyverno.io", "ValidatingPolicy"},
+		{"kyverno.io", "ValidatingPolicy"},
+		{"kyverno.io", ""},
+	} {
+		if IsLegacyPolicyKind(tt.group, tt.kind) {
+			t.Errorf("IsLegacyPolicyKind(%q, %q) = true, want false", tt.group, tt.kind)
+		}
+	}
+}
+
+func TestBuildKindError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		kind        string
+		replacement string
+	}{
+		{"ClusterPolicy", "ValidatingPolicy, MutatingPolicy, GeneratingPolicy or ImageValidatingPolicy"},
+		{"Policy", "NamespacedValidatingPolicy and the other namespaced policy types"},
+		{"ClusterCleanupPolicy", "DeletingPolicy"},
+		{"CleanupPolicy", "NamespacedDeletingPolicy"},
+		{"PolicyException", "PolicyException (policies.kyverno.io)"},
+	}
+	for _, tt := range tests {
+		err, ok := BuildKindError("kyverno.io", "v1", tt.kind)
+		if !ok {
+			t.Fatalf("BuildKindError(%q) ok = false, want true", tt.kind)
+		}
+		if err == nil {
+			t.Fatalf("BuildKindError(%q) returned a nil error", tt.kind)
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "kyverno.io/v1 "+tt.kind+" is no longer accepted for create or update") {
+			t.Errorf("BuildKindError(%q) = %q, expected a rejection notice for the kind", tt.kind, msg)
+		}
+		if !strings.Contains(msg, tt.replacement) {
+			t.Errorf("BuildKindError(%q) = %q, expected replacement %q", tt.kind, msg, tt.replacement)
+		}
+		if !strings.Contains(msg, MigrationGuideURL) {
+			t.Errorf("BuildKindError(%q) = %q, expected migration guide URL", tt.kind, msg)
+		}
+	}
+}
+
+func TestBuildKindErrorNonLegacyKind(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"ValidatingPolicy", "DeletingPolicy", ""} {
+		if err, ok := BuildKindError("kyverno.io", "v1", kind); ok || err != nil {
+			t.Errorf("BuildKindError(%q) = (%v, %v), expected (nil, false)", kind, err, ok)
+		}
+	}
+}
+
+func TestBuildKindErrorIgnoresNonKyvernoGroup(t *testing.T) {
+	t.Parallel()
+	if _, ok := BuildKindError("policies.kyverno.io", "v1", "PolicyException"); ok {
+		t.Fatalf("expected non-kyverno.io group to be ignored")
+	}
+}
+
 func TestNormalizeFieldPath(t *testing.T) {
 	t.Parallel()
 	got := NormalizeFieldPath("spec.rules[3].validate.failureActionOverrides[7].action")

--- a/pkg/toggle/context.go
+++ b/pkg/toggle/context.go
@@ -15,6 +15,7 @@ type Toggles interface {
 	DumpMutatePatches() bool
 	AutogenV2() bool
 	AllowHTTPInNamespacedPolicies() bool
+	BlockLegacyPolicyAPIs() bool
 }
 
 type defaultToggles struct{}
@@ -49,6 +50,10 @@ func (defaultToggles) AutogenV2() bool {
 
 func (defaultToggles) AllowHTTPInNamespacedPolicies() bool {
 	return AllowHTTPInNamespacedPolicies.Enabled()
+}
+
+func (defaultToggles) BlockLegacyPolicyAPIs() bool {
+	return BlockLegacyPolicyAPIs.Enabled()
 }
 
 type contextKey struct{}

--- a/pkg/toggle/context_test.go
+++ b/pkg/toggle/context_test.go
@@ -15,6 +15,7 @@ type mockToggles struct {
 	dumpMutatePatches                 bool
 	autogenV2                         bool
 	allowHTTPInNamespacedPolicies     bool
+	blockLegacyPolicyAPIs             bool
 }
 
 func (m mockToggles) ProtectManagedResources() bool  { return m.protectManagedResources }
@@ -27,6 +28,7 @@ func (m mockToggles) GenerateMutatingAdmissionPolicy() bool { return m.generateM
 func (m mockToggles) DumpMutatePatches() bool               { return m.dumpMutatePatches }
 func (m mockToggles) AutogenV2() bool                       { return m.autogenV2 }
 func (m mockToggles) AllowHTTPInNamespacedPolicies() bool   { return m.allowHTTPInNamespacedPolicies }
+func (m mockToggles) BlockLegacyPolicyAPIs() bool           { return m.blockLegacyPolicyAPIs }
 
 func TestNewContext(t *testing.T) {
 	tests := []struct {

--- a/pkg/toggle/toggle.go
+++ b/pkg/toggle/toggle.go
@@ -63,6 +63,11 @@ const (
 	HTTPAllowlistFlagName    = "httpAllowlist"
 	HTTPAllowlistDescription = "Comma-separated list of URL prefixes (scheme+host[+path]) permitted in CEL http.Get/Post and apiCall.service calls. When set, only matching URLs are allowed. Example: 'https://api.example.com,https://webhook.corp/v1/'."
 	httpAllowlistEnvVar      = "FLAG_HTTP_ALLOWLIST"
+	// block legacy policy APIs (1.20 grace-window escape hatch, removed in 1.21)
+	BlockLegacyPolicyAPIsFlagName    = "blockLegacyPolicyAPIs"
+	BlockLegacyPolicyAPIsDescription = "Set the flag to 'false' to allow creating/updating legacy kyverno.io policy APIs during the 1.20 migration window. This is a temporary escape hatch and will be removed in 1.21."
+	blockLegacyPolicyAPIsEnvVar      = "FLAG_BLOCK_LEGACY_POLICY_APIS"
+	defaultBlockLegacyPolicyAPIs     = true
 )
 
 var (
@@ -76,6 +81,7 @@ var (
 	AllowHTTPInNamespacedPolicies     = newToggle(defaultAllowHTTPInNamespacedPolicies, allowHTTPInNamespacedPoliciesEnvVar)
 	HTTPBlocklist                     = newStringSliceFlag(append([]string{}, defaultPolicyHTTPBlocklist...), httpBlocklistEnvVar)
 	HTTPAllowlist                     = newStringSliceFlag(nil, httpAllowlistEnvVar)
+	BlockLegacyPolicyAPIs             = newToggle(defaultBlockLegacyPolicyAPIs, blockLegacyPolicyAPIsEnvVar)
 )
 
 type ToggleFlag interface {

--- a/pkg/toggle/toggle_test.go
+++ b/pkg/toggle/toggle_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_newToggle(t *testing.T) {
@@ -173,6 +174,22 @@ func Test_toggle_Enabled(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func Test_BlockLegacyPolicyAPIs_DefaultsOn(t *testing.T) {
+	// BlockLegacyPolicyAPIs must default to true: it is the 1.20 write-time block on legacy
+	// kyverno.io policy APIs, and the block must be on unless an operator explicitly opts out.
+	tr := newToggle(defaultBlockLegacyPolicyAPIs, blockLegacyPolicyAPIsEnvVar)
+	assert.True(t, tr.Enabled())
+
+	require.NoError(t, tr.Parse(""))
+	assert.True(t, tr.Enabled())
+}
+
+func Test_BlockLegacyPolicyAPIs_EnvVarOptOut(t *testing.T) {
+	t.Setenv(blockLegacyPolicyAPIsEnvVar, "false")
+	tr := newToggle(defaultBlockLegacyPolicyAPIs, blockLegacyPolicyAPIsEnvVar)
+	assert.False(t, tr.Enabled())
 }
 
 func Test_StringSliceFlag_Values(t *testing.T) {

--- a/pkg/webhooks/exception/validate.go
+++ b/pkg/webhooks/exception/validate.go
@@ -10,6 +10,7 @@ import (
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	validation "github.com/kyverno/kyverno/pkg/validation/exception"
 	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 )
 
 type exceptionHandlers struct {
@@ -24,9 +25,18 @@ func NewHandlers(validationOptions validation.ValidationOptions) *exceptionHandl
 
 // Validate performs the validation check on policy exception resources
 func (h *exceptionHandlers) Validate(ctx context.Context, logger logr.Logger, request handlers.AdmissionRequest, _ string, startTime time.Time) handlers.AdmissionResponse {
-	polex, _, err := admissionutils.GetPolicyExceptions(request.AdmissionRequest)
+	polex, oldPolex, err := admissionutils.GetPolicyExceptions(request.AdmissionRequest)
 	if err != nil {
 		logger.Error(err, "failed to unmarshal policy exceptions from admission request")
+		return admissionutils.Response(request.UID, err)
+	}
+	if err, blocked := deprecations.ShouldBlock(ctx, request.AdmissionRequest, func() bool {
+		return oldPolex != nil && apiequality.Semantic.DeepEqual(oldPolex.Spec, polex.Spec)
+	}); blocked {
+		logger.Error(err, "legacy policy exception write blocked", "kind", request.Kind.Kind, "namespace", request.Namespace, "name", request.Name)
+		if deprecatedMetric := metrics.GetDeprecatedAPIRequestMetrics(); deprecatedMetric != nil {
+			deprecatedMetric.Record(ctx, request.Namespace, request.Kind.Group, request.Kind.Version, request.Kind.Kind, "")
+		}
 		return admissionutils.Response(request.UID, err)
 	}
 	warnings := validation.ValidateNamespace(ctx, logger, polex.GetNamespace(), h.validationOptions)

--- a/pkg/webhooks/exception/validate.go
+++ b/pkg/webhooks/exception/validate.go
@@ -25,6 +25,15 @@ func NewHandlers(validationOptions validation.ValidationOptions) *exceptionHandl
 
 // Validate performs the validation check on policy exception resources
 func (h *exceptionHandlers) Validate(ctx context.Context, logger logr.Logger, request handlers.AdmissionRequest, _ string, startTime time.Time) handlers.AdmissionResponse {
+	// Subresource requests never touch spec, so there is nothing here to validate or warn
+	// about; short-circuit before validation and deprecation warnings, not just the
+	// legacy-policy block. Kubernetes guarantees a status-subresource write cannot change
+	// spec, see:
+	// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource
+	if request.SubResource != "" {
+		return admissionutils.ResponseSuccess(request.UID)
+	}
+
 	polex, oldPolex, err := admissionutils.GetPolicyExceptions(request.AdmissionRequest)
 	if err != nil {
 		logger.Error(err, "failed to unmarshal policy exceptions from admission request")

--- a/pkg/webhooks/exception/validate_test.go
+++ b/pkg/webhooks/exception/validate_test.go
@@ -205,10 +205,11 @@ func TestExceptionValidateBlocksLegacyWrites(t *testing.T) {
 	metadataOnlyChange.ObjectMeta.Labels = map[string]string{"foo": "bar"}
 
 	tests := []struct {
-		name      string
-		toggleOff bool
-		request   handlers.AdmissionRequest
-		allowed   bool
+		name       string
+		toggleOff  bool
+		request    handlers.AdmissionRequest
+		allowed    bool
+		wantSilent bool // if true, assert resp.Warnings is empty too, not just Allowed
 	}{
 		{
 			name:    "create is blocked",
@@ -231,9 +232,14 @@ func TestExceptionValidateBlocksLegacyWrites(t *testing.T) {
 			allowed: true,
 		},
 		{
-			name:    "status subresource update is allowed",
-			request: newLegacyExceptionRequest(t, admissionv1.Update, changedException, exception, "status"),
-			allowed: true,
+			// Legacy PolicyException has no status subresource today, so this case is
+			// defensive/future-proofing, matching the same short-circuit as the other two
+			// handlers: subresource writes skip validation/warnings entirely, not just the
+			// legacy-policy block.
+			name:       "status subresource update is allowed and silent",
+			request:    newLegacyExceptionRequest(t, admissionv1.Update, changedException, exception, "status"),
+			allowed:    true,
+			wantSilent: true,
 		},
 		{
 			name:      "toggle disabled allows create",
@@ -255,6 +261,9 @@ func TestExceptionValidateBlocksLegacyWrites(t *testing.T) {
 			h := NewHandlers(options)
 			resp := h.Validate(context.Background(), logr.Discard(), tt.request, "", time.Now())
 			assert.Equal(t, tt.allowed, resp.Allowed)
+			if tt.wantSilent {
+				assert.Empty(t, resp.Warnings)
+			}
 		})
 	}
 }

--- a/pkg/webhooks/exception/validate_test.go
+++ b/pkg/webhooks/exception/validate_test.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/go-logr/logr"
 	kyvernov2 "github.com/kyverno/kyverno/api/kyverno/v2"
+	"github.com/kyverno/kyverno/pkg/toggle"
 	validation "github.com/kyverno/kyverno/pkg/validation/exception"
 	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -155,6 +157,104 @@ func TestExceptionValidate(t *testing.T) {
 			} else {
 				assert.Empty(t, resp.Warnings)
 			}
+		})
+	}
+}
+
+func legacyExceptionKind() metav1.GroupVersionKind {
+	return metav1.GroupVersionKind{Group: "kyverno.io", Version: "v2", Kind: "PolicyException"}
+}
+
+func newLegacyExceptionRequest(t *testing.T, operation admissionv1.Operation, obj, oldObj *kyvernov2.PolicyException, subResource string) handlers.AdmissionRequest {
+	t.Helper()
+	raw, err := json.Marshal(obj)
+	require.NoError(t, err)
+	request := handlers.AdmissionRequest{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID:         types.UID("test-uid"),
+			Kind:        legacyExceptionKind(),
+			Operation:   operation,
+			SubResource: subResource,
+			Object:      runtime.RawExtension{Raw: raw},
+		},
+	}
+	if oldObj != nil {
+		oldRaw, err := json.Marshal(oldObj)
+		require.NoError(t, err)
+		request.OldObject = runtime.RawExtension{Raw: oldRaw}
+	}
+	return request
+}
+
+// TestExceptionValidateBlocksLegacyWrites covers the 1.20 write-time hard block on legacy
+// kyverno.io PolicyException (see #17483/#17484/#17486): creates and spec-changing updates are
+// denied, no-op GitOps re-applies and status-only changes are allowed, and the toggle escape
+// hatch restores 1.19 (warning-only) behavior.
+func TestExceptionValidateBlocksLegacyWrites(t *testing.T) {
+	options := validation.ValidationOptions{Enabled: true, Namespace: "*"}
+	exception := &kyvernov2.PolicyException{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-exception", Namespace: "default"},
+		Spec: kyvernov2.PolicyExceptionSpec{
+			Exceptions: []kyvernov2.Exception{{PolicyName: "test-policy"}},
+		},
+	}
+	changedException := exception.DeepCopy()
+	changedException.Spec.Exceptions[0].PolicyName = "other-policy"
+	metadataOnlyChange := exception.DeepCopy()
+	metadataOnlyChange.ObjectMeta.ResourceVersion = "123"
+	metadataOnlyChange.ObjectMeta.Labels = map[string]string{"foo": "bar"}
+
+	tests := []struct {
+		name      string
+		toggleOff bool
+		request   handlers.AdmissionRequest
+		allowed   bool
+	}{
+		{
+			name:    "create is blocked",
+			request: newLegacyExceptionRequest(t, admissionv1.Create, exception, nil, ""),
+			allowed: false,
+		},
+		{
+			name:    "spec-changing update is blocked",
+			request: newLegacyExceptionRequest(t, admissionv1.Update, changedException, exception, ""),
+			allowed: false,
+		},
+		{
+			name:    "no-op GitOps re-apply is allowed",
+			request: newLegacyExceptionRequest(t, admissionv1.Update, exception, exception, ""),
+			allowed: true,
+		},
+		{
+			name:    "metadata-only update is allowed",
+			request: newLegacyExceptionRequest(t, admissionv1.Update, metadataOnlyChange, exception, ""),
+			allowed: true,
+		},
+		{
+			name:    "status subresource update is allowed",
+			request: newLegacyExceptionRequest(t, admissionv1.Update, changedException, exception, "status"),
+			allowed: true,
+		},
+		{
+			name:      "toggle disabled allows create",
+			toggleOff: true,
+			request:   newLegacyExceptionRequest(t, admissionv1.Create, exception, nil, ""),
+			allowed:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				require.NoError(t, toggle.BlockLegacyPolicyAPIs.Parse(""))
+			})
+			if tt.toggleOff {
+				require.NoError(t, toggle.BlockLegacyPolicyAPIs.Parse("false"))
+			}
+
+			h := NewHandlers(options)
+			resp := h.Validate(context.Background(), logr.Discard(), tt.request, "", time.Now())
+			assert.Equal(t, tt.allowed, resp.Allowed)
 		})
 	}
 }

--- a/pkg/webhooks/policy/handlers.go
+++ b/pkg/webhooks/policy/handlers.go
@@ -86,6 +86,16 @@ func (h *policyHandlers) Validate(ctx context.Context, logger logr.Logger, reque
 	}
 
 	if pol := policy.AsKyvernoPolicy(); pol != nil {
+		// Subresource requests (e.g. /status) never touch spec, so there is nothing here to
+		// validate or warn about; short-circuit before policy validation and deprecation
+		// warnings, not just the legacy-policy block, so Kyverno's own controllers can manage
+		// status on legacy policies without tripping full re-validation on every reconcile.
+		// Kubernetes guarantees a status-subresource write cannot change spec, see:
+		// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource
+		if request.SubResource != "" {
+			return admissionutils.ResponseSuccess(request.UID)
+		}
+
 		var old kyvernov1.PolicyInterface
 		if oldPolicy != nil {
 			old = oldPolicy.AsKyvernoPolicy()

--- a/pkg/webhooks/policy/handlers.go
+++ b/pkg/webhooks/policy/handlers.go
@@ -18,6 +18,7 @@ import (
 	admissionutils "github.com/kyverno/kyverno/pkg/utils/admission"
 	policyvalidate "github.com/kyverno/kyverno/pkg/validation/policy"
 	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
@@ -90,11 +91,21 @@ func (h *policyHandlers) Validate(ctx context.Context, logger logr.Logger, reque
 			old = oldPolicy.AsKyvernoPolicy()
 		}
 
+		deprecatedMetric := metrics.GetDeprecatedAPIRequestMetrics()
+		if err, blocked := deprecations.ShouldBlock(ctx, request.AdmissionRequest, func() bool {
+			return old != nil && apiequality.Semantic.DeepEqual(old.GetSpec(), pol.GetSpec())
+		}); blocked {
+			logger.Error(err, "legacy policy write blocked", "kind", request.Kind.Kind, "namespace", request.Namespace, "name", request.Name)
+			if deprecatedMetric != nil {
+				deprecatedMetric.Record(ctx, request.Namespace, request.Kind.Group, request.Kind.Version, request.Kind.Kind, "")
+			}
+			return admissionutils.Response(request.UID, err)
+		}
+
 		warnings, err := policyvalidate.Validate(policy.AsKyvernoPolicy(), old, h.client, false, h.backgroundServiceAccountName, h.reportsServiceAccountName)
 		if err != nil {
 			logger.Error(err, "policy validation errors")
 		}
-		deprecatedMetric := metrics.GetDeprecatedAPIRequestMetrics()
 		if warning, ok := deprecations.BuildKindWarning(request.Kind.Group, request.Kind.Version, request.Kind.Kind); ok {
 			logger.V(2).Info(warning.Message, "kind", request.Kind.Kind, "namespace", request.Namespace, "name", request.Name)
 			warnings = append(warnings, warning.Message)

--- a/pkg/webhooks/policy/handlers_test.go
+++ b/pkg/webhooks/policy/handlers_test.go
@@ -1,0 +1,205 @@
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	"github.com/kyverno/kyverno/pkg/toggle"
+	"github.com/kyverno/kyverno/pkg/webhooks/handlers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+// cachedFakeDiscovery adapts a plain discoveryfake.FakeDiscovery into a
+// discovery.CachedDiscoveryInterface (adding no-op Fresh/Invalidate), so
+// policyvalidate.Validate's discovery.ServerPreferredResources(client.Discovery().CachedDiscoveryInterface())
+// call has a real, non-nil, non-aggregated discovery interface to walk instead of the dclient
+// test fake's CachedDiscoveryInterface(), which stubs to nil and panics deeper in client-go.
+type cachedFakeDiscovery struct {
+	*discoveryfake.FakeDiscovery
+}
+
+func (cachedFakeDiscovery) Fresh() bool { return true }
+func (cachedFakeDiscovery) Invalidate() {}
+
+// discoveryWithCache overrides only CachedDiscoveryInterface() on top of
+// dclient.NewFakeDiscoveryClient, which the rest of the fake dclient.Interface still needs.
+type discoveryWithCache struct {
+	dclient.IDiscovery
+	cached discovery.CachedDiscoveryInterface
+}
+
+func (d discoveryWithCache) CachedDiscoveryInterface() discovery.CachedDiscoveryInterface {
+	return d.cached
+}
+
+func newFakeClient() dclient.Interface {
+	fakeDisco := &discoveryfake.FakeDiscovery{Fake: &kubetesting.Fake{}}
+	disco := discoveryWithCache{
+		IDiscovery: dclient.NewFakeDiscoveryClient(nil),
+		cached:     cachedFakeDiscovery{fakeDisco},
+	}
+	return dclient.NewFakeClientWithDisco(dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()), kubefake.NewSimpleClientset(), disco)
+}
+
+// validClusterPolicyRaw is a minimal, known-valid ClusterPolicy payload (one validate rule
+// matching Pods), used as the base fixture for the legacy-policy write-block tests below.
+const validClusterPolicyRaw = `{
+	"apiVersion": "kyverno.io/v1",
+	"kind": "ClusterPolicy",
+	"metadata": {"name": "check-labels"},
+	"spec": {
+		"rules": [{
+			"name": "check-labels",
+			"match": {"resources": {"kinds": ["Pod"]}},
+			"validate": {
+				"message": "label app is required",
+				"pattern": {"metadata": {"labels": {"app": "?*"}}}
+			}
+		}]
+	}
+}`
+
+func mustUnmarshalClusterPolicy(t *testing.T) *kyvernov1.ClusterPolicy {
+	t.Helper()
+	var policy *kyvernov1.ClusterPolicy
+	require.NoError(t, json.Unmarshal([]byte(validClusterPolicyRaw), &policy))
+	return policy
+}
+
+func legacyClusterPolicyKind() metav1.GroupVersionKind {
+	return metav1.GroupVersionKind{Group: "kyverno.io", Version: "v1", Kind: "ClusterPolicy"}
+}
+
+func newClusterPolicyRequest(t *testing.T, operation admissionv1.Operation, obj, oldObj *kyvernov1.ClusterPolicy, subResource string) handlers.AdmissionRequest {
+	t.Helper()
+	raw, err := json.Marshal(obj)
+	require.NoError(t, err)
+	request := handlers.AdmissionRequest{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID:         types.UID("test-uid"),
+			Kind:        legacyClusterPolicyKind(),
+			Operation:   operation,
+			SubResource: subResource,
+			Object:      runtime.RawExtension{Raw: raw},
+		},
+	}
+	if oldObj != nil {
+		oldRaw, err := json.Marshal(oldObj)
+		require.NoError(t, err)
+		request.OldObject = runtime.RawExtension{Raw: oldRaw}
+	}
+	return request
+}
+
+// TestValidateBlocksLegacyWrites covers the 1.20 write-time hard block on legacy
+// ClusterPolicy/Policy (see #17483/#17484/#17486): creates and spec-changing updates are denied,
+// no-op GitOps re-applies and metadata/status-only changes are allowed, and the
+// blockLegacyPolicyAPIs toggle is the escape hatch back to 1.19 (warning-only) behavior.
+func TestValidateBlocksLegacyWrites(t *testing.T) {
+	policy := mustUnmarshalClusterPolicy(t)
+	changedPolicy := policy.DeepCopy()
+	changedPolicy.Spec.Rules[0].Validation.Message = "a different message"
+	metadataOnlyChange := policy.DeepCopy()
+	metadataOnlyChange.ObjectMeta.ResourceVersion = "123"
+	metadataOnlyChange.ObjectMeta.Labels = map[string]string{"foo": "bar"}
+
+	tests := []struct {
+		name      string
+		toggleOff bool
+		request   handlers.AdmissionRequest
+		allowed   bool
+	}{
+		{
+			name:    "create is blocked",
+			request: newClusterPolicyRequest(t, admissionv1.Create, policy, nil, ""),
+			allowed: false,
+		},
+		{
+			name:    "spec-changing update is blocked",
+			request: newClusterPolicyRequest(t, admissionv1.Update, changedPolicy, policy, ""),
+			allowed: false,
+		},
+		{
+			name:    "no-op GitOps re-apply is allowed",
+			request: newClusterPolicyRequest(t, admissionv1.Update, policy, policy, ""),
+			allowed: true,
+		},
+		{
+			name:    "metadata-only update is allowed",
+			request: newClusterPolicyRequest(t, admissionv1.Update, metadataOnlyChange, policy, ""),
+			allowed: true,
+		},
+		{
+			name:    "status subresource update is allowed",
+			request: newClusterPolicyRequest(t, admissionv1.Update, changedPolicy, policy, "status"),
+			allowed: true,
+		},
+		{
+			name:      "toggle disabled allows create",
+			toggleOff: true,
+			request:   newClusterPolicyRequest(t, admissionv1.Create, policy, nil, ""),
+			allowed:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				require.NoError(t, toggle.BlockLegacyPolicyAPIs.Parse(""))
+			})
+			if tt.toggleOff {
+				require.NoError(t, toggle.BlockLegacyPolicyAPIs.Parse("false"))
+			}
+
+			h := NewHandlers(newFakeClient(), nil, "", "")
+			resp := h.Validate(context.Background(), logr.Discard(), tt.request, "", time.Now())
+			assert.Equal(t, tt.allowed, resp.Allowed, "message: %v", resp.Result)
+		})
+	}
+}
+
+// TestValidateCELPoliciesUnaffected proves the legacy-policy write block never engages for the
+// CEL-based policies.kyverno.io kinds handled earlier in Validate's dispatch chain.
+func TestValidateCELPoliciesUnaffected(t *testing.T) {
+	t.Cleanup(func() {
+		require.NoError(t, toggle.BlockLegacyPolicyAPIs.Parse(""))
+	})
+
+	raw := []byte(`{
+		"apiVersion": "policies.kyverno.io/v1beta1",
+		"kind": "ValidatingPolicy",
+		"metadata": {"name": "vpol"},
+		"spec": {
+			"validationActions": ["Deny"],
+			"matchConstraints": {"resourceRules": [{"apiGroups": [""], "apiVersions": ["v1"], "resources": ["pods"], "operations": ["CREATE"]}]},
+			"validations": [{"expression": "true"}]
+		}
+	}`)
+	request := handlers.AdmissionRequest{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID:       types.UID("test-uid"),
+			Kind:      metav1.GroupVersionKind{Group: "policies.kyverno.io", Version: "v1beta1", Kind: "ValidatingPolicy"},
+			Operation: admissionv1.Create,
+			Object:    runtime.RawExtension{Raw: raw},
+		},
+	}
+
+	h := NewHandlers(newFakeClient(), nil, "", "")
+	resp := h.Validate(context.Background(), logr.Discard(), request, "", time.Now())
+	assert.True(t, resp.Allowed, "message: %v", resp.Result)
+}

--- a/pkg/webhooks/policy/handlers_test.go
+++ b/pkg/webhooks/policy/handlers_test.go
@@ -119,10 +119,11 @@ func TestValidateBlocksLegacyWrites(t *testing.T) {
 	metadataOnlyChange.ObjectMeta.Labels = map[string]string{"foo": "bar"}
 
 	tests := []struct {
-		name      string
-		toggleOff bool
-		request   handlers.AdmissionRequest
-		allowed   bool
+		name       string
+		toggleOff  bool
+		request    handlers.AdmissionRequest
+		allowed    bool
+		wantSilent bool // if true, assert resp.Warnings is empty too, not just Allowed
 	}{
 		{
 			name:    "create is blocked",
@@ -145,9 +146,14 @@ func TestValidateBlocksLegacyWrites(t *testing.T) {
 			allowed: true,
 		},
 		{
-			name:    "status subresource update is allowed",
-			request: newClusterPolicyRequest(t, admissionv1.Update, changedPolicy, policy, "status"),
-			allowed: true,
+			// Subresource writes short-circuit before validation/warnings entirely (not just
+			// the legacy-policy block), so this must be genuinely silent: allowed with no
+			// warnings, unlike the no-op/metadata-only cases above which still carry the
+			// pre-existing 1.19 deprecation warning by design.
+			name:       "status subresource update is allowed and silent",
+			request:    newClusterPolicyRequest(t, admissionv1.Update, changedPolicy, policy, "status"),
+			allowed:    true,
+			wantSilent: true,
 		},
 		{
 			name:      "toggle disabled allows create",
@@ -169,6 +175,9 @@ func TestValidateBlocksLegacyWrites(t *testing.T) {
 			h := NewHandlers(newFakeClient(), nil, "", "")
 			resp := h.Validate(context.Background(), logr.Discard(), tt.request, "", time.Now())
 			assert.Equal(t, tt.allowed, resp.Allowed, "message: %v", resp.Result)
+			if tt.wantSilent {
+				assert.Empty(t, resp.Warnings)
+			}
 		})
 	}
 }

--- a/test/conformance/chainsaw/deprecations/.chainsaw.yaml
+++ b/test/conformance/chainsaw/deprecations/.chainsaw.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/configuration-chainsaw-v1alpha2.json
+apiVersion: chainsaw.kyverno.io/v1alpha2
+kind: Configuration
+metadata:
+  name: configuration
+spec:
+  discovery:
+    fullName: true
+  execution:
+    failFast: true
+  namespace:
+    fastDelete: true
+  timeouts:
+    apply: 30s
+    assert: 1m30s
+    error: 1m30s

--- a/test/conformance/chainsaw/deprecations/create-blocked/README.md
+++ b/test/conformance/chainsaw/deprecations/create-blocked/README.md
@@ -1,0 +1,12 @@
+# create-blocked
+
+Verifies the 1.20 write-time hard block on legacy `kyverno.io` policy APIs
+(https://github.com/kyverno/kyverno/issues/17483): creating a `ClusterPolicy`, `Policy`,
+`ClusterCleanupPolicy`, `CleanupPolicy`, or legacy `PolicyException` — in any served version — is
+denied with a migration-guiding error, under the default `features.blockLegacyPolicyAPIs.enabled:
+true` setting.
+
+This specifically covers `kyverno.io/v2` for `ClusterCleanupPolicy`/`CleanupPolicy`/
+`PolicyException`, which is each resource's storage version, to prove the admission webhook rules
+actually intercept the version most manifests use (previously only `v2beta1`/`v2alpha1` were
+registered, so a `v2` write bypassed the webhook entirely).

--- a/test/conformance/chainsaw/deprecations/create-blocked/chainsaw-test.yaml
+++ b/test/conformance/chainsaw/deprecations/create-blocked/chainsaw-test.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: create-blocked
+spec:
+  description: >
+    Under the 1.20 default (features.blockLegacyPolicyAPIs.enabled=true), creating any legacy
+    kyverno.io policy kind, in any served version, is hard-denied at admission. This exercises
+    every legacy kind/version pair, including the storage versions (kyverno.io/v2 for
+    CleanupPolicy/ClusterCleanupPolicy/PolicyException) that previously bypassed the admission
+    webhook entirely because the webhook rules only listed v2beta1 (see #17483).
+  concurrent: false
+  steps:
+  - name: cluster-policy
+    try:
+    - error:
+        file: cluster-policy-v1.yaml
+    - error:
+        file: cluster-policy-v2beta1.yaml
+  - name: policy
+    try:
+    - error:
+        file: policy-v1.yaml
+    - error:
+        file: policy-v2beta1.yaml
+  - name: cluster-cleanup-policy
+    try:
+    - error:
+        file: cluster-cleanup-policy-v2.yaml
+    - error:
+        file: cluster-cleanup-policy-v2beta1.yaml
+  - name: cleanup-policy
+    try:
+    - error:
+        file: cleanup-policy-v2.yaml
+    - error:
+        file: cleanup-policy-v2beta1.yaml
+  - name: policy-exception
+    try:
+    - error:
+        file: policy-exception-v2.yaml
+    - error:
+        file: policy-exception-v2beta1.yaml

--- a/test/conformance/chainsaw/deprecations/create-blocked/cleanup-policy-v2.yaml
+++ b/test/conformance/chainsaw/deprecations/create-blocked/cleanup-policy-v2.yaml
@@ -1,0 +1,14 @@
+apiVersion: kyverno.io/v2
+kind: CleanupPolicy
+metadata:
+  name: deprecations-cleanup-v2
+  namespace: ($namespace)
+spec:
+  schedule: "0 0 * * *"
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        names:
+        - deprecations-does-not-exist

--- a/test/conformance/chainsaw/deprecations/create-blocked/cleanup-policy-v2beta1.yaml
+++ b/test/conformance/chainsaw/deprecations/create-blocked/cleanup-policy-v2beta1.yaml
@@ -1,0 +1,14 @@
+apiVersion: kyverno.io/v2beta1
+kind: CleanupPolicy
+metadata:
+  name: deprecations-cleanup-v2beta1
+  namespace: ($namespace)
+spec:
+  schedule: "0 0 * * *"
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        names:
+        - deprecations-does-not-exist

--- a/test/conformance/chainsaw/deprecations/create-blocked/cluster-cleanup-policy-v2.yaml
+++ b/test/conformance/chainsaw/deprecations/create-blocked/cluster-cleanup-policy-v2.yaml
@@ -1,0 +1,13 @@
+apiVersion: kyverno.io/v2
+kind: ClusterCleanupPolicy
+metadata:
+  name: deprecations-cluster-cleanup-v2
+spec:
+  schedule: "0 0 * * *"
+  match:
+    any:
+    - resources:
+        kinds:
+        - Namespace
+        names:
+        - deprecations-does-not-exist

--- a/test/conformance/chainsaw/deprecations/create-blocked/cluster-cleanup-policy-v2beta1.yaml
+++ b/test/conformance/chainsaw/deprecations/create-blocked/cluster-cleanup-policy-v2beta1.yaml
@@ -1,0 +1,13 @@
+apiVersion: kyverno.io/v2beta1
+kind: ClusterCleanupPolicy
+metadata:
+  name: deprecations-cluster-cleanup-v2beta1
+spec:
+  schedule: "0 0 * * *"
+  match:
+    any:
+    - resources:
+        kinds:
+        - Namespace
+        names:
+        - deprecations-does-not-exist

--- a/test/conformance/chainsaw/deprecations/create-blocked/cluster-policy-v1.yaml
+++ b/test/conformance/chainsaw/deprecations/create-blocked/cluster-policy-v1.yaml
@@ -1,0 +1,17 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deprecations-cluster-policy-v1
+spec:
+  rules:
+  - name: check-labels
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "label app is required"
+      pattern:
+        metadata:
+          labels:
+            app: "?*"

--- a/test/conformance/chainsaw/deprecations/create-blocked/cluster-policy-v2beta1.yaml
+++ b/test/conformance/chainsaw/deprecations/create-blocked/cluster-policy-v2beta1.yaml
@@ -1,0 +1,18 @@
+apiVersion: kyverno.io/v2beta1
+kind: ClusterPolicy
+metadata:
+  name: deprecations-cluster-policy-v2beta1
+spec:
+  rules:
+  - name: check-labels
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "label app is required"
+      pattern:
+        metadata:
+          labels:
+            app: "?*"

--- a/test/conformance/chainsaw/deprecations/create-blocked/policy-exception-v2.yaml
+++ b/test/conformance/chainsaw/deprecations/create-blocked/policy-exception-v2.yaml
@@ -1,0 +1,15 @@
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: deprecations-polex-v2
+  namespace: ($namespace)
+spec:
+  exceptions:
+  - policyName: does-not-exist
+    ruleNames:
+    - "*"
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod

--- a/test/conformance/chainsaw/deprecations/create-blocked/policy-exception-v2beta1.yaml
+++ b/test/conformance/chainsaw/deprecations/create-blocked/policy-exception-v2beta1.yaml
@@ -1,0 +1,15 @@
+apiVersion: kyverno.io/v2beta1
+kind: PolicyException
+metadata:
+  name: deprecations-polex-v2beta1
+  namespace: ($namespace)
+spec:
+  exceptions:
+  - policyName: does-not-exist
+    ruleNames:
+    - "*"
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod

--- a/test/conformance/chainsaw/deprecations/create-blocked/policy-v1.yaml
+++ b/test/conformance/chainsaw/deprecations/create-blocked/policy-v1.yaml
@@ -1,0 +1,18 @@
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: deprecations-policy-v1
+  namespace: ($namespace)
+spec:
+  rules:
+  - name: check-labels
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "label app is required"
+      pattern:
+        metadata:
+          labels:
+            app: "?*"

--- a/test/conformance/chainsaw/deprecations/create-blocked/policy-v2beta1.yaml
+++ b/test/conformance/chainsaw/deprecations/create-blocked/policy-v2beta1.yaml
@@ -1,0 +1,19 @@
+apiVersion: kyverno.io/v2beta1
+kind: Policy
+metadata:
+  name: deprecations-policy-v2beta1
+  namespace: ($namespace)
+spec:
+  rules:
+  - name: check-labels
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "label app is required"
+      pattern:
+        metadata:
+          labels:
+            app: "?*"


### PR DESCRIPTION
## Summary

Implements Kyverno 1.20 Phase 2 (per the plan in #17214): legacy `kyverno.io` policy CRDs and
versions stay fully served, but the admission webhooks now **hard-deny** new creates and genuine
spec-changing updates of legacy policy kinds, pointing users at the CEL-based
`policies.kyverno.io` equivalents. Existing stored legacy policies are unaffected — they continue
to be read, listed, deleted, and **enforced** exactly as before.

This closes three sub-issues together because they are not independently shippable: the hard
error (#17483) would break every GitOps-managed legacy policy on upgrade without the spec-only
diff (#17484), and needs an operator escape hatch (#17486) for anyone who hits it before
migrating.

Closes #17483
Closes #17484
Closes #17486

Part of #17214 (1.20 legacy policy removal plan). Follow-on work tracked separately:
CLI behavior (#17485), `kyvernopre` diagnostics (#17487).

## What changed

| Behavior | Legacy kinds (`ClusterPolicy`, `Policy`, `CleanupPolicy`, `ClusterCleanupPolicy`, legacy `PolicyException`) |
|---|---|
| Create | ❌ denied, with a migration message naming the `policies.kyverno.io` replacement |
| Update, spec changed | ❌ denied |
| Update, spec unchanged (GitOps/Helm no-op reconcile, metadata-only change) | ✅ allowed, silently |
| Delete / status subresource | ✅ always allowed |
| Existing stored policies | ✅ read/listed/deleted/**enforced** unchanged |
| `policies.kyverno.io` (CEL) kinds | ✅ entirely unaffected |

### Code

- **`pkg/deprecations`**: added `BuildKindError` / `IsLegacyPolicyKind`, reusing the existing
  `BuildKindWarning` replacement table so the deny message and the 1.19 warning stay consistent.
  Added a single shared gate, `ShouldBlock`, used by all three webhook call sites so the decision
  logic can't drift between kinds:
  - toggle off → allow (escape hatch)
  - subresource request (e.g. `/status`) → always allow
  - Delete/Connect → always allow
  - kind outside the legacy set → always allow
  - Create → deny
  - Update → deny only if the **spec** actually changed

- **Spec-only, GitOps-safe diff (#17484)**: each kind already exposes a typed spec accessor
  (`kyvernov1.PolicyInterface.GetSpec()`, `kyvernov2.CleanupPolicyInterface.GetSpec()`,
  `kyvernov2.PolicyException.Spec`). Comparing those typed structs with
  `k8s.io/apimachinery/pkg/api/equality.Semantic.DeepEqual` avoids decoding to `unstructured` and
  diffing JSON — no key-ordering or apiserver-defaulting false positives, and by construction it
  never looks at `metadata` (`resourceVersion`, `managedFields`,
  `last-applied-configuration`, labels) or `status`, so ArgoCD/Flux/Helm reconcile passes on an
  unchanged legacy policy are allowed through silently instead of breaking on every upgrade.

- **`pkg/toggle`**: new `BlockLegacyPolicyAPIs` toggle (default `true`), following the existing
  `ProtectManagedResources` pattern exactly — `--blockLegacyPolicyAPIs` flag /
  `FLAG_BLOCK_LEGACY_POLICY_APIS` env var / `features.blockLegacyPolicyAPIs.enabled` Helm value.
  This is the **temporary 1.20 migration escape hatch** (#17486); it is documented as removed in
  1.21.

- **Webhook wiring**: the block is inserted at the top of each handler's legacy-kind branch,
  before existing validation/warning logic runs, in:
  - `pkg/webhooks/policy/handlers.go` (ClusterPolicy/Policy) — placed strictly inside the
    `AsKyvernoPolicy()` branch so the CEL policy branches above it are untouched.
  - `cmd/cleanup-controller/handlers/admission/policy/handlers.go` (CleanupPolicy/ClusterCleanupPolicy)
  - `pkg/webhooks/exception/validate.go` (legacy PolicyException)

  The `kyverno_deprecated_api_requests_total` metric is still recorded on the newly-denied path.

- **Fixed a pre-existing webhook rule gap** (found during investigation, not previously reported):
  the `policyexceptions` and `cleanuppolicies`/`clustercleanuppolicies` admission webhook rules
  were missing `v2` — **the storage version for both resources**, i.e. the version most manifests
  actually use. Only `v2beta1` (and a `v2alpha1` PolicyException entry that has never mapped to a
  real type) were registered. Without `v2`, a `kyverno.io/v2` PolicyException or CleanupPolicy
  never reached Kyverno's webhook **at all**, which would have made this entire write-time block
  trivially bypassable. Fixed in `cmd/kyverno/main.go` and `cmd/cleanup-controller/main.go`, and
  verified live (see below) that `v2` writes were previously unintercepted and are now denied.

### Design decisions

- **One shared `ShouldBlock` gate instead of three separate implementations** — the three webhook
  handlers differ in unmarshaling and downstream validation, but the *decision* of whether to
  block must be identical. Centralizing it in `pkg/deprecations` means the toggle check,
  subresource exemption, and diff semantics can only be implemented once.
- **Typed spec comparison over `unstructured` diffing** — considered decoding both objects to
  `unstructured` and comparing `spec` maps, but each kind already has a well-typed spec accessor
  with no func/chan fields, so comparing those directly with `apiequality.Semantic.DeepEqual` is
  simpler and avoids JSON round-trip artifacts entirely.
- **Subresource exemption is unconditional, not kind-specific** — `ClusterCleanupPolicy`/
  `CleanupPolicy` status writes come from Kyverno's own cleanup controller
  (`pkg/controllers/cleanup/controller.go`) via the *same* admission webhook (its rule matches
  `cleanuppolicies/*`, including subresources). Exempting `SubResource != ""` unconditionally
  means Kyverno can never accidentally deadlock itself against its own status reconciliation,
  regardless of which kind adds a status subresource in the future.
- **`v2alpha1` left in place on the exception rule** rather than removed, even though no
  `v2alpha1` PolicyException type has ever existed — it's a harmless dead entry, and removing
  webhook rule versions is explicitly the concern of a different, not-yet-ready sub-issue
  (#17491), so this PR only *adds* `v2` rather than also cleaning up unrelated entries.
- **Chainsaw scope**: added `test/conformance/chainsaw/deprecations/create-blocked/`, which
  exercises every legacy kind × served version create against a real apiserver + webhook — this
  is the one thing unit tests structurally cannot prove (real webhook rule registration, i.e. the
  `v2` bypass above). I deliberately did **not** add a chainsaw test that toggles the Helm value
  mid-suite to seed "already-existing" legacy policies for the no-op/enforcement/status-subresource
  scenarios — there's no precedent for mid-suite Helm upgrades in this repo's chainsaw tests, and
  it would risk flaky cross-test interference within the same kind cluster/job. Those scenarios
  are instead covered thoroughly at the unit/handler level (see below) and were manually verified
  end-to-end on a real kind cluster (see Testing).
- **No new Helm chart render-test infrastructure** — the repo has no `helm-unittest` suite or Go
  chart-render tests today (confirmed by inspection), only a `helm test` hook for an unrelated
  helper. Introducing net-new chart test tooling felt out of scope for this PR; the new
  `--blockLegacyPolicyAPIs=` flag was verified via `helm template` (both default and
  `--set features.blockLegacyPolicyAPIs.enabled=false`) and the live kind-cluster escape-hatch
  test below. Flagging this as a gap against #17486's "Add chart render tests" checklist item in
  case maintainers want that addressed separately.

## Testing

**Codegen**
- `make codegen-all` / `make verify-codegen` pass locally (regenerated `config/install-latest-testing.yaml` to pick up the new `--blockLegacyPolicyAPIs` flag on the generated static install manifest).

**Unit / `go test ./...`**
- `go build ./...` and `go vet ./...`: clean.
- `go test ./...`: all packages pass. The only failures are 3 pre-existing, network-dependent
  cosign/sigstore tests in `pkg/image/verifiers/cpol/cosign` (TUF root fetch from `ghcr.io` fails
  with "resource temporarily unavailable" — no egress in the sandbox this was run in); unrelated
  to any file touched by this PR.
- New/extended tests, one table per scenario (create denied / spec-update denied / no-op update
  allowed / metadata-only update allowed / status-subresource allowed / toggle-off allowed /
  CEL-policies-unaffected):
  - `pkg/deprecations/block_test.go` (new) — `ShouldBlock` in isolation, including a
    "specsEqual must not be called" check to assert laziness for Create/Delete/subresource paths.
  - `pkg/deprecations/deprecations_test.go` — `BuildKindError`/`IsLegacyPolicyKind` table tests.
  - `pkg/webhooks/policy/handlers_test.go` (new) — full handler tests for ClusterPolicy, plus a
    dedicated test proving `ValidatingPolicy` (CEL) is unaffected.
  - `cmd/cleanup-controller/handlers/admission/policy/handlers_test.go` (new) — full handler
    tests for ClusterCleanupPolicy, specifically including the status-subresource case (the
    concrete cleanup-controller self-deadlock risk).
  - `pkg/webhooks/exception/validate_test.go` — extended with the same matrix for legacy
    PolicyException.
  - `pkg/toggle/toggle_test.go` — default-on and env-var opt-out for `BlockLegacyPolicyAPIs`.

**Chainsaw**
- New suite `test/conformance/chainsaw/deprecations/create-blocked/`, wired into
  `.github/workflows/tests-conformance.yaml`, covering all 10 legacy kind/version combinations
  under the default (`blockLegacyPolicyAPIs: true`) install.

**Manual end-to-end verification on a local kind cluster** (built and deployed this branch's
images via `make kind-create-cluster && make kind-deploy-kyverno`):
- ✅ All 10 legacy kind/version combinations (`ClusterPolicy` v1/v2beta1, `Policy` v1/v2beta1,
  `ClusterCleanupPolicy`/`CleanupPolicy` v2/v2beta1, legacy `PolicyException` v2/v2beta1) denied
  on create, each with a migration message naming the correct replacement + guide URL.
- ✅ Before this fix, `kyverno.io/v2` `ClusterCleanupPolicy`/`PolicyException` writes bypassed the
  webhook entirely; after the rule fix, both are correctly intercepted and denied.
- ✅ CEL `ValidatingPolicy` create succeeds, entirely unaffected.
- ✅ GitOps no-op re-apply of an identical, already-stored legacy `ClusterPolicy` — twice in a
  row — succeeds silently; a metadata-only label change succeeds; a real `spec` change is denied.
- ✅ A pre-existing enforce-mode legacy `ClusterPolicy` still rejects a violating Pod after the
  upgrade (the core promise of the 1.20 design).
- ✅ A direct `--subresource=status` patch on a legacy `ClusterCleanupPolicy` (simulating the
  cleanup controller's own `UpdateStatus` call) succeeds, while a `spec` patch on the same object
  is denied in the same session — confirms no self-deadlock.
- ✅ `helm upgrade --set features.blockLegacyPolicyAPIs.enabled=false` restores 1.19 (warning-only)
  behavior; flipping it back to `true` re-enables the block on the same release.

## Conventions followed

- Matches the existing `pkg/toggle` pattern (`ProtectManagedResources`) exactly for the new
  toggle: const block, package-level `var`, `Toggles` context interface method, flag registration
  in both binaries.
- Matches the existing `pkg/deprecations` pattern for the new error constructor: same
  `replacements` table, same `MigrationGuideURL`, same `group != "kyverno.io"` guard as
  `BuildKindWarning`.
- Handler test scaffolding follows the existing `pkg/webhooks/exception/validate_test.go` /
  `pkg/webhooks/handlers/filter_test.go` admission-request builder patterns.
- Chainsaw suite follows `test/conformance/chainsaw/policy-validation/` for
  `.chainsaw.yaml` config and the `error:` step idiom from
  `test/conformance/chainsaw/validate/clusterpolicy/standard/enforce/resource-apply-block/` for
  asserting a hard denial.
- Helm changes follow the existing `features.forceFailurePolicyIgnore` / `protectManagedResources`
  pattern in `values.yaml`, `_helpers.tpl`, and the controller deployment `pick(...)` lists;
  `charts/kyverno/README.md` regenerated via `make codegen-helm-docs` rather than hand-edited.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a feature flag, enabled by default, to block creation and specification-changing updates to legacy Kyverno policy APIs.
  - No-op reapplications, metadata-only updates, status updates, and existing policy enforcement remain supported.
  - Added migration guidance when legacy API writes are rejected.
  - Legacy policy handling now covers supported v2 API resources.

- **Documentation**
  - Documented the Helm chart setting and legacy API migration behavior.

- **Tests**
  - Added conformance coverage across legacy policy types and supported API versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->