### PR TITLE
fix: return from the policystatus watchdog when its context is cancelled

### DIFF
--- a/pkg/controllers/policystatus/controller.go
+++ b/pkg/controllers/policystatus/controller.go
@@ -215,9 +215,21 @@ func (c controller) Run(ctx context.Context, workers int) {
 	controllerutils.Run(ctx, logger, ControllerName, time.Second, c.queue, workers, maxRetries, c.reconcile, c.watchdog)
 }
 
+// watchdog forwards webhook state notifications to the queue until ctx is
+// cancelled. Nothing ever closes the notify channel, so ranging over it would
+// never return, and controllerutils.Run waits on this routine in its outermost
+// defer: the whole leader controller set would stay up after leadership loss.
 func (c *controller) watchdog(ctx context.Context, logger logr.Logger) {
-	for key := range c.polStateRecorder.NotifyChannel() {
-		c.queue.Add(key)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case key, ok := <-c.polStateRecorder.NotifyChannel():
+			if !ok {
+				return
+			}
+			c.queue.Add(key)
+		}
 	}
 }
 

--- a/pkg/controllers/policystatus/controller_test.go
+++ b/pkg/controllers/policystatus/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
@@ -23,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/util/workqueue"
 )
 
 // emptyMatchResources is a convenience for constructing policy specs with no resource rules.
@@ -489,4 +491,46 @@ func TestReconcileBeta1Conditions_RBACChecksAutogenTargets(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newWatchdogTestController(notify chan string) controller {
+	return controller{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[any](),
+			workqueue.TypedRateLimitingQueueConfig[any]{Name: "policystatus-watchdog-test"}),
+		polStateRecorder: webhook.NewStateRecorder(notify),
+	}
+}
+
+// Nothing ever closes the notify channel, so a watchdog that ranges over it
+// never returns, and controllerutils.Run waits for its routines in its
+// outermost defer. Run must still return once its context is cancelled.
+func TestRunReturnsOnContextCancel(t *testing.T) {
+	c := newWatchdogTestController(make(chan string))
+	ctx, cancel := context.WithCancel(context.Background())
+
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		c.Run(ctx, 1)
+	}()
+	cancel()
+
+	select {
+	case <-returned:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return after its context was cancelled")
+	}
+}
+
+func TestWatchdogForwardsNotificationsToQueue(t *testing.T) {
+	notify := make(chan string)
+	c := newWatchdogTestController(notify)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go c.watchdog(ctx, logr.Discard())
+	notify <- "ValidatingPolicy/test"
+
+	assert.Eventually(t, func() bool { return c.queue.Len() == 1 }, 5*time.Second, 10*time.Millisecond)
 }


### PR DESCRIPTION
## Explanation

Fix. After leadership loss the policystatus controller never shut down, so the whole leader controller set stayed up on a replica that was no longer the leader.

## Related issue

Closes #17537

## What type of PR is this

/kind bug

## Proposed Changes

`watchdog` ranged over `polStateRecorder.NotifyChannel()`. Nothing ever closes that channel, so the range never returned, and `controllerutils.Run` waits on this routine in its outermost defer.

Now selects on `ctx.Done()` and the channel, the shape `pkg/controllers/webhook/controller.go:414` already uses.

### Proof Manifests

Not applicable, no user-facing behaviour change. `TestRunReturnsOnContextCancel` hangs 10s and fails with the fix reverted.

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [X] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md).
- [X] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

AI-assisted. I reviewed every line of this diff before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Policy status controllers now shut down correctly when their context is cancelled or leadership ends.
  - Notifications continue to be forwarded to the processing queue while the controller is running.

- **Tests**
  - Added coverage for graceful shutdown and notification processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->