### PR TITLE
docs: fix 'becuase' typo in enforce-validate-existing test README

### DIFF
--- a/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce/enforce-validate-existing-allow-existing-violations/README.md
+++ b/test/conformance/chainsaw/validate/clusterpolicy/standard/enforce/enforce-validate-existing-allow-existing-violations/README.md
@@ -6,7 +6,7 @@ This test mainly verifies that an enforce validate policy blocks changes in old 
 
 1. A bad pod is created that violates the policy.
 2. The policy is applied.
-3. Violating changes in bad pod causes error becuase `allowExistingViolations` is set to `false`
+3. Violating changes in bad pod causes error because `allowExistingViolations` is set to `false`
 
 ## Reference Issue(s)
 


### PR DESCRIPTION
## Description

Fix a spelling typo (`becuase` → `because`) in the `enforce-validate-existing-allow-existing-violations` conformance test README.

This is a documentation-only change; no code or test behavior is affected.

## Checklist

- [x] Documentation-only typo fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a spelling error in the test documentation describing behavior when `allowExistingViolations` is set to `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->