### PR TITLE
fix: preserve legacy report sources and webhook API versions in 1.20

### DIFF
--- a/pkg/controllers/report/aggregate/controller.go
+++ b/pkg/controllers/report/aggregate/controller.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/controllers"
 	"github.com/kyverno/kyverno/pkg/controllers/report/utils"
+	"github.com/kyverno/kyverno/pkg/deprecations"
 	"github.com/kyverno/kyverno/pkg/openreports"
 	controllerutils "github.com/kyverno/kyverno/pkg/utils/controller"
 	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
@@ -87,6 +88,12 @@ type controller struct {
 	// queues
 	frontQueue workqueue.TypedRateLimitingInterface[any]
 	backQueue  workqueue.TypedRateLimitingInterface[any]
+
+	// legacyReportSourceWarnOnce throttles the legacy kyverno.io report
+	// source deprecation log (see #17491) to a single line for the life of
+	// this controller, since backReconcile runs per report, per worker, on
+	// every resync. Zero value is ready to use.
+	legacyReportSourceWarnOnce sync.Once
 }
 
 // PolicyMapEntry holds an active traditional policy and its (autogen-expanded)
@@ -850,6 +857,19 @@ func (c *controller) backReconcile(ctx context.Context, logger logr.Logger, _, n
 	policyMap, err := c.createPolicyMap()
 	if err != nil {
 		return err
+	}
+	// Note, throttled to once per controller lifetime and only when legacy
+	// policies are present, that legacy kyverno.io report sources
+	// (ClusterPolicy/Policy) are still being aggregated. DEPRECATED in 1.20,
+	// removed in 1.21 (see #17491). backReconcile runs per report across
+	// multiple workers on every resync, so this is gated by a sync.Once
+	// rather than logged unconditionally on every call. This is report-scoped
+	// and intentionally does not duplicate the legacy-policy-count gauge
+	// landing separately in #17488.
+	if len(policyMap) > 0 {
+		c.legacyReportSourceWarnOnce.Do(func() {
+			logger.Info("aggregating deprecated legacy kyverno.io policy report results", "source", reportutils.SourceKyverno, "legacyPolicies", len(policyMap), "guidance", deprecations.MigrationGuideURL)
+		})
 	}
 	vapMap, err := c.createVapMap()
 	if err != nil {

--- a/pkg/controllers/report/aggregate/controller.go
+++ b/pkg/controllers/report/aggregate/controller.go
@@ -868,7 +868,7 @@ func (c *controller) backReconcile(ctx context.Context, logger logr.Logger, _, n
 	// landing separately in #17488.
 	if len(policyMap) > 0 {
 		c.legacyReportSourceWarnOnce.Do(func() {
-			logger.Info("aggregating deprecated legacy kyverno.io policy report results", "source", reportutils.SourceKyverno, "legacyPolicies", len(policyMap), "guidance", deprecations.MigrationGuideURL)
+			logger.Info("deprecated legacy kyverno.io policies present; their report results are still aggregated", "source", reportutils.SourceKyverno, "legacyPolicies", len(policyMap), "guidance", deprecations.MigrationGuideURL)
 		})
 	}
 	vapMap, err := c.createVapMap()

--- a/pkg/controllers/report/aggregate/utils.go
+++ b/pkg/controllers/report/aggregate/utils.go
@@ -99,6 +99,14 @@ func MergeReports(maps Maps, accumulator map[string]openreportsv1alpha1.ReportRe
 						accumulator[key] = result
 					}
 				}
+			// SourceKyverno is the legacy kyverno.io policy report source
+			// (ClusterPolicy/Policy). It is DEPRECATED in 1.20 and slated for
+			// removal in 1.21 (see #17491). Kyverno still reads and
+			// aggregates these results for reporting continuity; the keying
+			// is identical to the default branch below, so the two clauses
+			// share a body via fallthrough and cannot drift apart.
+			case reportutils.SourceKyverno:
+				fallthrough
 			default:
 				currentPolicy := maps.Pol[result.Policy]
 				if currentPolicy.Rules != nil && currentPolicy.Rules.Has(result.Rule) {

--- a/pkg/controllers/report/aggregate/utils_test.go
+++ b/pkg/controllers/report/aggregate/utils_test.go
@@ -1,0 +1,101 @@
+package aggregate_test
+
+import (
+	"testing"
+
+	reportsv1 "github.com/kyverno/kyverno/api/reports/v1"
+	"github.com/kyverno/kyverno/pkg/controllers/report/aggregate"
+	reportutils "github.com/kyverno/kyverno/pkg/utils/report"
+	openreportsv1alpha1 "github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// TestMergeReports_AggregatesLegacyKyvernoSource proves reporting continuity
+// for #17491: a legacy kyverno.io (ClusterPolicy/Policy) report result, whose
+// ReportResult.Source is reportutils.SourceKyverno, is still aggregated by
+// MergeReports exactly as it was before the explicit
+// `case reportutils.SourceKyverno: fallthrough` was added to the switch in
+// utils.go, keyed the same way as the (still-existing) default branch.
+func TestMergeReports_AggregatesLegacyKyvernoSource(t *testing.T) {
+	const uid = "test-uid"
+	report := &reportsv1.EphemeralReport{
+		Spec: reportsv1.EphemeralReportSpec{
+			Results: []openreportsv1alpha1.ReportResult{
+				{
+					Source: reportutils.SourceKyverno,
+					Policy: "default/require-app-label",
+					Rule:   "check-app-label",
+				},
+			},
+		},
+	}
+	maps := aggregate.Maps{
+		Pol: map[string]aggregate.PolicyMapEntry{
+			"default/require-app-label": {
+				Rules: sets.New[string]("check-app-label"),
+			},
+		},
+	}
+
+	accumulator := map[string]openreportsv1alpha1.ReportResult{}
+	aggregate.MergeReports(maps, accumulator, uid, report)
+
+	key := reportutils.SourceKyverno + "/default/require-app-label/check-app-label/" + uid
+	result, ok := accumulator[key]
+	assert.True(t, ok, "expected legacy kyverno.io result to be aggregated under key %q, got keys %v", key, keys(accumulator))
+	assert.Equal(t, reportutils.SourceKyverno, result.Source)
+	assert.Equal(t, "check-app-label", result.Rule)
+}
+
+// TestMergeReports_LegacyAndCELCoexist guards against the new explicit
+// `case reportutils.SourceKyverno:` accidentally swallowing or altering
+// results from other (CEL/native) sources: a legacy result and a
+// SourceValidatingPolicy result in the same report must both land in the
+// accumulator.
+func TestMergeReports_LegacyAndCELCoexist(t *testing.T) {
+	const uid = "test-uid"
+	report := &reportsv1.EphemeralReport{
+		Spec: reportsv1.EphemeralReportSpec{
+			Results: []openreportsv1alpha1.ReportResult{
+				{
+					Source: reportutils.SourceKyverno,
+					Policy: "default/require-app-label",
+					Rule:   "check-app-label",
+				},
+				{
+					Source: reportutils.SourceValidatingPolicy,
+					Policy: "check-deployment-replicas",
+				},
+			},
+		},
+	}
+	maps := aggregate.Maps{
+		Pol: map[string]aggregate.PolicyMapEntry{
+			"default/require-app-label": {
+				Rules: sets.New[string]("check-app-label"),
+			},
+		},
+		Vpol: sets.New[string]("check-deployment-replicas"),
+	}
+
+	accumulator := map[string]openreportsv1alpha1.ReportResult{}
+	aggregate.MergeReports(maps, accumulator, uid, report)
+
+	legacyKey := reportutils.SourceKyverno + "/default/require-app-label/check-app-label/" + uid
+	celKey := reportutils.SourceValidatingPolicy + "/check-deployment-replicas/" + uid
+
+	_, legacyOK := accumulator[legacyKey]
+	_, celOK := accumulator[celKey]
+	assert.True(t, legacyOK, "expected legacy kyverno.io result under key %q, got keys %v", legacyKey, keys(accumulator))
+	assert.True(t, celOK, "expected CEL ValidatingPolicy result under key %q, got keys %v", celKey, keys(accumulator))
+	assert.Len(t, accumulator, 2)
+}
+
+func keys(m map[string]openreportsv1alpha1.ReportResult) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -114,6 +114,14 @@ var (
 		APIGroups:   []string{"policies.kyverno.io"},
 		APIVersions: []string{"v1alpha1", "v1beta1", "v1"},
 	}
+	// policyRule intercepts create and update requests for the legacy
+	// kyverno.io ClusterPolicy and Policy kinds. APIVersions keeps both "v1"
+	// and "v2beta1" in 1.20 so legacy create/update requests keep reaching
+	// the engine, which is where the 1.20 hard error on legacy writes is
+	// raised (see deprecations.BuildKindError and #17491). Dropping either
+	// version here would stop the API server from routing those requests to
+	// this webhook, letting them bypass the engine and skip the intended
+	// error entirely. The legacy versions are removed in 1.21.
 	policyRule = admissionregistrationv1.Rule{
 		Resources:   []string{"clusterpolicies", "policies"},
 		APIGroups:   []string{"kyverno.io"},

--- a/pkg/controllers/webhook/legacy_apiversions_test.go
+++ b/pkg/controllers/webhook/legacy_apiversions_test.go
@@ -1,0 +1,72 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kyverno/kyverno/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// findPolicyRule locates the RuleWithOperations whose Rule targets the legacy
+// kyverno.io ClusterPolicy/Policy kinds among the given rules.
+func findPolicyRule(t *testing.T, rules []admissionregistrationv1.RuleWithOperations) admissionregistrationv1.Rule {
+	t.Helper()
+	for _, r := range rules {
+		if len(r.Rule.APIGroups) == 1 && r.Rule.APIGroups[0] == "kyverno.io" &&
+			len(r.Rule.Resources) == 2 && r.Rule.Resources[0] == "clusterpolicies" && r.Rule.Resources[1] == "policies" {
+			return r.Rule
+		}
+	}
+	t.Fatalf("no rule found for kyverno.io clusterpolicies/policies")
+	return admissionregistrationv1.Rule{}
+}
+
+// TestPolicyValidatingWebhookPreservesLegacyAPIVersions is a 1.20 regression
+// guard for #17491: legacy kyverno.io create/update requests must keep
+// reaching the engine so the intended hard error (see
+// pkg/deprecations.BuildKindError) is still raised. This test fails if
+// controller.go's policyRule.APIVersions is changed to drop "v1" or
+// "v2beta1" before the 1.21 removal.
+func TestPolicyValidatingWebhookPreservesLegacyAPIVersions(t *testing.T) {
+	c := &controller{
+		defaultTimeout:    10,
+		servicePort:       443,
+		clusterroleLister: rbacv1listers.NewClusterRoleLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})),
+	}
+
+	vwc, err := c.buildPolicyValidatingWebhookConfiguration(context.TODO(), config.NewDefaultConfiguration(false), nil)
+	require.NoError(t, err)
+	require.Len(t, vwc.Webhooks, 1)
+
+	rule := findPolicyRule(t, vwc.Webhooks[0].Rules)
+	assert.Equal(t, []string{"v1", "v2beta1"}, rule.APIVersions)
+}
+
+// TestPolicyMutatingWebhookPreservesLegacyAPIVersions mirrors
+// TestPolicyValidatingWebhookPreservesLegacyAPIVersions for the mutating
+// policy webhook configuration.
+func TestPolicyMutatingWebhookPreservesLegacyAPIVersions(t *testing.T) {
+	c := &controller{
+		defaultTimeout:    10,
+		servicePort:       443,
+		clusterroleLister: rbacv1listers.NewClusterRoleLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})),
+	}
+
+	mwc, err := c.buildPolicyMutatingWebhookConfiguration(context.TODO(), config.NewDefaultConfiguration(false), nil)
+	require.NoError(t, err)
+	require.Len(t, mwc.Webhooks, 1)
+
+	rule := findPolicyRule(t, mwc.Webhooks[0].Rules)
+	assert.Equal(t, []string{"v1", "v2beta1"}, rule.APIVersions)
+}
+
+// TestPolicyRuleAPIVersions is a cheap secondary guard directly on the
+// package-level policyRule variable.
+func TestPolicyRuleAPIVersions(t *testing.T) {
+	assert.Equal(t, []string{"v1", "v2beta1"}, policyRule.APIVersions)
+}


### PR DESCRIPTION
## Explanation

This PR is part of the phase 2 (Kyverno 1.20) work under the legacy `kyverno.io` policy deprecation epic (#17214). In 1.20, legacy policy CRDs stay served and existing legacy policies remain readable and enforceable; deprecation is only signaled, and removal happens in 1.21.

This change preserves two behaviors that must not regress during the migration window, and adds a deprecation signal:

- The reports controller keeps reading and aggregating report results from legacy `kyverno.io` policies (`ClusterPolicy` and `Policy`), so reports stay complete while users migrate.
- The policy webhook keeps its legacy `policyRule.APIVersions` (`v1`, `v2beta1`) so create and update requests for legacy policies still reach the engine and receive the intended hard error.

This is a change that preserves existing behavior and adds an observational deprecation log. It does not alter admission decisions, reconcile outcomes, or generated resources.

## Related issue

Closes #17491

## Milestone of this PR

/milestone 1.20.0

## Documentation (required for features)

This PR adds no new user-facing feature. It preserves existing 1.20 behavior and adds an internal deprecation log line, so no website documentation change is required.

- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind cleanup

## Proposed Changes

**Reports controller — keep aggregating legacy sources, mark them deprecated**

- `pkg/controllers/report/aggregate/utils.go`: add an explicit `case reportutils.SourceKyverno:` that falls through to the existing `default:` branch in `MergeReports`. Behavior is identical to before; the explicit case documents that the legacy `kyverno.io` source is deprecated but still aggregated, and gives 1.21 a single labeled place to remove it. `MergeReports` stays pure (no I/O, clock, or clients).
- `pkg/controllers/report/aggregate/controller.go`: emit a once-per-process deprecation log from `backReconcile` when legacy policies are present, gated by `sync.Once`. `backReconcile` runs per report across multiple workers on every resync, so the log is throttled rather than emitted on every call. No new metric is added; the legacy-policy-count gauge is handled separately in #17488.

**Webhook — preserve legacy API versions in 1.20**

- `pkg/controllers/webhook/controller.go`: no functional change. This PR adds a comment above `policyRule` explaining that `APIVersions: ["v1", "v2beta1"]` must stay for 1.20 so legacy create and update requests still route to the webhook and reach the engine, where the 1.20 hard error is returned. Dropping a version now would let those requests bypass the engine and skip the error. The versions are removed in 1.21.

**Tests**

- `pkg/controllers/webhook/legacy_apiversions_test.go`: assert the built validating and mutating webhook configurations still carry `["v1", "v2beta1"]` for the legacy `kyverno.io` policy rule, plus a direct guard on the `policyRule` variable. These tests fail if the API versions change, which is the regression this PR protects against.
- `pkg/controllers/report/aggregate/utils_test.go`: assert that a legacy `SourceKyverno` result is still aggregated under the expected key (continuity), and that legacy and CEL sources coexist without one swallowing the other.

### Proof Manifests

This change is internal and observational (a deprecation log plus preserved aggregation and webhook rules), so there is no user-facing manifest that demonstrates new behavior. The guarantees are covered by unit tests instead:

- The webhook regression test fails when `policyRule.APIVersions` is changed and passes when reverted.
- The aggregate tests prove legacy report results are still aggregated.

To observe the deprecation log in a running cluster, apply any legacy `kyverno.io/v1` `ClusterPolicy` and watch the reports controller log:

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: Audit
  rules:
    - name: check-team-label
      match:
        any:
          - resources:
              kinds:
                - Pod
      validate:
        message: "The label `team` is required."
        pattern:
          metadata:
            labels:
              team: "?*"
```

The reports controller then logs, once per process, that deprecated legacy `kyverno.io` policies are present and their report results are still aggregated.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The reports change adds an explicit `case` that falls through to the existing `default:` body rather than changing behavior, which keeps aggregation byte-for-byte identical while documenting the deprecation. The log uses `sync.Once` rather than a per-reconcile emit to avoid noise across the worker pool, and adds no metric to avoid duplicating the legacy-policy gauge in #17488.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Legacy Kyverno policy report results continue to be aggregated correctly alongside newer policy report sources.
  - Legacy policy API requests continue reaching validation and mutation webhooks across supported API versions.
- **Warnings**
  - A one-time deprecation warning appears when legacy Kyverno policies are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->