### PR TITLE
chore: cut release v1.19.1

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: kyverno-policies
-version: 3.9.1-rc.1  # VERSION
-appVersion: v1.19.1-rc.1
+version: 3.9.1  # VERSION
+appVersion: v1.19.1
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policies/README.md
+++ b/charts/kyverno-policies/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes Pod Security Standards implemented as Kyverno policies
 
-![Version: 3.9.1-rc.1](https://img.shields.io/badge/Version-3.9.1--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.1-rc.1](https://img.shields.io/badge/AppVersion-v1.19.1--rc.1-informational?style=flat-square)
+![Version: 3.9.1](https://img.shields.io/badge/Version-3.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.1](https://img.shields.io/badge/AppVersion-v1.19.1-informational?style=flat-square)
 
 ## About
 

--- a/charts/kyverno/Chart.lock
+++ b/charts/kyverno/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: grafana
   repository: ""
-  version: 3.9.1-rc.1
+  version: 3.9.1
 - name: crds
   repository: ""
-  version: 3.9.1-rc.1
+  version: 3.9.1
 - name: kyverno-api
   repository: https://kyverno.github.io/api
   version: 0.0.1-alpha.4
@@ -14,5 +14,5 @@ dependencies:
 - name: reports-server
   repository: https://kyverno.github.io/reports-server/
   version: 0.1.6
-digest: sha256:5ef99a369f4630fe1711ffdf35f3020cca2582c1951cf85f425591fdd7964d03
-generated: "2026-09-08T23:36:54.669495+08:00"
+digest: sha256:625e5115971d43d95c0b643286f9b49aa79f7a3e198d8a5f0eb03e790e5bf370
+generated: "2026-09-10T13:05:30.550462+08:00"

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: kyverno
-version: 3.9.1-rc.1  # VERSION
-appVersion: v1.19.1-rc.1
+version: 3.9.1  # VERSION
+appVersion: v1.19.1
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:
@@ -42,10 +42,10 @@ annotations:
       description: Add support for configuring container lifecycle hooks (e.g. a preStop sleep) on the admission, background, cleanup and reports controllers.
 dependencies:
   - name: grafana
-    version: 3.9.1-rc.1  # VERSION
+    version: 3.9.1  # VERSION
     condition: grafana.enabled
   - name: crds
-    version: 3.9.1-rc.1  # VERSION
+    version: 3.9.1  # VERSION
     condition: crds.install
   - name: kyverno-api
     version: 0.0.1-alpha.4

--- a/charts/kyverno/README.md
+++ b/charts/kyverno/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes Native Policy Management
 
-![Version: 3.9.1-rc.1](https://img.shields.io/badge/Version-3.9.1--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.1-rc.1](https://img.shields.io/badge/AppVersion-v1.19.1--rc.1-informational?style=flat-square)
+![Version: 3.9.1](https://img.shields.io/badge/Version-3.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.1](https://img.shields.io/badge/AppVersion-v1.19.1-informational?style=flat-square)
 
 ## About
 
@@ -987,8 +987,8 @@ Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | crds | 3.9.1-rc.1 |
-|  | grafana | 3.9.1-rc.1 |
+|  | crds | 3.9.1 |
+|  | grafana | 3.9.1 |
 | https://kyverno.github.io/api | kyverno-api | 0.0.1-alpha.4 |
 | https://kyverno.github.io/reports-server/ | reports-server | 0.1.6 |
 | https://openreports.github.io/reports-api | openreports | 0.1.0 |

--- a/charts/kyverno/charts/crds/Chart.yaml
+++ b/charts/kyverno/charts/crds/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: crds
-version: 3.9.1-rc.1  # VERSION
+version: 3.9.1  # VERSION

--- a/charts/kyverno/charts/crds/README.md
+++ b/charts/kyverno/charts/crds/README.md
@@ -1,6 +1,6 @@
 # crds
 
-![Version: 3.9.1-rc.1](https://img.shields.io/badge/Version-3.9.1--rc.1-informational?style=flat-square)
+![Version: 3.9.1](https://img.shields.io/badge/Version-3.9.1-informational?style=flat-square)
 
 ## Values
 

--- a/charts/kyverno/charts/grafana/Chart.yaml
+++ b/charts/kyverno/charts/grafana/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: grafana
-version: 3.9.1-rc.1  # VERSION
+version: 3.9.1  # VERSION

--- a/charts/kyverno/charts/grafana/README.md
+++ b/charts/kyverno/charts/grafana/README.md
@@ -1,6 +1,6 @@
 # grafana
 
-![Version: 3.9.1-rc.1](https://img.shields.io/badge/Version-3.9.1--rc.1-informational?style=flat-square)
+![Version: 3.9.1](https://img.shields.io/badge/Version-3.9.1-informational?style=flat-square)
 
 ## Values
 


### PR DESCRIPTION
## Description

Cut release `v1.19.1` (GA):

- Bump Helm chart versions (`kyverno`, `kyverno-policies`, `crds`, `grafana`) to `3.9.1`
- Bump chart `appVersion` to `v1.19.1`
- Regenerate Helm chart docs
- Update `Chart.lock`

The branch is unchanged since `v1.19.1-rc.1`, so GA ships the same content as the RC.

Once merged, the merged commit will be tagged `v1.19.1` to trigger the release workflow.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have signed all my commits (DCO).