### PR TITLE
feat: verify OCI image volume references by default

### DIFF
--- a/pkg/cel/compiler/images.go
+++ b/pkg/cel/compiler/images.go
@@ -21,6 +21,9 @@ var (
 	}, {
 		Name:       "ephemeralContainers",
 		Expression: "(object != null ? object : oldObject).spec.?ephemeralContainers.orValue([]).map(e, e.image)",
+	}, {
+		Name:       "imageVolumes",
+		Expression: "(object != null ? object : oldObject).spec.?volumes.orValue([]).filter(e, has(e.image)).map(e, e.image.reference)",
 	}}
 	podControllerImageExtractors = []v1beta1.ImageExtractor{{
 		Name:       "containers",
@@ -31,6 +34,9 @@ var (
 	}, {
 		Name:       "ephemeralContainers",
 		Expression: "(object != null ? object : oldObject).spec.template.spec.?ephemeralContainers.orValue([]).map(e, e.image)",
+	}, {
+		Name:       "imageVolumes",
+		Expression: "(object != null ? object : oldObject).spec.template.spec.?volumes.orValue([]).filter(e, has(e.image)).map(e, e.image.reference)",
 	}}
 	cronJobImageExtractors = []v1beta1.ImageExtractor{{
 		Name:       "containers",
@@ -41,6 +47,9 @@ var (
 	}, {
 		Name:       "ephemeralContainers",
 		Expression: "(object != null ? object : oldObject).spec.jobTemplate.spec.template.spec.?ephemeralContainers.orValue([]).map(e, e.image)",
+	}, {
+		Name:       "imageVolumes",
+		Expression: "(object != null ? object : oldObject).spec.jobTemplate.spec.template.spec.?volumes.orValue([]).filter(e, has(e.image)).map(e, e.image.reference)",
 	}}
 )
 

--- a/pkg/cel/compiler/images_test.go
+++ b/pkg/cel/compiler/images_test.go
@@ -93,6 +93,7 @@ func Test_Match(t *testing.T) {
 				"kyverno/ephr-image-one",
 				"kyverno/ephr-image-two",
 			},
+			"imageVolumes": {},
 		},
 		gvr:     &metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
 		wantErr: false,
@@ -146,6 +147,57 @@ func Test_Match(t *testing.T) {
 			"ephemeralContainers": {
 				"kyverno/ephr-image-one",
 				"kyverno/ephr-image-two",
+			},
+			"imageVolumes": {},
+		},
+		gvr:     &metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+		wantErr: false,
+	}, {
+		name: "pod image volume extraction",
+		imageExtractor: []v1beta1.ImageExtractor{{
+			Name:       "one",
+			Expression: "request.images",
+		}},
+		request: map[string]any{
+			"request": map[string]any{
+				"images": []string{
+					"nginx:latest",
+				},
+			},
+			"object": map[string]any{
+				"spec": map[string]any{
+					"containers": []map[string]string{{
+						"image": "kyverno/image-one",
+					}},
+					"volumes": []map[string]any{{
+						"name": "model",
+						"image": map[string]string{
+							"reference": "kyverno/model:v1",
+						},
+					}, {
+						"name":      "config",
+						"configMap": map[string]string{"name": "cm"},
+					}, {
+						"name": "extra-model",
+						"image": map[string]string{
+							"reference": "kyverno/model:v2",
+						},
+					}},
+				},
+			},
+		},
+		wantResult: map[string][]string{
+			"one": {
+				"nginx:latest",
+			},
+			"containers": {
+				"kyverno/image-one",
+			},
+			"initContainers":      {},
+			"ephemeralContainers": {},
+			"imageVolumes": {
+				"kyverno/model:v1",
+				"kyverno/model:v2",
 			},
 		},
 		gvr:     &metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},

--- a/pkg/utils/api/image.go
+++ b/pkg/utils/api/image.go
@@ -152,7 +152,7 @@ func extract(
 }
 
 func BuildStandardExtractors(tags ...string) []imageExtractor {
-	extractors := make([]imageExtractor, 0, 3)
+	extractors := make([]imageExtractor, 0, 4)
 	for _, tag := range []string{"initContainers", "containers", "ephemeralContainers"} {
 		t := make([]string, 0, len(tags)+1+1)
 		t = append(t, tags...)
@@ -160,6 +160,15 @@ func BuildStandardExtractors(tags ...string) []imageExtractor {
 		t = append(t, "*")
 		extractors = append(extractors, imageExtractor{Fields: t, Key: "name", Value: "image", Name: tag})
 	}
+	// OCI image volumes (`spec.volumes[*].image.reference`) mount the contents of an
+	// OCI object as a read-only volume. Extract the referenced image so it is subject
+	// to the same image verification as container images. The image reference lives at
+	// `.image.reference`, so we descend into the `image` object and read `reference`;
+	// volumes without an `image` field are skipped during extraction.
+	v := make([]string, 0, len(tags)+3)
+	v = append(v, tags...)
+	v = append(v, "volumes", "*", "image")
+	extractors = append(extractors, imageExtractor{Fields: v, Key: "", Value: "reference", Name: "imageVolumes"})
 	return extractors
 }
 

--- a/pkg/utils/api/image_test.go
+++ b/pkg/utils/api/image_test.go
@@ -470,6 +470,39 @@ func Test_extractImageInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			raw: []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"myapp"},"spec":{"containers":[{"name":"nginx","image":"nginx:latest"}],"volumes":[{"name":"model","image":{"reference":"kyverno/model:v1"}},{"name":"cfg","configMap":{"name":"cm"}}]}}`),
+			images: map[string]map[string]ImageInfo{
+				"containers": {
+					"nginx": {
+						imageutils.ImageInfo{
+							Registry:         "docker.io",
+							Name:             "nginx",
+							Path:             "nginx",
+							Tag:              "latest",
+							Reference:        "docker.io/nginx:latest",
+							ReferenceWithTag: "docker.io/nginx:latest",
+						},
+						"/spec/containers/0/image",
+						[]string{},
+					},
+				},
+				"imageVolumes": {
+					"/spec/volumes/0/image/reference": {
+						imageutils.ImageInfo{
+							Registry:         "docker.io",
+							Name:             "model",
+							Path:             "kyverno/model",
+							Tag:              "v1",
+							Reference:        "docker.io/kyverno/model:v1",
+							ReferenceWithTag: "docker.io/kyverno/model:v1",
+						},
+						"/spec/volumes/0/image/reference",
+						[]string{},
+					},
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		resource, err := kubeutils.BytesToUnstructured(test.raw)


### PR DESCRIPTION
## Description

This adds a new built-in image extractor, `imageVolumes`, so that OCI **ImageVolumes** (`spec.volumes[*].image.reference`) are subject to the same image rules (verifyImages / ImageValidatingPolicy, registry allow-lists, digest pinning, etc.) as `containers`, `initContainers`, and `ephemeralContainers`.

## Why this should be on by default

OCI ImageVolumes mount the contents of an arbitrary OCI artifact into a Pod as a read-only volume. That content is pulled from a registry exactly like a container image and can carry executables, libraries, ML models, or config that the workload then loads and runs. Until now Kyverno's extractors only looked at the three container fields, so every image-based policy silently ignored ImageVolumes — a real supply-chain gap. OCI ImageVolumes are beta and enabled by default since Kubernetes v1.33/v1.35, so real workloads (notably AI/ML model distribution) already use them, and coverage should be the default before adoption grows.

## What changed

- **Legacy engine** (`pkg/utils/api/image.go`): `BuildStandardExtractors` now also extracts `spec.volumes[*].image.reference`, with the correct prefix for Pods, pod controllers, and CronJobs. Volumes without an `image` field (configMap, secret, emptyDir, …) are skipped.
- **CEL engine** (`pkg/cel/compiler/images.go`): the pod, pod-controller, and cronjob extractor sets gain an `imageVolumes` expression mapping `spec.volumes[*]` entries that have an `image` field to `image.reference`.

## Behavior note / upgrade impact

Policies that verify images (e.g. `verifyImages` with the default `required: true`) will now also evaluate ImageVolume references. Clusters already using ImageVolumes with unsigned images may start seeing those Pods blocked; such clusters should sign those images or add an explicit exception, the same as they would for any container image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Image extraction now includes OCI image references defined in pod volumes.
  - Image volume references are reported alongside container image references for pods, controllers, and scheduled workloads.

- **Bug Fixes**
  - Non-image volumes are ignored during image extraction.
  - Image references are correctly extracted from both current and previous object versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->