### PR TITLE
fix(jmespath): preserve float64 precision in string conversion

### DIFF
--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -1149,7 +1149,9 @@ func jpObjectFromLists(arguments []any) (any, error) {
 	return output, nil
 }
 
-// InterfaceToString casts an interface to a string type
+// ifaceToString converts supported scalar values to strings and rejects other types.
+// Floating-point values use their original bit size and the shortest fixed-point
+// representation that preserves their precision when parsed back.
 func ifaceToString(iface any) (string, error) {
 	switch i := iface.(type) {
 	case int:

--- a/pkg/engine/jmespath/functions.go
+++ b/pkg/engine/jmespath/functions.go
@@ -1155,7 +1155,7 @@ func ifaceToString(iface any) (string, error) {
 	case int:
 		return strconv.Itoa(i), nil
 	case float64:
-		return strconv.FormatFloat(i, 'f', -1, 32), nil
+		return strconv.FormatFloat(i, 'f', -1, 64), nil
 	case float32:
 		return strconv.FormatFloat(float64(i), 'f', -1, 32), nil
 	case string:

--- a/pkg/engine/jmespath/precision_test.go
+++ b/pkg/engine/jmespath/precision_test.go
@@ -8,6 +8,8 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+// Test_IfaceToStringPrecision checks exact scalar conversions, including values
+// that lose precision when a float64 is formatted as a float32, and unsupported types.
 func Test_IfaceToStringPrecision(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -39,6 +41,8 @@ func Test_IfaceToStringPrecision(t *testing.T) {
 	})
 }
 
+// Test_NumericFunctionsPrecision verifies that matching, replacement, and object
+// keys use the original numeric value rather than its rounded float32 equivalent.
 func Test_NumericFunctionsPrecision(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -63,6 +67,8 @@ func Test_NumericFunctionsPrecision(t *testing.T) {
 	}
 }
 
+// Fuzz_IfaceToStringFloat64RoundTrip checks that converting finite float64 values
+// to text and parsing them back preserves every bit, including the sign of zero.
 func Fuzz_IfaceToStringFloat64RoundTrip(f *testing.F) {
 	for _, value := range []float64{0, math.Copysign(0, -1), 16777217, -16777217, 1000000007, 1.0000000000000002, math.SmallestNonzeroFloat64, math.MaxFloat64} {
 		f.Add(value)

--- a/pkg/engine/jmespath/precision_test.go
+++ b/pkg/engine/jmespath/precision_test.go
@@ -1,0 +1,80 @@
+package jmespath
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_IfaceToStringPrecision(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{"float64 boundary", float64(16777217), "16777217"},
+		{"float64 large", float64(1000000007), "1000000007"},
+		{"float64 negative", float64(-16777217), "-16777217"},
+		{"float64 fraction", 1.0000000000000002, "1.0000000000000002"},
+		{"float64 zero", float64(0), "0"},
+		{"float32", float32(1.2), "1.2"},
+		{"integer", 42, "42"},
+		{"string", "value", "value"},
+		{"boolean", true, "true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ifaceToString(tc.input)
+			assert.NilError(t, err)
+			assert.Equal(t, got, tc.want)
+		})
+	}
+	t.Run("unsupported", func(t *testing.T) {
+		t.Parallel()
+		_, err := ifaceToString(nil)
+		assert.ErrorContains(t, err, "undefined type cast")
+	})
+}
+
+func Test_NumericFunctionsPrecision(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		query string
+		want  any
+	}{
+		{"regex_match('^16777217$', value)", true},
+		{"regex_match('^16777216$', value)", false},
+		{"pattern_match('16777217', value)", true},
+		{"pattern_match('16777216', value)", false},
+		{"regex_replace_all('^16777217$', value, 'matched')", "matched"},
+		{"object_from_lists([value], ['matched'])", map[string]any{"16777217": "matched"}},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			t.Parallel()
+			query, err := jmespathInterface.Query(tc.query)
+			assert.NilError(t, err)
+			got, err := query.Search(map[string]any{"value": float64(16777217)})
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tc.want)
+		})
+	}
+}
+
+func Fuzz_IfaceToStringFloat64RoundTrip(f *testing.F) {
+	for _, value := range []float64{0, math.Copysign(0, -1), 16777217, -16777217, 1000000007, 1.0000000000000002, math.SmallestNonzeroFloat64, math.MaxFloat64} {
+		f.Add(value)
+	}
+	f.Fuzz(func(t *testing.T, value float64) {
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			t.Skip("only finite numbers occur in JSON")
+		}
+		encoded, err := ifaceToString(value)
+		assert.NilError(t, err)
+		decoded, err := strconv.ParseFloat(encoded, 64)
+		assert.NilError(t, err)
+		assert.Equal(t, math.Float64bits(decoded), math.Float64bits(value))
+	})
+}


### PR DESCRIPTION
## Explanation

JMESPath functions can round numeric inputs before matching, replacing, or using them as object keys. For example, `16777217` becomes `16777216`, causing an exact match against the original value to fail and a match against the rounded value to succeed.

This fix preserves float64 precision when converting numbers to strings.

## Related issue

Closes #17526

## Milestone of this PR

To be assigned by maintainers.

## Documentation (required for features)

Bug fix; exempt under the PR documentation guide. No new API or CLI flags.

## What type of PR is this

/kind bug

## Proposed Changes

- Use 64-bit precision for the float64 branch of `ifaceToString`, preserving the float32 branch.
- Cover large, negative, and fractional inputs, exact matches and false matches in the affected functions, and the existing supported types.
- Add a native Go fuzz test asserting that finite float64 values retain their exact bits after conversion to text and parsing back, including signed zero and the smallest/largest finite values.

No dependencies added or upgraded.

### Proof Manifests

Save as `values.yaml`:

```yaml
value: 16777217
```

Run with the CLI built from this branch:

```sh
kyverno jp query -i values.yaml "regex_match('^16777217$', value)" "pattern_match('16777217', value)" "regex_replace_all('^16777217$', value, 'matched')" "object_from_lists([value], ['matched'])"
```

Expected results: `true`, `true`, `"matched"`, and `{"16777217":"matched"}`. Before this fix they are `false`, `false`, `"16777216"`, and `{"16777216":"matched"}`.

## Validation

- Regression tests failed against the original implementation and passed with the fix.
- Full `make test-unit` passed with the race detector and coverage (211 tested packages).
- `make test-cli` passed: 5,416 tests, zero failures.
- Full golangci-lint passed: zero issues.
- `make imports fmt` and `make imports-check fmt-check` passed.
- Code generation and `make verify-codegen` passed in an isolated copy with no generated differences. The generation was resumed after a Docker failure during temporary-cluster cleanup.
- Four existing JMESPath Chainsaw tests passed on Kubernetes v1.35.1 with locally built images: `jmespath-logic`, `jmespath-with-special-chars`, and both invalid-variable-substitution cases. This was a targeted e2e run, not the full conformance matrix.
- Float64 roundtrip fuzzing passed 60,648 executions in 15 seconds. `ifaceToString` statement coverage is 100%.

## Checklist

- [x] I have read the contributing guidelines.
- [x] I have read the PR documentation guide and provided a CLI reproduction.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

@badnikhil offered an additional reproduction test on the issue; additional cases are welcome for comparison with the regression coverage included here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric conversion to preserve full precision for large and high-precision decimal values.
  * JMESPath numeric and pattern functions now handle large floating-point values without unintended rounding or precision loss.

* **Tests**
  * Added coverage for precision-sensitive conversions and numeric operations, including integer boundaries, fractions, unsupported values, and exact floating-point round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->