### PR TITLE
fix(webhook): avoid image validating policy webhook name collisions

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,6 +71,10 @@ const (
 	ImageValidatingPolicyValidateWebhookName = "ivpol.validate.kyverno.svc"
 	// ImageValidatingPolicyWebhookName defines default mutating webhook name for imagevalidatingpolicies
 	ImageValidatingPolicyMutateWebhookName = "ivpol.mutate.kyverno.svc"
+	// NamespacedImageValidatingPolicyValidateWebhookName defines default validating webhook name for namespacedimagevalidatingpolicies
+	NamespacedImageValidatingPolicyValidateWebhookName = "nivpol.validate.kyverno.svc"
+	// NamespacedImageValidatingPolicyMutateWebhookName defines default mutating webhook name for namespacedimagevalidatingpolicies
+	NamespacedImageValidatingPolicyMutateWebhookName = "nivpol.mutate.kyverno.svc"
 )
 
 // paths

--- a/pkg/controllers/webhook/controller.go
+++ b/pkg/controllers/webhook/controller.go
@@ -1051,7 +1051,7 @@ func (c *controller) buildForJSONPoliciesMutation(cfg config.Configuration, caBu
 
 	validate = append(validate, buildWebhookRules(cfg,
 		c.server,
-		config.ImageValidatingPolicyMutateWebhookName,
+		config.NamespacedImageValidatingPolicyMutateWebhookName,
 		"/nivpol/mutate",
 		c.servicePort,
 		caBundle,
@@ -1348,7 +1348,7 @@ func (c *controller) buildForJSONPoliciesValidation(cfg config.Configuration, ca
 	}
 	result.Webhooks = append(result.Webhooks, buildWebhookRules(cfg,
 		c.server,
-		config.ImageValidatingPolicyValidateWebhookName,
+		config.NamespacedImageValidatingPolicyValidateWebhookName,
 		"/nivpol/validate",
 		c.servicePort,
 		caBundle,

--- a/pkg/controllers/webhook/validating_test.go
+++ b/pkg/controllers/webhook/validating_test.go
@@ -1447,3 +1447,54 @@ func TestBuildWebhookRules_NamespacedPoliciesInSameNamespaceShareAWebhook(t *tes
 		}
 	}
 }
+
+func TestBuildWebhookRules_ImageValidatingPolicyWebhookNamesDoNotCollide(t *testing.T) {
+	matchConstraints := &admissionregistrationv1.MatchResources{
+		ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+			{
+				RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+						Scope:       ptr.To(admissionregistrationv1.ScopeType("*")),
+					},
+				},
+			},
+		},
+	}
+
+	ivpol := &policiesv1beta1.ImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "check-images",
+		},
+		Spec: policiesv1beta1.ImageValidatingPolicySpec{
+			MatchConstraints: matchConstraints,
+		},
+	}
+
+	nivpol := &policiesv1beta1.NamespacedImageValidatingPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "check-images",
+			Namespace: "default",
+		},
+		Spec: policiesv1beta1.ImageValidatingPolicySpec{
+			MatchConstraints: matchConstraints,
+		},
+	}
+
+	expressionCache := NewExpressionCache()
+	cfg := config.NewDefaultConfiguration(false)
+
+	ivpolWebhooks := buildWebhookRules(cfg, "", config.ImageValidatingPolicyValidateWebhookName, "/ivpol/validate", 0, nil,
+		[]engineapi.GenericPolicy{engineapi.NewImageValidatingPolicy(ivpol)}, expressionCache)
+	nivpolWebhooks := buildWebhookRules(cfg, "", config.NamespacedImageValidatingPolicyValidateWebhookName, "/nivpol/validate", 0, nil,
+		[]engineapi.GenericPolicy{engineapi.NewNamespacedImageValidatingPolicy(nivpol)}, expressionCache)
+
+	assert.Len(t, ivpolWebhooks, 1)
+	assert.Len(t, nivpolWebhooks, 1)
+	assert.Equal(t, config.ImageValidatingPolicyValidateWebhookName+"-fail", ivpolWebhooks[0].Name)
+	assert.Equal(t, config.NamespacedImageValidatingPolicyValidateWebhookName+"-fail", nivpolWebhooks[0].Name)
+	assert.NotEqual(t, ivpolWebhooks[0].Name, nivpolWebhooks[0].Name)
+}


### PR DESCRIPTION
## Explanation

When a cluster has both an `ImageValidatingPolicy` and a `NamespacedImageValidatingPolicy`, Kyverno generates two webhooks with the same name. Kubernetes rejects the webhook configuration, so the policies stop being applied. This fix gives namespaced image validating policies their own webhook names.

## Related issue

Closes #17557

## Milestone of this PR

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

Before this PR, `NamespacedImageValidatingPolicy` webhooks used the `ivpol.validate.kyverno.svc` and `ivpol.mutate.kyverno.svc` base names, the same as `ImageValidatingPolicy`.

This PR:

- Adds `NamespacedImageValidatingPolicyValidateWebhookName` (`nivpol.validate.kyverno.svc`) and `NamespacedImageValidatingPolicyMutateWebhookName` (`nivpol.mutate.kyverno.svc`).
- Uses them for the `/nivpol/validate` and `/nivpol/mutate` webhooks.
- Adds a regression test for one policy of each type.

Same pattern as #16578.

### Proof Manifests

Covered by the unit test. I have not run it on a cluster.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

The collision is in 1.18.0 and 1.19.x too, so it may be worth a cherry-pick to `release-1.19`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected webhook naming for namespaced image-validating policies.
  - Prevented naming conflicts between cluster-scoped and namespaced image-validating policy webhooks.
  - Ensured validation and mutation webhooks use distinct, appropriate names.

- **Tests**
  - Added coverage confirming webhook names remain unique when both policy types use matching configuration rules.
  - Verified distinct names for both validation and mutation webhook configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->