### PR TITLE
fix: propagate request context to toggle.FromContext call sites

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/apply/command.go
+++ b/cmd/cli/kubectl-kyverno/commands/apply/command.go
@@ -562,7 +562,7 @@ func (c *ApplyCommandConfig) applyPolicies(
 	for _, pol := range policies {
 		// TODO we should return this info to the caller
 		sa := config.KyvernoUserName(config.KyvernoServiceAccountName())
-		_, err := policyvalidation.Validate(pol, nil, nil, true, sa, sa)
+		_, err := policyvalidation.Validate(context.Background(), pol, nil, nil, true, sa, sa)
 		if err != nil {
 			log.Log.Error(err, "policy validation error")
 			rc.IncrementError(1)

--- a/cmd/cli/kubectl-kyverno/commands/oci/push/options.go
+++ b/cmd/cli/kubectl-kyverno/commands/oci/push/options.go
@@ -41,7 +41,7 @@ func (o options) execute(ctx context.Context, dir string, keychain authn.Keychai
 	}
 	for _, policy := range results.Policies {
 		sa := config.KyvernoUserName(config.KyvernoServiceAccountName())
-		if _, err := policyvalidation.Validate(policy, nil, nil, true, sa, sa); err != nil {
+		if _, err := policyvalidation.Validate(ctx, policy, nil, nil, true, sa, sa); err != nil {
 			return fmt.Errorf("validating policy %s: %v", policy.GetName(), err)
 		}
 	}

--- a/cmd/cli/kubectl-kyverno/commands/test/test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/test.go
@@ -435,7 +435,7 @@ func runTest(out io.Writer, testCase test.TestCase, registryAccess bool, warning
 	for _, pol := range results.Policies {
 		// TODO we should return this info to the caller
 		sa := config.KyvernoUserName(config.KyvernoServiceAccountName())
-		_, err := policyvalidation.Validate(pol, nil, nil, true, sa, sa)
+		_, err := policyvalidation.Validate(context.Background(), pol, nil, nil, true, sa, sa)
 		if err != nil {
 			log.Log.Error(err, "skipping invalid policy", "name", pol.GetName())
 			skippedPolicyNames[pol.GetName()] = err.Error()

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -481,7 +481,7 @@ func main() {
 			os.Exit(1)
 		}
 		// check if mutating admission policies are registered in the API server
-		generateMutatingAdmissionPolicy := toggle.FromContext(context.TODO()).GenerateMutatingAdmissionPolicy()
+		generateMutatingAdmissionPolicy := toggle.FromContext(signalCtx).GenerateMutatingAdmissionPolicy()
 		if generateMutatingAdmissionPolicy {
 			registered, err := admissionpolicy.IsMutatingAdmissionPolicyRegistered(setup.KubeClient)
 			if !registered {

--- a/pkg/controllers/admissionpolicygenerator/controller.go
+++ b/pkg/controllers/admissionpolicygenerator/controller.go
@@ -221,7 +221,7 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 
 	polType := strings.Split(key, "/")[0]
 	if polType == "ClusterPolicy" {
-		generateValidatingAdmissionPolicy := toggle.FromContext(context.TODO()).GenerateValidatingAdmissionPolicy()
+		generateValidatingAdmissionPolicy := toggle.FromContext(ctx).GenerateValidatingAdmissionPolicy()
 		if !generateValidatingAdmissionPolicy {
 			return nil
 		}
@@ -243,7 +243,7 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 			return err
 		}
 	} else if polType == "ValidatingPolicy" {
-		generateValidatingAdmissionPolicy := toggle.FromContext(context.TODO()).GenerateValidatingAdmissionPolicy()
+		generateValidatingAdmissionPolicy := toggle.FromContext(ctx).GenerateValidatingAdmissionPolicy()
 		if !generateValidatingAdmissionPolicy {
 			return nil
 		}
@@ -269,7 +269,7 @@ func (c *controller) reconcile(ctx context.Context, logger logr.Logger, key, nam
 			logger.Error(err, "unable to get the policy from policy informer")
 			return err
 		}
-		generateMutatingAdmissionPolicy := toggle.FromContext(context.TODO()).GenerateMutatingAdmissionPolicy()
+		generateMutatingAdmissionPolicy := toggle.FromContext(ctx).GenerateMutatingAdmissionPolicy()
 		if !generateMutatingAdmissionPolicy {
 			if !mpol.Spec.GenerateMutatingAdmissionPolicyEnabled() {
 				return nil

--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -984,7 +984,7 @@ func (c *controller) buildResourceMutatingWebhookConfiguration(ctx context.Conte
 		errs = append(errs, fmt.Errorf("failed to build webhook rules for policies: %v", err))
 	}
 
-	if err := c.buildForJSONPoliciesMutation(cfg, caBundle, result); err != nil {
+	if err := c.buildForJSONPoliciesMutation(ctx, cfg, caBundle, result); err != nil {
 		errs = append(errs, fmt.Errorf("failed to build webhook rules for imageverificationpolicies: %v", err))
 	}
 
@@ -997,7 +997,7 @@ func (c *controller) buildResourceMutatingWebhookConfiguration(ctx context.Conte
 	return result, multierr.Combine(errs...)
 }
 
-func (c *controller) buildForJSONPoliciesMutation(cfg config.Configuration, caBundle []byte, result *admissionregistrationv1.MutatingWebhookConfiguration) error {
+func (c *controller) buildForJSONPoliciesMutation(ctx context.Context, cfg config.Configuration, caBundle []byte, result *admissionregistrationv1.MutatingWebhookConfiguration) error {
 	if !c.watchdogCheck() {
 		return nil
 	}
@@ -1007,7 +1007,7 @@ func (c *controller) buildForJSONPoliciesMutation(cfg config.Configuration, caBu
 		return err
 	}
 
-	validate := buildWebhookRules(cfg,
+	validate := buildWebhookRules(ctx, cfg,
 		c.server,
 		config.MutatingPolicyWebhookName,
 		"/mpol",
@@ -1021,7 +1021,7 @@ func (c *controller) buildForJSONPoliciesMutation(cfg config.Configuration, caBu
 		return err
 	}
 
-	validate = append(validate, buildWebhookRules(cfg,
+	validate = append(validate, buildWebhookRules(ctx, cfg,
 		c.server,
 		config.NamespacedMutatingPolicyWebhookName,
 		"/nmpol",
@@ -1035,7 +1035,7 @@ func (c *controller) buildForJSONPoliciesMutation(cfg config.Configuration, caBu
 		return err
 	}
 
-	validate = append(validate, buildWebhookRules(cfg,
+	validate = append(validate, buildWebhookRules(ctx, cfg,
 		c.server,
 		config.ImageValidatingPolicyMutateWebhookName,
 		"/ivpol/mutate",
@@ -1049,7 +1049,7 @@ func (c *controller) buildForJSONPoliciesMutation(cfg config.Configuration, caBu
 		return err
 	}
 
-	validate = append(validate, buildWebhookRules(cfg,
+	validate = append(validate, buildWebhookRules(ctx, cfg,
 		c.server,
 		config.ImageValidatingPolicyMutateWebhookName,
 		"/nivpol/mutate",
@@ -1234,7 +1234,7 @@ func (c *controller) buildResourceValidatingWebhookConfiguration(ctx context.Con
 		errs = append(errs, fmt.Errorf("failed to build webhook rules for policies: %v", err))
 	}
 
-	if err := c.buildForJSONPoliciesValidation(cfg, caBundle, webhookConfig); err != nil {
+	if err := c.buildForJSONPoliciesValidation(ctx, cfg, caBundle, webhookConfig); err != nil {
 		errs = append(errs, fmt.Errorf("failed to build webhook rules for validatingpolicies: %v", err))
 	}
 
@@ -1247,7 +1247,7 @@ func (c *controller) buildResourceValidatingWebhookConfiguration(ctx context.Con
 	return webhookConfig, multierr.Combine(errs...)
 }
 
-func (c *controller) buildForJSONPoliciesValidation(cfg config.Configuration, caBundle []byte, result *admissionregistrationv1.ValidatingWebhookConfiguration) error {
+func (c *controller) buildForJSONPoliciesValidation(ctx context.Context, cfg config.Configuration, caBundle []byte, result *admissionregistrationv1.ValidatingWebhookConfiguration) error {
 	if !c.watchdogCheck() {
 		return nil
 	}
@@ -1256,7 +1256,7 @@ func (c *controller) buildForJSONPoliciesValidation(cfg config.Configuration, ca
 	if err != nil {
 		return err
 	}
-	vpolWebhooks := buildWebhookRules(cfg,
+	vpolWebhooks := buildWebhookRules(ctx, cfg,
 		c.server,
 		config.ValidatingPolicyWebhookName,
 		"/vpol",
@@ -1274,7 +1274,7 @@ func (c *controller) buildForJSONPoliciesValidation(cfg config.Configuration, ca
 	if err != nil {
 		return err
 	}
-	nvpolWebhooks := buildWebhookRules(cfg,
+	nvpolWebhooks := buildWebhookRules(ctx, cfg,
 		c.server,
 		config.NamespacedValidatingPolicyWebhookName,
 		"/nvpol",
@@ -1292,7 +1292,7 @@ func (c *controller) buildForJSONPoliciesValidation(cfg config.Configuration, ca
 	if err != nil {
 		return err
 	}
-	gpolWebhooks := buildWebhookRules(cfg,
+	gpolWebhooks := buildWebhookRules(ctx, cfg,
 		c.server,
 		config.GeneratingPolicyWebhookName,
 		"/gpol",
@@ -1310,7 +1310,7 @@ func (c *controller) buildForJSONPoliciesValidation(cfg config.Configuration, ca
 	if err != nil {
 		return err
 	}
-	ngpolWebhooks := buildWebhookRules(cfg,
+	ngpolWebhooks := buildWebhookRules(ctx, cfg,
 		c.server,
 		config.NamespacedGeneratingPolicyWebhookName,
 		"/ngpol",
@@ -1328,7 +1328,7 @@ func (c *controller) buildForJSONPoliciesValidation(cfg config.Configuration, ca
 	if err != nil {
 		return err
 	}
-	ivpolWebhooks := buildWebhookRules(cfg,
+	ivpolWebhooks := buildWebhookRules(ctx, cfg,
 		c.server,
 		config.ImageValidatingPolicyValidateWebhookName,
 		"/ivpol/validate",
@@ -1346,7 +1346,7 @@ func (c *controller) buildForJSONPoliciesValidation(cfg config.Configuration, ca
 	if err != nil {
 		return err
 	}
-	result.Webhooks = append(result.Webhooks, buildWebhookRules(cfg,
+	result.Webhooks = append(result.Webhooks, buildWebhookRules(ctx, cfg,
 		c.server,
 		config.ImageValidatingPolicyValidateWebhookName,
 		"/nivpol/validate",

--- a/pkg/controllers/webhook/match_conditions_test.go
+++ b/pkg/controllers/webhook/match_conditions_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"context"
 	"testing"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
@@ -140,6 +141,7 @@ func TestBuildWebhookRules_NamespaceObjectMatchConditionsNotOffloaded(t *testing
 			expressionCache := NewExpressionCache()
 			expressionCache.AddPolicyExpressions(vpol.GetMatchConditions())
 			webhooks := buildWebhookRules(
+				context.Background(),
 				config.NewDefaultConfiguration(false),
 				"",
 				config.ValidatingPolicyWebhookName,

--- a/pkg/controllers/webhook/validating.go
+++ b/pkg/controllers/webhook/validating.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func buildWebhookRules(cfg config.Configuration, server, name, queryPath string, servicePort int32, caBundle []byte, policies []engineapi.GenericPolicy, expressionCache *expressionCache) []admissionregistrationv1.ValidatingWebhook {
+func buildWebhookRules(ctx context.Context, cfg config.Configuration, server, name, queryPath string, servicePort int32, caBundle []byte, policies []engineapi.GenericPolicy, expressionCache *expressionCache) []admissionregistrationv1.ValidatingWebhook {
 	var fineGrained, basic []engineapi.GenericPolicy
 	for _, policy := range policies {
 		p := extractGenericPolicy(policy)
@@ -154,7 +154,7 @@ func buildWebhookRules(cfg config.Configuration, server, name, queryPath string,
 			if p.GetTimeoutSeconds() != nil {
 				webhook.TimeoutSeconds = p.GetTimeoutSeconds()
 			}
-			if p.GetFailurePolicy(toggle.FromContext(context.TODO()).ForceFailurePolicyIgnore()) == admissionregistrationv1.Ignore {
+			if p.GetFailurePolicy(toggle.FromContext(ctx).ForceFailurePolicyIgnore()) == admissionregistrationv1.Ignore {
 				webhook.FailurePolicy = ptr.To(admissionregistrationv1.Ignore)
 				webhook.Name = generateName(name+"-ignore-finegrained", p)
 				webhook.ClientConfig = newClientConfig(server, servicePort, caBundle, path.Join(queryPath, p.GetName()))
@@ -301,7 +301,7 @@ func buildWebhookRules(cfg config.Configuration, server, name, queryPath string,
 					webhookRules = append(webhookRules, match.RuleWithOperations)
 				}
 			}
-			if p.GetFailurePolicy(toggle.FromContext(context.TODO()).ForceFailurePolicyIgnore()) == admissionregistrationv1.Ignore {
+			if p.GetFailurePolicy(toggle.FromContext(ctx).ForceFailurePolicyIgnore()) == admissionregistrationv1.Ignore {
 				webhookIgnore.Rules = append(webhookIgnore.Rules, webhookRules...)
 			} else {
 				webhookFail.Rules = append(webhookFail.Rules, webhookRules...)

--- a/pkg/controllers/webhook/validating_test.go
+++ b/pkg/controllers/webhook/validating_test.go
@@ -1,9 +1,12 @@
 package webhook
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/kyverno/kyverno/pkg/toggle"
 
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	"github.com/kyverno/kyverno/api/kyverno"
@@ -312,6 +315,7 @@ func TestBuildWebhookRules_ValidatingPolicy(t *testing.T) {
 				expressionCache.AddPolicyExpressions(vpol.GetMatchConditions())
 			}
 			webhooks := buildWebhookRules(
+				context.Background(),
 				config.NewDefaultConfiguration(false),
 				"",
 				config.ValidatingPolicyWebhookName,
@@ -440,6 +444,7 @@ func TestBuildWebhookRules_NamespacedValidatingPolicy(t *testing.T) {
 				expressionCache.AddPolicyExpressions(nvpol.GetMatchConditions())
 			}
 			webhooks := buildWebhookRules(
+				context.Background(),
 				config.NewDefaultConfiguration(false),
 				"",
 				config.NamespacedValidatingPolicyWebhookName,
@@ -505,6 +510,7 @@ func TestBuildWebhookRules_FineGrained_DeterministicOrdering(t *testing.T) {
 			cache.AddPolicyExpressions(extractGenericPolicy(p).GetMatchConditions())
 		}
 		return buildWebhookRules(
+			context.Background(),
 			config.NewDefaultConfiguration(false),
 			"", webhookName, queryPath,
 			0, nil, generic, cache,
@@ -761,6 +767,7 @@ func TestBuildWebhookRules_ImageValidatingPolicy(t *testing.T) {
 				expressionCache.AddPolicyExpressions(ivpol.GetMatchConditions())
 			}
 			webhooks := buildWebhookRules(
+				context.Background(),
 				config.NewDefaultConfiguration(false),
 				"",
 				config.ImageValidatingPolicyValidateWebhookName,
@@ -845,6 +852,7 @@ func TestBuildWebhookRules_ImageValidatingPolicy_EphemeralContainers(t *testing.
 		ivpols := []engineapi.GenericPolicy{engineapi.NewImageValidatingPolicy(ivpol)}
 		expressionCache.AddPolicyExpressions(ivpol.GetMatchConditions())
 		webhooks := buildWebhookRules(
+			context.Background(),
 			config.NewDefaultConfiguration(false),
 			"",
 			config.ImageValidatingPolicyValidateWebhookName,
@@ -1024,6 +1032,7 @@ func TestBuildWebhookRules_GeneratingPolicyWebhookNamesDoNotCollide(t *testing.T
 
 	expressionCache := NewExpressionCache()
 	gpolWebhooks := buildWebhookRules(
+		context.Background(),
 		config.NewDefaultConfiguration(false),
 		"",
 		config.GeneratingPolicyWebhookName,
@@ -1034,6 +1043,7 @@ func TestBuildWebhookRules_GeneratingPolicyWebhookNamesDoNotCollide(t *testing.T
 		expressionCache,
 	)
 	ngpolWebhooks := buildWebhookRules(
+		context.Background(),
 		config.NewDefaultConfiguration(false),
 		"",
 		config.NamespacedGeneratingPolicyWebhookName,
@@ -1110,6 +1120,7 @@ func TestBuildWebhookRules_GeneratingPolicyMatchConditionsOnlyFilterCreate(t *te
 			expressionCache := NewExpressionCache()
 			expressionCache.AddPolicyExpressions(gpol.GetMatchConditions())
 			webhooks := buildWebhookRules(
+				context.Background(),
 				config.NewDefaultConfiguration(false),
 				"",
 				config.GeneratingPolicyWebhookName,
@@ -1178,9 +1189,9 @@ func TestBuildWebhookRules_MutatingPolicyWebhookNamesDoNotCollide(t *testing.T) 
 	expressionCache := NewExpressionCache()
 	cfg := config.NewDefaultConfiguration(false)
 
-	mpolWebhooks := buildWebhookRules(cfg, "", config.MutatingPolicyWebhookName, "/mpol", 0, nil,
+	mpolWebhooks := buildWebhookRules(context.Background(), cfg, "", config.MutatingPolicyWebhookName, "/mpol", 0, nil,
 		[]engineapi.GenericPolicy{engineapi.NewMutatingPolicy(mpol)}, expressionCache)
-	nmpolWebhooks := buildWebhookRules(cfg, "", config.NamespacedMutatingPolicyWebhookName, "/nmpol", 0, nil,
+	nmpolWebhooks := buildWebhookRules(context.Background(), cfg, "", config.NamespacedMutatingPolicyWebhookName, "/nmpol", 0, nil,
 		[]engineapi.GenericPolicy{engineapi.NewNamespacedMutatingPolicy(nmpol)}, expressionCache)
 
 	assert.Len(t, mpolWebhooks, 1)
@@ -1260,6 +1271,7 @@ func TestBuildWebhookRules_NamespacedPoliciesInDifferentNamespaces(t *testing.T)
 	})
 
 	webhooks := buildWebhookRules(
+		context.Background(),
 		config.NewDefaultConfiguration(false),
 		"", config.NamespacedValidatingPolicyWebhookName, "/nvpol", 0, nil,
 		[]engineapi.GenericPolicy{teamA, teamB},
@@ -1316,6 +1328,7 @@ func TestBuildWebhookRules_PoliciesWithDifferentSelectorsGetSeparateWebhooks(t *
 	}
 
 	webhooks := buildWebhookRules(
+		context.Background(),
 		config.NewDefaultConfiguration(false),
 		"",
 		config.ValidatingPolicyWebhookName,
@@ -1375,6 +1388,7 @@ func TestBuildWebhookRules_PoliciesSharingSelectorsShareAWebhook(t *testing.T) {
 	}
 
 	webhooks := buildWebhookRules(
+		context.Background(),
 		config.NewDefaultConfiguration(false),
 		"",
 		config.ValidatingPolicyWebhookName,
@@ -1426,6 +1440,7 @@ func TestBuildWebhookRules_NamespacedPoliciesInSameNamespaceShareAWebhook(t *tes
 	}
 
 	webhooks := buildWebhookRules(
+		context.Background(),
 		config.NewDefaultConfiguration(false),
 		"",
 		config.NamespacedValidatingPolicyWebhookName,
@@ -1446,4 +1461,56 @@ func TestBuildWebhookRules_NamespacedPoliciesInSameNamespaceShareAWebhook(t *tes
 			assert.Contains(t, *webhook.ClientConfig.Service.Path, "policy-b")
 		}
 	}
+}
+
+// forceIgnoreToggles overrides ForceFailurePolicyIgnore on top of the default toggles.
+type forceIgnoreToggles struct{ toggle.Toggles }
+
+func (forceIgnoreToggles) ForceFailurePolicyIgnore() bool { return true }
+
+func TestBuildWebhookRules_HonoursForceFailurePolicyIgnoreFromContext(t *testing.T) {
+	vpol := &policiesv1beta1.ValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "fail-policy"},
+		Spec: policiesv1beta1.ValidatingPolicySpec{
+			FailurePolicy: ptr.To(admissionregistrationv1.Fail),
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{{
+					RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"pods"},
+						},
+					},
+				}},
+			},
+		},
+	}
+	build := func(ctx context.Context) []admissionregistrationv1.ValidatingWebhook {
+		return buildWebhookRules(
+			ctx,
+			config.NewDefaultConfiguration(false),
+			"",
+			config.ValidatingPolicyWebhookName,
+			"/vpol",
+			0,
+			nil,
+			[]engineapi.GenericPolicy{engineapi.NewValidatingPolicy(vpol)},
+			NewExpressionCache(),
+		)
+	}
+
+	// without a request-scoped override the policy's own failurePolicy (Fail) applies
+	webhooks := build(context.Background())
+	assert.Len(t, webhooks, 1)
+	assert.Equal(t, config.ValidatingPolicyWebhookName+"-fail", webhooks[0].Name)
+	assert.Equal(t, ptr.To(admissionregistrationv1.Fail), webhooks[0].FailurePolicy)
+
+	// a ForceFailurePolicyIgnore toggle carried by the context must be honoured
+	ctx := toggle.NewContext(context.Background(), forceIgnoreToggles{toggle.FromContext(context.Background())})
+	webhooks = build(ctx)
+	assert.Len(t, webhooks, 1)
+	assert.Equal(t, config.ValidatingPolicyWebhookName+"-ignore", webhooks[0].Name)
+	assert.Equal(t, ptr.To(admissionregistrationv1.Ignore), webhooks[0].FailurePolicy)
 }

--- a/pkg/validation/policy/actions.go
+++ b/pkg/validation/policy/actions.go
@@ -26,7 +26,7 @@ type Validation interface {
 // - Mutate
 // - Validation
 // - Generate
-func validateActions(idx int, rule *kyvernov1.Rule, client dclient.Interface, mock bool, backgroundSA, reportsSA string) (warnings []string, err error) {
+func validateActions(ctx context.Context, idx int, rule *kyvernov1.Rule, client dclient.Interface, mock bool, backgroundSA, reportsSA string) (warnings []string, err error) {
 	if rule == nil {
 		return nil, nil
 	}
@@ -36,7 +36,7 @@ func validateActions(idx int, rule *kyvernov1.Rule, client dclient.Interface, mo
 	// Mutate
 	if rule.HasMutate() {
 		checker = mutate.NewMutateFactory(rule, client, mock, backgroundSA, reportsSA)
-		if w, path, err := checker.Validate(context.TODO(), nil); err != nil {
+		if w, path, err := checker.Validate(ctx, nil); err != nil {
 			return nil, fmt.Errorf("path: spec.rules[%d].mutate.%s.: %v", idx, path, err)
 		} else if w != nil {
 			warnings = append(warnings, w...)
@@ -47,14 +47,14 @@ func validateActions(idx int, rule *kyvernov1.Rule, client dclient.Interface, mo
 	if rule.HasValidate() {
 		if reportsSA != "" {
 			checker = validate.NewValidateFactory(rule, client, mock, reportsSA)
-			if w, path, err := checker.Validate(context.TODO(), nil); err != nil {
+			if w, path, err := checker.Validate(ctx, nil); err != nil {
 				return nil, fmt.Errorf("path: spec.rules[%d].validate.%s.: %v", idx, path, err)
 			} else if w != nil {
 				warnings = append(warnings, w...)
 			}
 		}
 
-		if client != nil && rule.HasValidateCEL() && toggle.FromContext(context.TODO()).GenerateValidatingAdmissionPolicy() {
+		if client != nil && rule.HasValidateCEL() && toggle.FromContext(ctx).GenerateValidatingAdmissionPolicy() {
 			authCheck := authChecker.NewSelfChecker(client.GetKubeClient().AuthorizationV1().SelfSubjectAccessReviews())
 			if !admissionpolicy.HasValidatingAdmissionPolicyPermission(authCheck) {
 				warnings = append(warnings, "insufficient permissions to generate ValidatingAdmissionPolicies")
@@ -73,7 +73,7 @@ func validateActions(idx int, rule *kyvernov1.Rule, client dclient.Interface, mo
 		// this need to modified to use different implementation for online and offline mode
 		if mock {
 			checker = generate.NewFakeGenerate(*rule.Generation)
-			if w, path, err := checker.Validate(context.TODO(), nil); err != nil {
+			if w, path, err := checker.Validate(ctx, nil); err != nil {
 				return nil, fmt.Errorf("path: spec.rules[%d].generate.%s.: %v", idx, path, err)
 			} else if w != nil {
 				warnings = append(warnings, w...)
@@ -89,7 +89,7 @@ func validateActions(idx int, rule *kyvernov1.Rule, client dclient.Interface, mo
 				}
 			}
 			checker = generate.NewGenerateFactory(client, rule, backgroundSA, reportsSA, logging.GlobalLogger())
-			if w, path, err := checker.Validate(context.TODO(), nil); err != nil {
+			if w, path, err := checker.Validate(ctx, nil); err != nil {
 				return nil, fmt.Errorf("path: spec.rules[%d].generate.%s.: %v", idx, path, err)
 			} else if w != nil {
 				warnings = append(warnings, w...)

--- a/pkg/validation/policy/actions.go
+++ b/pkg/validation/policy/actions.go
@@ -82,7 +82,7 @@ func validateActions(ctx context.Context, idx int, rule *kyvernov1.Rule, client 
 			if rule.Generation.Synchronize {
 				admissionSA := fmt.Sprintf("system:serviceaccount:%s:%s", config.KyvernoNamespace(), config.KyvernoServiceAccountName())
 				checker = generate.NewGenerateFactory(client, rule, admissionSA, reportsSA, logging.GlobalLogger())
-				if w, path, err := checker.Validate(context.TODO(), []string{"list", "get"}); err != nil {
+				if w, path, err := checker.Validate(ctx, []string{"list", "get"}); err != nil {
 					return nil, fmt.Errorf("path: spec.rules[%d].generate.%s.: %v", idx, path, err)
 				} else if w != nil {
 					warnings = append(warnings, w...)

--- a/pkg/validation/policy/actions_test.go
+++ b/pkg/validation/policy/actions_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"context"
 	"testing"
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
@@ -8,7 +9,7 @@ import (
 )
 
 func Test_validateActions_NilRule(t *testing.T) {
-	warnings, err := validateActions(0, nil, nil, true, "", "")
+	warnings, err := validateActions(context.Background(), 0, nil, nil, true, "", "")
 	assert.Nil(t, err)
 	assert.Nil(t, warnings)
 }
@@ -35,7 +36,7 @@ func Test_validateActions_GenerateSameKind(t *testing.T) {
 	}
 	rule.MatchResources.Kinds = []string{"ConfigMap"}
 
-	warnings, err := validateActions(0, rule, nil, true, "", "")
+	warnings, err := validateActions(context.Background(), 0, rule, nil, true, "", "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "generation kind and match resource kind should not be the same")
 	assert.Nil(t, warnings)
@@ -54,7 +55,7 @@ func Test_validateActions_GenerateMockSuccess(t *testing.T) {
 		},
 	}
 
-	warnings, err := validateActions(0, rule, nil, true, "", "")
+	warnings, err := validateActions(context.Background(), 0, rule, nil, true, "", "")
 	assert.NoError(t, err)
 	assert.Empty(t, warnings)
 }

--- a/pkg/validation/policy/fuzz_test.go
+++ b/pkg/validation/policy/fuzz_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"context"
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
@@ -13,6 +14,6 @@ func FuzzValidatePolicy(f *testing.F) {
 		p := &kyverno.ClusterPolicy{}
 		ff.GenerateStruct(p)
 
-		Validate(p, nil, nil, true, "admin", "admin")
+		Validate(context.Background(), p, nil, nil, true, "admin", "admin")
 	})
 }

--- a/pkg/validation/policy/validate.go
+++ b/pkg/validation/policy/validate.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -114,7 +115,7 @@ func validateJSONPatch(patch string, ruleIdx int) error {
 }
 
 // Validate checks the policy and rules declarations for required configurations
-func Validate(policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interface, mock bool, backgroundSA, reportsSA string) ([]string, error) {
+func Validate(ctx context.Context, policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interface, mock bool, backgroundSA, reportsSA string) ([]string, error) {
 	var warnings []string
 	if policy.GetKind() == "ClusterPolicy" && policy.GetNamespace() != "" {
 		warnings = append(warnings, "A clusterpolicy should not have the namespace defined")
@@ -340,7 +341,7 @@ func Validate(policy, oldPolicy kyvernov1.PolicyInterface, client dclient.Interf
 			}
 		}
 
-		w, err := validateActions(i, &rules[i], client, mock, backgroundSA, reportsSA)
+		w, err := validateActions(ctx, i, &rules[i], client, mock, backgroundSA, reportsSA)
 		if err != nil {
 			return warnings, err
 		} else if len(w) > 0 {

--- a/pkg/validation/policy/validate_test.go
+++ b/pkg/validation/policy/validate_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -416,7 +417,7 @@ func Test_Validate_Policy(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	_, err = Validate(policy, nil, nil, true, "", "")
+	_, err = Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.Nil(t, err)
 }
 
@@ -563,7 +564,7 @@ func Test_Validate_ErrorFormat(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	_, err = Validate(policy, nil, nil, true, "", "")
+	_, err = Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.NotNil(t, err)
 }
 
@@ -1036,7 +1037,7 @@ func Test_Validate_Kind(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	_, err = Validate(policy, nil, nil, true, "", "")
+	_, err = Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.NotNil(t, err)
 }
 
@@ -1084,7 +1085,7 @@ func Test_Validate_Any_Kind(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	_, err = Validate(policy, nil, nil, true, "", "")
+	_, err = Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.NotNil(t, err)
 }
 
@@ -1128,7 +1129,7 @@ func Test_Wildcards_Kind(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	_, err = Validate(policy, nil, nil, true, "", "")
+	_, err = Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.NotNil(t, err)
 }
 
@@ -1177,7 +1178,7 @@ func Test_Namespced_Policy(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	_, err = Validate(policy, nil, nil, true, "", "")
+	_, err = Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.NotNil(t, err)
 }
 
@@ -1224,7 +1225,7 @@ func Test_patchesJson6902_Policy(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	_, err = Validate(policy, nil, nil, true, "", "")
+	_, err = Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.Nil(t, err)
 }
 
@@ -1271,7 +1272,7 @@ func Test_deny_exec(t *testing.T) {
 	err = json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	_, err = Validate(policy, nil, nil, true, "", "")
+	_, err = Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.Nil(t, err)
 }
 
@@ -1418,7 +1419,7 @@ func Test_SignatureAlgorithm(t *testing.T) {
 		err := json.Unmarshal(testcase.policy, &policy)
 		assert.Nil(t, err)
 
-		_, err = Validate(policy, nil, nil, true, "", "")
+		_, err = Validate(context.Background(), policy, nil, nil, true, "", "")
 		if testcase.expectedOutput {
 			assert.Nil(t, err)
 		} else {
@@ -1467,7 +1468,7 @@ func Test_existing_resource_policy(t *testing.T) {
 	err = json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	_, err = Validate(policy, nil, nil, true, "", "")
+	_, err = Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.Nil(t, err)
 }
 
@@ -1522,7 +1523,7 @@ func Test_PodControllerAutoGenExclusion_All_Controllers_Policy(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	res, err := Validate(policy, nil, nil, true, "", "")
+	res, err := Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.Nil(t, err)
 	assert.Nil(t, res)
 }
@@ -1578,7 +1579,7 @@ func Test_PodControllerAutoGenExclusion_Not_All_Controllers_Policy(t *testing.T)
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	warnings, err := Validate(policy, nil, nil, true, "", "")
+	warnings, err := Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.NotNil(t, warnings)
 	assert.Nil(t, err)
 }
@@ -1634,7 +1635,7 @@ func Test_PodControllerAutoGenExclusion_None_Policy(t *testing.T) {
 	err := json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	warnings, err := Validate(policy, nil, nil, true, "", "")
+	warnings, err := Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.Nil(t, warnings)
 	assert.Nil(t, err)
 }
@@ -2175,7 +2176,7 @@ func Test_Any_wildcard_policy(t *testing.T) {
 	err = json.Unmarshal(rawPolicy, &policy)
 	assert.Nil(t, err)
 
-	_, err = Validate(policy, nil, nil, true, "", "")
+	_, err = Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.NotNil(t, err)
 }
 
@@ -2232,7 +2233,7 @@ func Test_Validate_RuleImageExtractorsJMESPath(t *testing.T) {
 
 	expectedErr := fmt.Errorf("path: spec.rules[0]: jmespath may not be used in an image extractor when mutating digests with verify images")
 
-	_, actualErr := Validate(policy, nil, nil, true, "", "")
+	_, actualErr := Validate(context.Background(), policy, nil, nil, true, "", "")
 	assert.Equal(t, expectedErr.Error(), actualErr.Error())
 }
 

--- a/pkg/webhooks/policy/handlers.go
+++ b/pkg/webhooks/policy/handlers.go
@@ -112,7 +112,7 @@ func (h *policyHandlers) Validate(ctx context.Context, logger logr.Logger, reque
 			return admissionutils.Response(request.UID, err)
 		}
 
-		warnings, err := policyvalidate.Validate(policy.AsKyvernoPolicy(), old, h.client, false, h.backgroundServiceAccountName, h.reportsServiceAccountName)
+		warnings, err := policyvalidate.Validate(ctx, policy.AsKyvernoPolicy(), old, h.client, false, h.backgroundServiceAccountName, h.reportsServiceAccountName)
 		if err != nil {
 			logger.Error(err, "policy validation errors")
 		}

--- a/pkg/webhooks/resource/mpol/handler.go
+++ b/pkg/webhooks/resource/mpol/handler.go
@@ -129,7 +129,7 @@ func (h *handler) mutate(ctx context.Context, logger logr.Logger, admissionReque
 		}()
 	}
 
-	resp, err := h.admissionResponse(request, response)
+	resp, err := h.admissionResponse(ctx, request, response)
 	if err != nil {
 		logger.Error(err, "mutation failures")
 		return admissionutils.Response(admissionRequest.UID, err)
@@ -211,7 +211,7 @@ func (h *handler) needsReports(request celengine.EngineRequest) bool {
 	return true
 }
 
-func (h *handler) admissionResponse(request celengine.EngineRequest, response mpolengine.EngineResponse) (handlers.AdmissionResponse, error) {
+func (h *handler) admissionResponse(ctx context.Context, request celengine.EngineRequest, response mpolengine.EngineResponse) (handlers.AdmissionResponse, error) {
 	if len(response.Policies) == 0 {
 		return admissionutils.ResponseSuccess(request.Request.UID), nil
 	}
@@ -220,7 +220,7 @@ func (h *handler) admissionResponse(request celengine.EngineRequest, response mp
 	var mutationErrors []string
 
 	for _, policy := range response.Policies {
-		failurePolicy := policy.Policy.GetFailurePolicy(toggle.FromContext(context.TODO()).ForceFailurePolicyIgnore())
+		failurePolicy := policy.Policy.GetFailurePolicy(toggle.FromContext(ctx).ForceFailurePolicyIgnore())
 		for _, rule := range policy.Rules {
 			switch rule.Status() {
 			case engineapi.RuleStatusError:

--- a/pkg/webhooks/resource/mpol/handler_test.go
+++ b/pkg/webhooks/resource/mpol/handler_test.go
@@ -2,10 +2,14 @@ package mpol
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/kyverno/kyverno/pkg/toggle"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 
 	"github.com/go-logr/logr"
 	policiesv1beta1 "github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
@@ -184,3 +188,44 @@ func TestMutate_BackgroundRequestAllowedWhenDisabled(t *testing.T) {
 // Admission-disabled policies are excluded from admission-driven UR creation
 // inside the engine's MatchesMutateExisting (see the reconciler/provider tests);
 // the handler creates URs for whatever the engine returns.
+
+// forceIgnoreToggles overrides ForceFailurePolicyIgnore on top of the default toggles.
+type forceIgnoreToggles struct{ toggle.Toggles }
+
+func (forceIgnoreToggles) ForceFailurePolicyIgnore() bool { return true }
+
+func TestAdmissionResponse_HonoursForceFailurePolicyIgnoreFromContext(t *testing.T) {
+	h := New(nil, &mockEngine{}, nil, &mockReportsConfig{}, &mockURGenerator{}, "", nil)
+	request := celengine.EngineRequest{
+		Request: admissionv1.AdmissionRequest{
+			UID:       types.UID("test-uid"),
+			Name:      "test",
+			Namespace: "default",
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+		},
+	}
+	response := mpolengine.EngineResponse{
+		Policies: []mpolengine.MutatingPolicyResponse{{
+			Policy: &policiesv1beta1.MutatingPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-policy"},
+				Spec: policiesv1beta1.MutatingPolicySpec{
+					FailurePolicy: ptr.To(admissionregistrationv1.Fail),
+				},
+			},
+			Rules: []engineapi.RuleResponse{
+				*engineapi.RuleError("rule", engineapi.Mutation, "mutation failed", errors.New("boom"), nil),
+			},
+		}},
+	}
+
+	// without a request-scoped override the policy's own failurePolicy (Fail) applies
+	resp, err := h.admissionResponse(context.Background(), request, response)
+	assert.Error(t, err)
+	assert.False(t, resp.Allowed, "rule errors must block the request when failurePolicy is Fail")
+
+	// a ForceFailurePolicyIgnore toggle carried by the request context must be honoured
+	ctx := toggle.NewContext(context.Background(), forceIgnoreToggles{toggle.FromContext(context.Background())})
+	resp, err = h.admissionResponse(ctx, request, response)
+	assert.NoError(t, err)
+	assert.True(t, resp.Allowed, "rule errors must not block the request when the context forces failurePolicy Ignore")
+}


### PR DESCRIPTION
## Explanation

This is a fix. Several code paths resolved feature toggles with `toggle.FromContext(context.TODO())` even though a `context.Context` was already available in the call chain. Because `context.TODO()` never carries the toggles injected via `toggle.NewContext`, those lookups silently fell back to the process-wide defaults and ignored any context-scoped override (most notably `ForceFailurePolicyIgnore`). This PR threads the existing context through to the toggle lookup so the toggle system's context-based design actually takes effect at these call sites.

## Related issue

Part of #17224 (also covers the two call sites reported in #16916).

## Milestone of this PR

/milestone 1.20.0

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

Not applicable: no user-facing behavior change, this is internal plumbing.

## What type of PR is this

/kind bug

## Proposed Changes

Thread the already-available `ctx` into `toggle.FromContext(...)` in:

- `pkg/controllers/admissionpolicygenerator/controller.go`: `reconcile` (3 sites) now uses its own `ctx`.
- `pkg/webhooks/resource/mpol/handler.go`: `admissionResponse` takes the request `ctx` from `mutate`.
- `pkg/controllers/webhook/validating.go`: `buildWebhookRules` takes a `ctx`; `buildForJSONPoliciesMutation` / `buildForJSONPoliciesValidation` in `controller.go` receive it from their `buildResource*WebhookConfiguration(ctx, ...)` callers.
- `pkg/validation/policy`: `Validate` / `validateActions` take a `ctx` (the policy admission webhook passes its request context; the CLI passes `context.Background()`), and the inner `checker.Validate(...)` calls use it as well instead of `context.TODO()`.
- `cmd/kyverno/main.go`: the startup MutatingAdmissionPolicy check uses `signalCtx`.

Deliberately left for a follow-up, as suggested on the original PR discussion (split per call site): the `vpol` and `ivpol` compilers (`pkg/cel/policies/vpol/compiler/compiler.go`, `pkg/image/verification/evaluator/compiler.go`). Their `Compile` methods are part of exported interfaces used by controllers and the CLI, and the issue notes they run in background controllers without a live request context.

### Proof Manifests

This change is internal plumbing with no policy-visible behavior change, so there is no YAML to apply. The proof is in the new unit tests, which fail on `main` and pass with this PR:

- `TestAdmissionResponse_HonoursForceFailurePolicyIgnoreFromContext` (`pkg/webhooks/resource/mpol`): a `MutatingPolicy` with `failurePolicy: Fail` and a rule error blocks the request with a plain context, and is allowed through when the context carries a `ForceFailurePolicyIgnore` toggle.
- `TestBuildWebhookRules_HonoursForceFailurePolicyIgnoreFromContext` (`pkg/controllers/webhook`): a `ValidatingPolicy` with `failurePolicy: Fail` lands in the `-fail` webhook with a plain context and in the `-ignore` webhook when the context forces ignore.

Verification run locally:

```
go build ./...
go test -race ./pkg/controllers/webhook/... ./pkg/controllers/admissionpolicygenerator/... ./pkg/webhooks/policy/... ./pkg/webhooks/resource/mpol/... ./pkg/validation/policy/... ./pkg/toggle/...
make imports-check fmt-check
./.tools/golangci-lint run <changed packages>   # 0 issues
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The change is a mechanical context-threading fix. `pkg/validation/policy.Validate` gains a leading `ctx` parameter; all in-repo callers (policy admission webhook, CLI `apply`/`test`/`oci push`, tests, fuzz test) are updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added legacy policy metrics covering policies and policy exceptions.

* **Bug Fixes**
  * Policy validation and admission processing now honor active operation contexts.
  * Force-failure-policy overrides are applied consistently during webhook processing.
  * Corrected webhook naming for namespaced image validation policies.
  * Command-line policy validation now preserves the relevant execution context.

* **Tests**
  * Added coverage for context-based overrides and webhook naming collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->