### PR TITLE
fix(cli): close the junit failure element without detailed results

### DIFF
--- a/cmd/cli/kubectl-kyverno/commands/test/output.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/output.go
@@ -359,10 +359,11 @@ func printOutputFormats(out io.Writer, outputFormat string, resultTable table.Ta
 			for _, policyRow := range rows {
 				b.WriteString(fmt.Sprintf("  <testcase classname=\"%s\" name=\"%s\">\n", policyRow.Rule, policyRow.Resource))
 				if policyRow.IsFailure {
-					b.WriteString(fmt.Sprintf("   <failure message=\"%s\">\n    Policy: %s\n    Rule: %s\n    Resource: %s\n    Result: %s", policyRow.Reason, policyRow.Policy, policyRow.Rule, policyRow.Resource, policyRow.Result))
+					b.WriteString(fmt.Sprintf("   <failure message=\"%s\">\n    Policy: %s\n    Rule: %s\n    Resource: %s\n    Result: %s\n", policyRow.Reason, policyRow.Policy, policyRow.Rule, policyRow.Resource, policyRow.Result))
 					if detailedResults {
-						b.WriteString(fmt.Sprintf("    Message: %s\n   </failure>\n", policyRow.Message))
+						b.WriteString(fmt.Sprintf("    Message: %s\n", policyRow.Message))
 					}
+					b.WriteString("   </failure>\n")
 				} else {
 					b.WriteString(fmt.Sprintf("   <system-out><![CDATA[\n    Reason: %s\n    Policy: %s\n    Rule: %s\n    Resource: %s\n", policyRow.Reason, policyRow.Policy, policyRow.Rule, policyRow.Resource))
 					if detailedResults {

--- a/cmd/cli/kubectl-kyverno/commands/test/output_test.go
+++ b/cmd/cli/kubectl-kyverno/commands/test/output_test.go
@@ -1,0 +1,37 @@
+package test
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/output/table"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintOutputFormatsJunitFailureIsValidXML(t *testing.T) {
+	for _, detailedResults := range []bool{false, true} {
+		var resultTable table.Table
+		row := table.Row{Message: "validation error: label app is required"}
+		row.Policy = "require-labels"
+		row.Rule = "check-labels"
+		row.Resource = "v1/Pod/default/nginx"
+		row.Result = "Fail"
+		row.Reason = "Want pass, got fail"
+		row.IsFailure = true
+		resultTable.Add(row)
+
+		var out bytes.Buffer
+		printOutputFormats(&out, "junit", resultTable, detailedResults)
+
+		decoder := xml.NewDecoder(strings.NewReader(strings.TrimSpace(out.String())))
+		var err error
+		for err == nil {
+			_, err = decoder.Token()
+		}
+		assert.True(t, errors.Is(err, io.EOF), "detailedResults=%v: %v", detailedResults, err)
+	}
+}


### PR DESCRIPTION
## Explanation

`kyverno test --output-format junit` produces invalid XML whenever a test fails without `--detailed-results`, because the `<failure>` element is never closed. CI tools that read JUnit reports then reject the file exactly when there is a failure to report. This fix always closes the element.

## Related issue

Closes #17559

## Milestone of this PR

## Documentation (required for features)

My PR contains new or altered behavior to Kyverno.
- [ ] I have sent the draft PR to add or update [the documentation](https://github.com/kyverno/website) and the link is:

## What type of PR is this

/kind bug

## Proposed Changes

Before this PR, `</failure>` was only written inside `if detailedResults`, and the `Result:` line had no trailing newline.

This PR:

- Writes `</failure>` after the optional `Message:` line, so it is always closed. This matches how #14612 fixed `<system-out>` just below.
- Adds the missing newline after `Result:`.
- Adds a test that renders a failing row in both modes and parses the output as XML.

### Proof Manifests

Covered by the unit test. It fails on main with `element <failure> closed by </testcase>` and passes with this change.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [AI Usage Policy](https://github.com/kyverno/community/blob/main/AI_USAGE_POLICY.md). If I used AI assistance, I have disclosed it in my commit(s) (e.g., via `Co-authored-by` or `Assisted-by` trailer).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed JUnit test reports so failed test cases always produce well-formed XML.
  - Ensured failure details and closing tags are correctly formatted in both detailed and non-detailed output modes.

- **Tests**
  - Added coverage validating JUnit output for failed validation results across both output modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->