### PR TITLE
fix(background): guard ListResource nil dereference in handleUpdate

### DIFF
--- a/pkg/background/gpol/dynamic_watcher.go
+++ b/pkg/background/gpol/dynamic_watcher.go
@@ -537,35 +537,36 @@ func (wm *WatchManager) handleUpdate(obj *unstructured.Unstructured, gvr schema.
 			downstreams, err := wm.client.ListResource(context.TODO(), obj.GetAPIVersion(), obj.GetKind(), "", selector)
 			if err != nil {
 				wm.log.Error(err, "failed to list downstream resources")
-			}
-			for _, downstream := range downstreams.Items {
-				// if the downstream doesn't exist in the metadata cache, it means sync is disabled.
-				if _, exists := watcher.metadataCache[downstream.GetUID()]; !exists {
-					continue
-				}
-				// update the downstream resources with the source information.
-				newResource := &unstructured.Unstructured{}
-				newResource.SetUnstructuredContent(source.UnstructuredContent())
-				newResource.SetName(downstream.GetName())
-				newResource.SetNamespace(downstream.GetNamespace())
-				newResource.SetKind(downstream.GetKind())
-				newResource.SetAPIVersion(downstream.GetAPIVersion())
-				newResource.SetLabels(downstream.GetLabels())
-				_, err := wm.client.UpdateResource(context.TODO(), downstream.GetAPIVersion(), downstream.GetKind(), downstream.GetNamespace(), newResource, false)
-				if err != nil {
-					wm.log.Error(err, "failed to update downstream resource", "name", downstream.GetName(), "namespace", downstream.GetNamespace())
-				} else {
-					wm.log.V(4).Info("downstream resource updated", "name", downstream.GetName(), "namespace", downstream.GetNamespace())
-					hash := reportutils.CalculateResourceHash(*newResource)
-					// update the metadata cache for the downstream resource
-					watcher.metadataCache[downstream.GetUID()] = Resource{
-						Name:      downstream.GetName(),
-						Namespace: downstream.GetNamespace(),
-						Labels:    downstream.GetLabels(),
-						Hash:      hash,
-						Data:      newResource,
+			} else {
+				for _, downstream := range downstreams.Items {
+					// if the downstream doesn't exist in the metadata cache, it means sync is disabled.
+					if _, exists := watcher.metadataCache[downstream.GetUID()]; !exists {
+						continue
 					}
-					wm.log.V(4).Info("resource metadata updated", "name", downstream.GetName(), "namespace", downstream.GetNamespace(), "hash", hash)
+					// update the downstream resources with the source information.
+					newResource := &unstructured.Unstructured{}
+					newResource.SetUnstructuredContent(source.UnstructuredContent())
+					newResource.SetName(downstream.GetName())
+					newResource.SetNamespace(downstream.GetNamespace())
+					newResource.SetKind(downstream.GetKind())
+					newResource.SetAPIVersion(downstream.GetAPIVersion())
+					newResource.SetLabels(downstream.GetLabels())
+					_, err := wm.client.UpdateResource(context.TODO(), downstream.GetAPIVersion(), downstream.GetKind(), downstream.GetNamespace(), newResource, false)
+					if err != nil {
+						wm.log.Error(err, "failed to update downstream resource", "name", downstream.GetName(), "namespace", downstream.GetNamespace())
+					} else {
+						wm.log.V(4).Info("downstream resource updated", "name", downstream.GetName(), "namespace", downstream.GetNamespace())
+						hash := reportutils.CalculateResourceHash(*newResource)
+						// update the metadata cache for the downstream resource
+						watcher.metadataCache[downstream.GetUID()] = Resource{
+							Name:      downstream.GetName(),
+							Namespace: downstream.GetNamespace(),
+							Labels:    downstream.GetLabels(),
+							Hash:      hash,
+							Data:      newResource,
+						}
+						wm.log.V(4).Info("resource metadata updated", "name", downstream.GetName(), "namespace", downstream.GetNamespace(), "hash", hash)
+					}
 				}
 			}
 		} else {

--- a/pkg/background/gpol/dynamic_watcher_test.go
+++ b/pkg/background/gpol/dynamic_watcher_test.go
@@ -1447,12 +1447,36 @@ func TestHandleUpdate(t *testing.T) {
 				},
 			},
 		}
+	t.Run("list error does not panic", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("handleUpdate panicked on list error: %v", r)
+			}
+		}()
 
-		wm.InvalidateDownstreams(policyName, nil)
-		wm.handleUpdate(updated, gvr)
-		assert.Empty(t, client.updated)
+		listClient := &fullMockClient{
+			listResult: nil,
+			listErr:    fmt.Errorf("api server unavailable"),
+		}
+		wm := &WatchManager{
+			log:    logging.WithName("test"),
+			client: listClient,
+			dynamicWatchers: map[schema.GroupVersionResource]*watcher{
+				gvr: {metadataCache: map[types.UID]Resource{}},
+			},
+		}
+
+		// src-uid is not in the cache, so handleUpdate takes the source-sync
+		// branch and calls ListResource — which returns an error.
+		src := makeObj("src-uid", "src-pod", "default", nil)
+		wm.handleUpdate(src, gvr)
 	})
-}
+
+			wm.InvalidateDownstreams(policyName, nil)
+			wm.handleUpdate(updated, gvr)
+			assert.Empty(t, client.updated)
+		})
+	}
 
 func TestWatchManager_CacheIntegrity(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}


### PR DESCRIPTION
## Explanation

When ListResource returns an error in handleUpdate, the list result is nil. The previous code logged the error but continued into downstreams.Items, causing a nil pointer dereference panic in the watch goroutine, taking down the whole process.

Fix by wrapping the loop in an else block, matching the existing pattern in handleDelete (line 612).

## Related issue

Closes #17527

## What type of PR is this

/kind bug

## Proposed Changes

- Guard the iteration over `downstreams.Items` inside `pkg/background/gpol/dynamic_watcher.go` by wrapping it in an `else` block after the `ListResource` error check.
- Added a unit test in `dynamic_watcher_test.go` (`list error does not panic`) verifying that `handleUpdate` recovers and returns cleanly without panicking when `ListResource` returns an error.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented downstream resource updates when retrieving source data fails.
  - Improved error handling to avoid crashes during source synchronization failures.
  - Added coverage for list-operation errors to ensure stable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->